### PR TITLE
JWK creation from a shared secret

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -1,0 +1,21 @@
+cache_dir: "/cache/gitsplit"
+
+splits:
+    - prefix: "src/Component/Core"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-core.git"
+    - prefix: "src/Component/Checker"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-checker.git"
+    - prefix: "src/Component/Signature"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-signature.git"
+    - prefix: "src/Component/Encryption"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-encryption.git"
+    - prefix: "src/Component/KeyManagement"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-key-mgmt.git"
+    - prefix: "src/Component/Console"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-console.git"
+    - prefix: "src/Bundle/JoseFramework"
+      target: "https://${GH_TOKEN}@github.com/web-token/jwt-bundle.git"
+
+origins:
+    - ^master$
+    - ^v\d+\.\d+\.\d+$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 language: php
-sudo: true
+
+sudo: required
+
 cache:
-  directories:
-    - "$HOME/.composer/cache"
-    - vendor
+    directories:
+        - "$HOME/.composer/cache"
+        - "vendor"
+
 matrix:
-  allow_failures:
-    - php: nightly
-  fast_finish: true
-  include:
-    - php: 7.1
-      env: deps=low
-    - php: 7.1
-    - php: nightly
-    - php: 7.2
+    allow_failures:
+        - php: nightly
+    fast_finish: true
+    include:
+        - php: 7.1
+          env: deps=low
+        - php: 7.1
+        - php: nightly
+        - php: 7.2
+
 before_script:
-  - chmod +x ./tests/install_php_ext.sh
-  - if [ "$TRAVIS_PHP_VERSION" = '7.1' ]; then ./tests/install_php_ext.sh; fi
-  - composer self-update
-  - mkdir -p build/logs
-  - if [[ $deps = low ]]; then composer update --no-interaction --prefer-lowest ; fi
-  - if [[ !$deps ]]; then composer install --no-interaction ; fi
+    - chmod +x ./tests/install_php_ext.sh
+    - if [ "$TRAVIS_PHP_VERSION" = '7.1' ]; then ./tests/install_php_ext.sh; fi
+    - composer self-update
+    - mkdir -p build/logs
+    - if [[ $deps = low ]]; then composer update --no-interaction --prefer-lowest ; fi
+    - if [[ !$deps ]]; then composer install --no-interaction ; fi
+
 script:
-  - "./vendor/bin/phpunit --coverage-clover build/logs/clover.xml"
+    - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
 after_success:
-  - vendor/bin/coveralls --no-interaction
+    - ./vendor/bin/coveralls --no-interaction

--- a/performance/JWE/A128GCMKWBench.php
+++ b/performance/JWE/A128GCMKWBench.php
@@ -3,7 +3,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/A128KWBench.php
+++ b/performance/JWE/A128KWBench.php
@@ -3,7 +3,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/A192GCMKWBench.php
+++ b/performance/JWE/A192GCMKWBench.php
@@ -3,7 +3,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/A192KWBench.php
+++ b/performance/JWE/A192KWBench.php
@@ -3,7 +3,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/A256GCMKWBench.php
+++ b/performance/JWE/A256GCMKWBench.php
@@ -3,7 +3,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/A256KWBench.php
+++ b/performance/JWE/A256KWBench.php
@@ -3,7 +3,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/ECDHESA128KWBench.php
+++ b/performance/JWE/ECDHESA128KWBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/ECDHESA192KWBench.php
+++ b/performance/JWE/ECDHESA192KWBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/ECDHESA256KWBench.php
+++ b/performance/JWE/ECDHESA256KWBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/ECDHESBench.php
+++ b/performance/JWE/ECDHESBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/EncryptionBench.php
+++ b/performance/JWE/EncryptionBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/PBES2HS256A128KWBench.php
+++ b/performance/JWE/PBES2HS256A128KWBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/PBES2HS384A192KWBench.php
+++ b/performance/JWE/PBES2HS384A192KWBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/PBES2HS512A256KWBench.php
+++ b/performance/JWE/PBES2HS512A256KWBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/RSA1_5Bench.php
+++ b/performance/JWE/RSA1_5Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/RSAOAEP256Bench.php
+++ b/performance/JWE/RSAOAEP256Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWE/RSAOAEPBench.php
+++ b/performance/JWE/RSAOAEPBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/ES256Bench.php
+++ b/performance/JWS/ES256Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/ES384Bench.php
+++ b/performance/JWS/ES384Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/ES512Bench.php
+++ b/performance/JWS/ES512Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/EdDSABench.php
+++ b/performance/JWS/EdDSABench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/HS256Bench.php
+++ b/performance/JWS/HS256Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/HS384Bench.php
+++ b/performance/JWS/HS384Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/HS512Bench.php
+++ b/performance/JWS/HS512Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/NoneBench.php
+++ b/performance/JWS/NoneBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/PS256Bench.php
+++ b/performance/JWS/PS256Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/PS384Bench.php
+++ b/performance/JWS/PS384Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/PS512Bench.php
+++ b/performance/JWS/PS512Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/RS256Bench.php
+++ b/performance/JWS/RS256Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/RS384Bench.php
+++ b/performance/JWS/RS384Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/RS512Bench.php
+++ b/performance/JWS/RS512Bench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/performance/JWS/SignatureBench.php
+++ b/performance/JWS/SignatureBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Controller/JWKSetController.php
+++ b/src/Bundle/JoseFramework/Controller/JWKSetController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Controller/JWKSetControllerFactory.php
+++ b/src/Bundle/JoseFramework/Controller/JWKSetControllerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/AlgorithmCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/AlgorithmCollector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/CheckerCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/CheckerCollector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/Collector.php
+++ b/src/Bundle/JoseFramework/DataCollector/Collector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/JWECollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JWECollector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/JWSCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JWSCollector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/JoseCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JoseCollector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DataCollector/KeyCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/KeyCollector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/AlgorithmCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/AlgorithmCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/CheckerCollectorCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/CheckerCollectorCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/ClaimCheckerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/ClaimCheckerCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/CompressionMethodCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/CompressionMethodCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/DataCollectorCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/DataCollectorCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/EncryptionSerializerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/EncryptionSerializerCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/HeaderCheckerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/HeaderCheckerCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/JWECollectorCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/JWECollectorCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/JWSCollectorCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/JWSCollectorCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/KeyAnalyzerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/KeyAnalyzerCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/KeyCollectorCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/KeyCollectorCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/KeySetControllerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/KeySetControllerCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/SignatureSerializerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/SignatureSerializerCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Configuration.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/JoseFrameworkExtension.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/JoseFrameworkExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/AbstractSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/AbstractSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/CheckerSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/CheckerSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/ClaimChecker.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/ClaimChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/HeaderChecker.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/HeaderChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Console/ConsoleSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Console/ConsoleSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Core/CoreSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Core/CoreSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/AbstractEncryptionSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/AbstractEncryptionSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/EncryptionSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/EncryptionSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEBuilder.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEDecrypter.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEDecrypter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWESerializer.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWESerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JKUSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JKUSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/JKU.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/JKU.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/JWKSet.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/JWKSet.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/JWKSetSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/JWKSetSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/X5U.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource/X5U.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/CertificateFile.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/CertificateFile.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWK.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWK.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWKSet.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWKSet.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWKSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWKSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/KeyFile.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/KeyFile.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource;
+
+use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
+use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class Secret.
+ */
+final class Secret extends AbstractSource implements JWKSource
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createDefinition(ContainerBuilder $container, array $config): Definition
+    {
+        $definition = new Definition(JWK::class);
+        $definition->setFactory([
+            new Reference(JWKFactory::class),
+            'createFromSecret',
+        ]);
+        $definition->setArguments([
+            $config['secret'],
+            $config['additional_values'],
+        ]);
+        $definition->addTag('jose.jwk');
+
+        return $definition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey(): string
+    {
+        return 'secret';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addConfiguration(NodeDefinition $node)
+    {
+        parent::addConfiguration($node);
+        $node
+            ->children()
+                ->scalarNode('secret')
+                    ->info('The shared secret.')
+                    ->defaultNull()
+                ->end()
+                ->arrayNode('additional_values')
+                    ->info('Additional values to be added to the key.')
+                    ->defaultValue([])
+                    ->useAttributeAsKey('key')
+                    ->prototype('variable')->end()
+                ->end()
+            ->end();
+    }
+}

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
@@ -62,7 +62,7 @@ final class Secret extends AbstractSource implements JWKSource
             ->children()
                 ->scalarNode('secret')
                     ->info('The shared secret.')
-                    ->defaultNull()
+                    ->isRequired()
                 ->end()
                 ->arrayNode('additional_values')
                     ->info('Additional values to be added to the key.')

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Values.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Values.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/X5C.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/X5C.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKUriSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKUriSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/KeyManagementSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/KeyManagementSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/AbstractSignatureSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/AbstractSignatureSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSBuilder.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSSerializer.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSVerifier.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSVerifier.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/SignatureSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/SignatureSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Source.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Source.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/EnvVarProcessor/KeyEnvVarProcessor.php
+++ b/src/Bundle/JoseFramework/EnvVarProcessor/KeyEnvVarProcessor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Helper/ConfigurationHelper.php
+++ b/src/Bundle/JoseFramework/Helper/ConfigurationHelper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/JoseFrameworkBundle.php
+++ b/src/Bundle/JoseFramework/JoseFrameworkBundle.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Resources/config/commands.yml
+++ b/src/Bundle/JoseFramework/Resources/config/commands.yml
@@ -40,6 +40,10 @@ services:
         tags:
             - {name: 'console.command'}
 
+    Jose\Component\Console\SecretKeyGeneratorCommand:
+        tags:
+            - {name: 'console.command'}
+
     Jose\Component\Console\KeyFileLoaderCommand:
         tags:
             - {name: 'console.command'}

--- a/src/Bundle/JoseFramework/Resources/config/jwk_sources.yml
+++ b/src/Bundle/JoseFramework/Resources/config/jwk_sources.yml
@@ -14,6 +14,11 @@ services:
         class: 'Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource\Values'
         tags:
             - {'name': 'jose.jwk_source'}
+    jose.jwk_source.secret:
+        public: false
+        class: 'Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource\Secret'
+        tags:
+            - {'name': 'jose.jwk_source'}
     jose.jwk_source.jwk:
         public: false
         class: 'Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource\JWK'

--- a/src/Bundle/JoseFramework/Routing/JWKSetLoader.php
+++ b/src/Bundle/JoseFramework/Routing/JWKSetLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/AppKernel.php
+++ b/src/Bundle/JoseFramework/Tests/AppKernel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Checker/ClaimCheckerTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Checker/ClaimCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Checker/HeaderCheckerTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Checker/HeaderCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Console/ConsoleTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Console/ConsoleTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Encryption/JWEBuilderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Encryption/JWEBuilderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Encryption/JWEComputationTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Encryption/JWEComputationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Encryption/JWELoaderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Encryption/JWELoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/KeyManagement/JWKLoaderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/KeyManagement/JWKLoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/KeyManagement/JWKLoaderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/KeyManagement/JWKLoaderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\Tests\Functional\KeyManagement;
 
+use Base64Url\Base64Url;
 use Jose\Component\Core\JWK;
 use Jose\Component\KeyManagement\JWKFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -104,5 +105,23 @@ final class JWKLoaderTest extends WebTestCase
         $container = $client->getContainer();
         self::assertTrue($container->has('jose.key.jwkset1'));
         self::assertInstanceOf(JWK::class, $container->get('jose.key.jwkset1'));
+    }
+
+    /**
+     * @test
+     */
+    public function aJWKCanBeLoadedFromASecretInTheConfiguration()
+    {
+        $client = static::createClient();
+
+        $container = $client->getContainer();
+        self::assertTrue($container->has('jose.key.secret1'));
+        $jwk = $container->get('jose.key.secret1');
+
+        self::assertInstanceOf(JWK::class, $jwk);
+        self::assertEquals('oct', $jwk->get('kty'));
+        self::assertEquals('enc', $jwk->get('use'));
+        self::assertEquals('RS512', $jwk->get('alg'));
+        self::assertEquals('This is my secret', Base64Url::decode($jwk->get('k')));
     }
 }

--- a/src/Bundle/JoseFramework/Tests/Functional/KeyManagement/JWKSetLoaderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/KeyManagement/JWKSetLoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSBuilderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSBuilderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSComputationTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSComputationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSLoaderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSLoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/TestBundle/Checker/CustomChecker.php
+++ b/src/Bundle/JoseFramework/Tests/TestBundle/Checker/CustomChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/TestBundle/Converter/CustomJsonConverter.php
+++ b/src/Bundle/JoseFramework/Tests/TestBundle/Converter/CustomJsonConverter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/TestBundle/DependencyInjection/TestExtension.php
+++ b/src/Bundle/JoseFramework/Tests/TestBundle/DependencyInjection/TestExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/TestBundle/MessageFactory.php
+++ b/src/Bundle/JoseFramework/Tests/TestBundle/MessageFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/TestBundle/Service/RequestFactory.php
+++ b/src/Bundle/JoseFramework/Tests/TestBundle/Service/RequestFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/TestBundle/TestBundle.php
+++ b/src/Bundle/JoseFramework/Tests/TestBundle/TestBundle.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Bundle/JoseFramework/Tests/config/config_test.yml
+++ b/src/Bundle/JoseFramework/Tests/config/config_test.yml
@@ -108,6 +108,13 @@ jose:
                 key_set: 'jose.key_set.jwkset1'
                 index: 0
                 is_public: true
+        secret1:
+            secret:
+                secret: 'This is my secret'
+                additional_values:
+                    use: 'enc'
+                    alg: 'RS512'
+                is_public: true
     key_sets:
         jwkset1:
             jwkset:

--- a/src/Component/Checker/AlgorithmChecker.php
+++ b/src/Component/Checker/AlgorithmChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/AudienceChecker.php
+++ b/src/Component/Checker/AudienceChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/ClaimChecker.php
+++ b/src/Component/Checker/ClaimChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/ClaimCheckerManager.php
+++ b/src/Component/Checker/ClaimCheckerManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/ClaimCheckerManagerFactory.php
+++ b/src/Component/Checker/ClaimCheckerManagerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/ExpirationTimeChecker.php
+++ b/src/Component/Checker/ExpirationTimeChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/HeaderChecker.php
+++ b/src/Component/Checker/HeaderChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/HeaderCheckerManager.php
+++ b/src/Component/Checker/HeaderCheckerManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/HeaderCheckerManagerFactory.php
+++ b/src/Component/Checker/HeaderCheckerManagerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/InvalidClaimException.php
+++ b/src/Component/Checker/InvalidClaimException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/InvalidHeaderException.php
+++ b/src/Component/Checker/InvalidHeaderException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/IssuedAtChecker.php
+++ b/src/Component/Checker/IssuedAtChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/NotBeforeChecker.php
+++ b/src/Component/Checker/NotBeforeChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/AlgorithmHeaderCheckerTest.php
+++ b/src/Component/Checker/Tests/AlgorithmHeaderCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/AudienceClaimCheckerTest.php
+++ b/src/Component/Checker/Tests/AudienceClaimCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/AudienceHeaderCheckerTest.php
+++ b/src/Component/Checker/Tests/AudienceHeaderCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/ClaimCheckerManagerFactoryTest.php
+++ b/src/Component/Checker/Tests/ClaimCheckerManagerFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/ExpirationTimeClaimCheckerTest.php
+++ b/src/Component/Checker/Tests/ExpirationTimeClaimCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/HeaderCheckerManagerFactoryTest.php
+++ b/src/Component/Checker/Tests/HeaderCheckerManagerFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/IssuedAtClaimCheckerTest.php
+++ b/src/Component/Checker/Tests/IssuedAtClaimCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/NotBeforeClaimCheckerTest.php
+++ b/src/Component/Checker/Tests/NotBeforeClaimCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/Stub/IssuerChecker.php
+++ b/src/Component/Checker/Tests/Stub/IssuerChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/Stub/OtherToken.php
+++ b/src/Component/Checker/Tests/Stub/OtherToken.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/Stub/Token.php
+++ b/src/Component/Checker/Tests/Stub/Token.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/Stub/TokenSupport.php
+++ b/src/Component/Checker/Tests/Stub/TokenSupport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/Tests/UnencodedPayloadHeaderCheckerTest.php
+++ b/src/Component/Checker/Tests/UnencodedPayloadHeaderCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/TokenTypeSupport.php
+++ b/src/Component/Checker/TokenTypeSupport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Checker/UnencodedPayloadChecker.php
+++ b/src/Component/Checker/UnencodedPayloadChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/AddKeyIntoKeysetCommand.php
+++ b/src/Component/Console/AddKeyIntoKeysetCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/EcKeyGeneratorCommand.php
+++ b/src/Component/Console/EcKeyGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/EcKeysetGeneratorCommand.php
+++ b/src/Component/Console/EcKeysetGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/GeneratorCommand.php
+++ b/src/Component/Console/GeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/GetThumbprintCommand.php
+++ b/src/Component/Console/GetThumbprintCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/JKULoaderCommand.php
+++ b/src/Component/Console/JKULoaderCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/KeyAnalyzerCommand.php
+++ b/src/Component/Console/KeyAnalyzerCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/KeyFileLoaderCommand.php
+++ b/src/Component/Console/KeyFileLoaderCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/KeysetAnalyzerCommand.php
+++ b/src/Component/Console/KeysetAnalyzerCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/MergeKeysetCommand.php
+++ b/src/Component/Console/MergeKeysetCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/NoneKeyGeneratorCommand.php
+++ b/src/Component/Console/NoneKeyGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/ObjectOutputCommand.php
+++ b/src/Component/Console/ObjectOutputCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/OctKeyGeneratorCommand.php
+++ b/src/Component/Console/OctKeyGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/OctKeysetGeneratorCommand.php
+++ b/src/Component/Console/OctKeysetGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/OkpKeyGeneratorCommand.php
+++ b/src/Component/Console/OkpKeyGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/OkpKeysetGeneratorCommand.php
+++ b/src/Component/Console/OkpKeysetGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/OptimizeRsaKeyCommand.php
+++ b/src/Component/Console/OptimizeRsaKeyCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/P12CertificateLoaderCommand.php
+++ b/src/Component/Console/P12CertificateLoaderCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/PemConverterCommand.php
+++ b/src/Component/Console/PemConverterCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/PublicKeyCommand.php
+++ b/src/Component/Console/PublicKeyCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/PublicKeysetCommand.php
+++ b/src/Component/Console/PublicKeysetCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/RotateKeysetCommand.php
+++ b/src/Component/Console/RotateKeysetCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/RsaKeyGeneratorCommand.php
+++ b/src/Component/Console/RsaKeyGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/RsaKeysetGeneratorCommand.php
+++ b/src/Component/Console/RsaKeysetGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/SecretKeyGeneratorCommand.php
+++ b/src/Component/Console/SecretKeyGeneratorCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/SecretKeyGeneratorCommand.php
+++ b/src/Component/Console/SecretKeyGeneratorCommand.php
@@ -31,10 +31,10 @@ final class SecretKeyGeneratorCommand extends GeneratorCommand
     {
         parent::configure();
         $this
-            ->setName('key:generate:secret')
+            ->setName('key:generate:from_secret')
             ->setDescription('Generate an octet key (JWK format) using an existing secret')
-            ->addArgument('secret', InputArgument::REQUIRED, 'The secret.')
-            ->addOption('is_b64', 'b', InputOption::VALUE_NONE, 'Indicates if the secret is Base64 encoded (useful for binary secrets).');
+            ->addArgument('secret', InputArgument::REQUIRED, 'The secret')
+            ->addOption('is_b64', 'b', InputOption::VALUE_NONE, 'Indicates if the secret is Base64 encoded (useful for binary secrets)');
     }
 
     /**

--- a/src/Component/Console/SecretKeyGeneratorCommand.php
+++ b/src/Component/Console/SecretKeyGeneratorCommand.php
@@ -16,12 +16,13 @@ namespace Jose\Component\Console;
 use Jose\Component\KeyManagement\JWKFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class OctKeyGeneratorCommand.
+ * Class SecretKeyGeneratorCommand.
  */
-final class OctKeyGeneratorCommand extends GeneratorCommand
+final class SecretKeyGeneratorCommand extends GeneratorCommand
 {
     /**
      * {@inheritdoc}
@@ -30,9 +31,10 @@ final class OctKeyGeneratorCommand extends GeneratorCommand
     {
         parent::configure();
         $this
-            ->setName('key:generate:oct')
-            ->setDescription('Generate an octet key (JWK format)')
-            ->addArgument('size', InputArgument::REQUIRED, 'Key size.');
+            ->setName('key:generate:secret')
+            ->setDescription('Generate an octet key (JWK format) using an existing secret')
+            ->addArgument('secret', InputArgument::REQUIRED, 'The secret.')
+            ->addOption('is_b64', 'b', InputOption::VALUE_NONE, 'Indicates if the secret is Base64 encoded (useful for binary secrets).');
     }
 
     /**
@@ -40,10 +42,13 @@ final class OctKeyGeneratorCommand extends GeneratorCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $size = intval($input->getArgument('size'));
+        $secret = $input->getArgument('secret');
+        if ($input->getOption('is_b64')) {
+            $secret = base64_decode($secret);
+        }
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createOctKey($size, $args);
+        $jwk = JWKFactory::createFromSecret($secret, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
     }
 }

--- a/src/Component/Console/Tests/AnalyzeCommandTest.php
+++ b/src/Component/Console/Tests/AnalyzeCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/Tests/KeyConversionCommandTest.php
+++ b/src/Component/Console/Tests/KeyConversionCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/Tests/KeyCreationCommandTest.php
+++ b/src/Component/Console/Tests/KeyCreationCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console\Tests;
 
+use Base64Url\Base64Url;
 use Jose\Component\Console;
 use Jose\Component\Core\Converter\StandardConverter;
 use Jose\Component\Core\JWK;
@@ -121,6 +122,48 @@ final class KeyCreationCommandTest extends TestCase
         $content = $output->fetch();
         $jwk = JWK::createFromJson($content);
         self::assertInstanceOf(JWK::class, $jwk);
+    }
+
+    /**
+     * @test
+     */
+    public function iCanCreateAnOctetKeyUsingASecret()
+    {
+        $converter = new StandardConverter();
+        $input = new ArrayInput([
+            'secret' => 'This is my secret',
+        ]);
+        $output = new BufferedOutput();
+        $command = new Console\SecretKeyGeneratorCommand($converter);
+
+        $command->run($input, $output);
+        $content = $output->fetch();
+        $jwk = JWK::createFromJson($content);
+        self::assertInstanceOf(JWK::class, $jwk);
+        self::assertTrue($jwk->has('k'));
+        self::assertEquals('This is my secret', Base64Url::decode($jwk->get('k')));
+    }
+
+    /**
+     * @test
+     */
+    public function iCanCreateAnOctetKeyUsingABinarySecret()
+    {
+        $secret = random_bytes(20);
+        $converter = new StandardConverter();
+        $input = new ArrayInput([
+            'secret' => $secret,
+            '--is_b64'
+        ]);
+        $output = new BufferedOutput();
+        $command = new Console\SecretKeyGeneratorCommand($converter);
+
+        $command->run($input, $output);
+        $content = $output->fetch();
+        $jwk = JWK::createFromJson($content);
+        self::assertInstanceOf(JWK::class, $jwk);
+        self::assertTrue($jwk->has('k'));
+        self::assertEquals($secret, Base64Url::decode($jwk->get('k')));
     }
 
     /**

--- a/src/Component/Console/Tests/KeyCreationCommandTest.php
+++ b/src/Component/Console/Tests/KeyCreationCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
@@ -153,7 +153,7 @@ final class KeyCreationCommandTest extends TestCase
         $converter = new StandardConverter();
         $input = new ArrayInput([
             'secret' => $secret,
-            '--is_b64'
+            '--is_b64',
         ]);
         $output = new BufferedOutput();
         $command = new Console\SecretKeyGeneratorCommand($converter);

--- a/src/Component/Console/Tests/KeySetCreationCommandTest.php
+++ b/src/Component/Console/Tests/KeySetCreationCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/X509CertificateLoaderCommand.php
+++ b/src/Component/Console/X509CertificateLoaderCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Console/X5ULoaderCommand.php
+++ b/src/Component/Console/X5ULoaderCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Algorithm.php
+++ b/src/Component/Core/Algorithm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/AlgorithmManager.php
+++ b/src/Component/Core/AlgorithmManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/AlgorithmManagerFactory.php
+++ b/src/Component/Core/AlgorithmManagerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Converter/JsonConverter.php
+++ b/src/Component/Core/Converter/JsonConverter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Converter/StandardConverter.php
+++ b/src/Component/Core/Converter/StandardConverter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/JWK.php
+++ b/src/Component/Core/JWK.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/JWKSet.php
+++ b/src/Component/Core/JWKSet.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/JWT.php
+++ b/src/Component/Core/JWT.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Tests/AlgorithmManagerFactoryTest.php
+++ b/src/Component/Core/Tests/AlgorithmManagerFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Tests/FooAlgorithm.php
+++ b/src/Component/Core/Tests/FooAlgorithm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Tests/JWKSetTest.php
+++ b/src/Component/Core/Tests/JWKSetTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Tests/JWKTest.php
+++ b/src/Component/Core/Tests/JWKTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Tests/JsonConverterTest.php
+++ b/src/Component/Core/Tests/JsonConverterTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/BigInteger.php
+++ b/src/Component/Core/Util/BigInteger.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/ECSignature.php
+++ b/src/Component/Core/Util/ECSignature.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/Curve.php
+++ b/src/Component/Core/Util/Ecc/Curve.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/Math.php
+++ b/src/Component/Core/Util/Ecc/Math.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/ModularArithmetic.php
+++ b/src/Component/Core/Util/Ecc/ModularArithmetic.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/NistCurve.php
+++ b/src/Component/Core/Util/Ecc/NistCurve.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/Point.php
+++ b/src/Component/Core/Util/Ecc/Point.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/PrivateKey.php
+++ b/src/Component/Core/Util/Ecc/PrivateKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Ecc/PublicKey.php
+++ b/src/Component/Core/Util/Ecc/PublicKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/Hash.php
+++ b/src/Component/Core/Util/Hash.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/KeyChecker.php
+++ b/src/Component/Core/Util/KeyChecker.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Core/Util/RSAKey.php
+++ b/src/Component/Core/Util/RSAKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/A128CBCHS256.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/A128CBCHS256.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/A128GCM.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/A128GCM.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/A192CBCHS384.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/A192CBCHS384.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/A192GCM.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/A192GCM.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/A256CBCHS512.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/A256CBCHS512.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/A256GCM.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/A256GCM.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/AESCBCHS.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/AESCBCHS.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryption/AESGCM.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/AESGCM.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/ContentEncryptionAlgorithm.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryptionAlgorithm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/A128GCMKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/A128GCMKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/A128KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/A128KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/A192GCMKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/A192GCMKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/A192KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/A192KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/A256GCMKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/A256GCMKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/A256KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/A256KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/AESGCMKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/AESGCMKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/AESKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/AESKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/Dir.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/Dir.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/DirectEncryption.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/DirectEncryption.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/ECDHES.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/ECDHES.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESA128KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESA128KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESA192KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESA192KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESA256KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESA256KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESAESKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/ECDHESAESKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/KeyAgreement.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/KeyAgreement.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/KeyAgreementWithKeyWrapping.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/KeyAgreementWithKeyWrapping.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/KeyEncryption.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/KeyEncryption.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/KeyWrapping.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/KeyWrapping.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/PBES2AESKW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/PBES2AESKW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/PBES2HS256A128KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/PBES2HS256A128KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/PBES2HS384A192KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/PBES2HS384A192KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/PBES2HS512A256KW.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/PBES2HS512A256KW.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/RSA.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/RSA.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/RSA15.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/RSA15.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/RSAOAEP.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/RSAOAEP.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryption/RSAOAEP256.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryption/RSAOAEP256.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Algorithm/KeyEncryptionAlgorithm.php
+++ b/src/Component/Encryption/Algorithm/KeyEncryptionAlgorithm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Compression/CompressionMethod.php
+++ b/src/Component/Encryption/Compression/CompressionMethod.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Compression/CompressionMethodManager.php
+++ b/src/Component/Encryption/Compression/CompressionMethodManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Compression/CompressionMethodManagerFactory.php
+++ b/src/Component/Encryption/Compression/CompressionMethodManagerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Compression/Deflate.php
+++ b/src/Component/Encryption/Compression/Deflate.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Compression/GZip.php
+++ b/src/Component/Encryption/Compression/GZip.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Compression/ZLib.php
+++ b/src/Component/Encryption/Compression/ZLib.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWE.php
+++ b/src/Component/Encryption/JWE.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWEBuilder.php
+++ b/src/Component/Encryption/JWEBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWEBuilderFactory.php
+++ b/src/Component/Encryption/JWEBuilderFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWEDecrypter.php
+++ b/src/Component/Encryption/JWEDecrypter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWEDecrypterFactory.php
+++ b/src/Component/Encryption/JWEDecrypterFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWELoader.php
+++ b/src/Component/Encryption/JWELoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/JWETokenSupport.php
+++ b/src/Component/Encryption/JWETokenSupport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Recipient.php
+++ b/src/Component/Encryption/Recipient.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Serializer/CompactSerializer.php
+++ b/src/Component/Encryption/Serializer/CompactSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Serializer/JSONFlattenedSerializer.php
+++ b/src/Component/Encryption/Serializer/JSONFlattenedSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Serializer/JSONGeneralSerializer.php
+++ b/src/Component/Encryption/Serializer/JSONGeneralSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Serializer/JWESerializer.php
+++ b/src/Component/Encryption/Serializer/JWESerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Serializer/JWESerializerManager.php
+++ b/src/Component/Encryption/Serializer/JWESerializerManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Serializer/JWESerializerManagerFactory.php
+++ b/src/Component/Encryption/Serializer/JWESerializerManagerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/AESCBC_HSContentEncryptionTest.php
+++ b/src/Component/Encryption/Tests/AESCBC_HSContentEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/AESGCMContentEncryptionTest.php
+++ b/src/Component/Encryption/Tests/AESGCMContentEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/AESGCMKWKeyEncryptionTest.php
+++ b/src/Component/Encryption/Tests/AESGCMKWKeyEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/AESKWKeyEncryptionTest.php
+++ b/src/Component/Encryption/Tests/AESKWKeyEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/CompressionTest.php
+++ b/src/Component/Encryption/Tests/CompressionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/DirAlgorithmTest.php
+++ b/src/Component/Encryption/Tests/DirAlgorithmTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/ECDHESKeyAgreementTest.php
+++ b/src/Component/Encryption/Tests/ECDHESKeyAgreementTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/ECDHESWithX25519EncryptionTest.php
+++ b/src/Component/Encryption/Tests/ECDHESWithX25519EncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/EncrypterTest.php
+++ b/src/Component/Encryption/Tests/EncrypterTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/EncryptionTest.php
+++ b/src/Component/Encryption/Tests/EncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/InvalidCurveAttackTest.php
+++ b/src/Component/Encryption/Tests/InvalidCurveAttackTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/JWEFlattenedTest.php
+++ b/src/Component/Encryption/Tests/JWEFlattenedTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/JWELoaderTest.php
+++ b/src/Component/Encryption/Tests/JWELoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/PBES2_HS_AESKWKeyEncryptionTest.php
+++ b/src/Component/Encryption/Tests/PBES2_HS_AESKWKeyEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionProtectedContentOnlyTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionProtectedContentOnlyTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionWithAdditionalAuthenticatedDataTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionWithAdditionalAuthenticatedDataTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionWithCompressionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionWithCompressionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionWithSpecificProtectedHeaderValuesTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/A128KWAndA128GCMEncryptionWithSpecificProtectedHeaderValuesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/A256GCMKWAndA128CBC_HS256EncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/A256GCMKWAndA128CBC_HS256EncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/DirAndA128GCMEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/DirAndA128GCMEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/ECDH_ES_A128KWAndA128GCMEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/ECDH_ES_A128KWAndA128GCMEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/ECDH_ES_AndA128CBC_HS256EncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/ECDH_ES_AndA128CBC_HS256EncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/MultipleRecipientEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/MultipleRecipientEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/NestingTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/NestingTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/PBES2_HS512_A256KWAndA128CBC_HS256EncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/PBES2_HS512_A256KWAndA128CBC_HS256EncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/RSA1_5AndA128CBC_HS256EncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/RSA1_5AndA128CBC_HS256EncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RFC7520/RSA_OAEPAndA256GCMEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RFC7520/RSA_OAEPAndA256GCMEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RSAEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RSAEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RSAKeyEncryptionTest.php
+++ b/src/Component/Encryption/Tests/RSAKeyEncryptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Tests/RSAKeyWithoutAllPrimesTest.php
+++ b/src/Component/Encryption/Tests/RSAKeyWithoutAllPrimesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Util/ConcatKDF.php
+++ b/src/Component/Encryption/Util/ConcatKDF.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Util/Ecc/EcDH.php
+++ b/src/Component/Encryption/Util/Ecc/EcDH.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Encryption/Util/RSACrypt.php
+++ b/src/Component/Encryption/Util/RSACrypt.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/JKUFactory.php
+++ b/src/Component/KeyManagement/JKUFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/JWKFactory.php
+++ b/src/Component/KeyManagement/JWKFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/JWKFactory.php
+++ b/src/Component/KeyManagement/JWKFactory.php
@@ -206,6 +206,27 @@ final class JWKFactory
     }
 
     /**
+     * This method create a JWK object using a shared secret.
+     *
+     * @param string $secret
+     * @param array  $additional_values
+     *
+     * @return JWK
+     */
+    public static function createFromSecret(string $secret, array $additional_values = []): JWK
+    {
+        $values = array_merge(
+            $additional_values,
+            [
+                'kty' => 'oct',
+                'k' => Base64Url::encode($secret),
+            ]
+        );
+
+        return JWK::create($values);
+    }
+
+    /**
      * @param string $file
      * @param array  $additional_values
      *
@@ -234,6 +255,8 @@ final class JWKFactory
      * @param string      $file
      * @param null|string $secret
      * @param array       $additional_values
+     *
+     * @throws \Exception
      *
      * @return JWK
      */
@@ -265,6 +288,8 @@ final class JWKFactory
      * @param resource $res
      * @param array    $additional_values
      *
+     * @throws \Exception
+     *
      * @return JWK
      */
     public static function createFromX509Resource($res, array $additional_values = []): JWK
@@ -280,6 +305,8 @@ final class JWKFactory
      * @param null|string $password
      * @param array       $additional_values
      *
+     * @throws \Exception
+     *
      * @return JWK
      */
     public static function createFromKeyFile(string $file, ?string $password = null, array $additional_values = []): JWK
@@ -294,6 +321,8 @@ final class JWKFactory
      * @param string      $key
      * @param null|string $password
      * @param array       $additional_values
+     *
+     * @throws \Exception
      *
      * @return JWK
      */

--- a/src/Component/KeyManagement/KeyAnalyzer/AlgorithmAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/AlgorithmAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/KeyAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/KeyAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/KeyAnalyzerManager.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/KeyAnalyzerManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/KeyIdentifierAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/KeyIdentifierAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/Message.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/Message.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/MessageBag.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/MessageBag.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/NoneAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/NoneAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/OctAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/OctAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/RsaAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/RsaAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyAnalyzer/UsageAnalyzer.php
+++ b/src/Component/KeyManagement/KeyAnalyzer/UsageAnalyzer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyConverter/ECKey.php
+++ b/src/Component/KeyManagement/KeyConverter/ECKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyConverter/KeyConverter.php
+++ b/src/Component/KeyManagement/KeyConverter/KeyConverter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/KeyConverter/RSAKey.php
+++ b/src/Component/KeyManagement/KeyConverter/RSAKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/CertificateTest.php
+++ b/src/Component/KeyManagement/Tests/CertificateTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/FooAlgorithm.php
+++ b/src/Component/KeyManagement/Tests/FooAlgorithm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/HttpMessageFactory.php
+++ b/src/Component/KeyManagement/Tests/HttpMessageFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/JWKAnalyzerTest.php
+++ b/src/Component/KeyManagement/Tests/JWKAnalyzerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/JWKFactoryTest.php
+++ b/src/Component/KeyManagement/Tests/JWKFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/JWKFactoryTest.php
+++ b/src/Component/KeyManagement/Tests/JWKFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement\Tests;
 
+use Base64Url\Base64Url;
 use Jose\Component\Core\JWK;
 use Jose\Component\KeyManagement\JWKFactory;
 use PHPUnit\Framework\TestCase;
@@ -63,6 +64,17 @@ final class JWKFactoryTest extends TestCase
             'x5t#256' => 'v7VlokKTGL3anRk8Nl0VcqVC9u5j2Fb5tdlQntUgDT4', ],
             $result->all()
         );
+    }
+
+    public function testCreateFromSecret()
+    {
+        $jwk = JWKFactory::createFromSecret('This is a very secured secret!!!!', ['kid' => 'FOO']);
+        self::assertTrue($jwk->has('kty'));
+        self::assertTrue($jwk->has('k'));
+        self::assertTrue($jwk->has('kid'));
+        self::assertEquals('oct', $jwk->get('kty'));
+        self::assertEquals('This is a very secured secret!!!!', Base64Url::decode($jwk->get('k')));
+        self::assertEquals('FOO', $jwk->get('kid'));
     }
 
     public function testCreateFromKey()

--- a/src/Component/KeyManagement/Tests/JWKSetTest.php
+++ b/src/Component/KeyManagement/Tests/JWKSetTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/JWKTest.php
+++ b/src/Component/KeyManagement/Tests/JWKTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/Keys/ECKeysTest.php
+++ b/src/Component/KeyManagement/Tests/Keys/ECKeysTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/Keys/NoneKeysTest.php
+++ b/src/Component/KeyManagement/Tests/Keys/NoneKeysTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/Keys/OKPKeysTest.php
+++ b/src/Component/KeyManagement/Tests/Keys/OKPKeysTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/Keys/OctKeysTest.php
+++ b/src/Component/KeyManagement/Tests/Keys/OctKeysTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/Keys/RSAKeysTest.php
+++ b/src/Component/KeyManagement/Tests/Keys/RSAKeysTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/MessageBagTest.php
+++ b/src/Component/KeyManagement/Tests/MessageBagTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/MessageFactory.php
+++ b/src/Component/KeyManagement/Tests/MessageFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/Tests/UrlKeySetFactoryTest.php
+++ b/src/Component/KeyManagement/Tests/UrlKeySetFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/UrlKeySetFactory.php
+++ b/src/Component/KeyManagement/UrlKeySetFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/KeyManagement/X5UFactory.php
+++ b/src/Component/KeyManagement/X5UFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/ECDSA.php
+++ b/src/Component/Signature/Algorithm/ECDSA.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/ES256.php
+++ b/src/Component/Signature/Algorithm/ES256.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/ES384.php
+++ b/src/Component/Signature/Algorithm/ES384.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/ES512.php
+++ b/src/Component/Signature/Algorithm/ES512.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/EdDSA.php
+++ b/src/Component/Signature/Algorithm/EdDSA.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/HMAC.php
+++ b/src/Component/Signature/Algorithm/HMAC.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/HS256.php
+++ b/src/Component/Signature/Algorithm/HS256.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/HS384.php
+++ b/src/Component/Signature/Algorithm/HS384.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/HS512.php
+++ b/src/Component/Signature/Algorithm/HS512.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/None.php
+++ b/src/Component/Signature/Algorithm/None.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/PS256.php
+++ b/src/Component/Signature/Algorithm/PS256.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/PS384.php
+++ b/src/Component/Signature/Algorithm/PS384.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/PS512.php
+++ b/src/Component/Signature/Algorithm/PS512.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/RS256.php
+++ b/src/Component/Signature/Algorithm/RS256.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/RS384.php
+++ b/src/Component/Signature/Algorithm/RS384.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/RS512.php
+++ b/src/Component/Signature/Algorithm/RS512.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/RSA.php
+++ b/src/Component/Signature/Algorithm/RSA.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Algorithm/SignatureAlgorithm.php
+++ b/src/Component/Signature/Algorithm/SignatureAlgorithm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWS.php
+++ b/src/Component/Signature/JWS.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWSBuilder.php
+++ b/src/Component/Signature/JWSBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWSBuilderFactory.php
+++ b/src/Component/Signature/JWSBuilderFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWSLoader.php
+++ b/src/Component/Signature/JWSLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWSTokenSupport.php
+++ b/src/Component/Signature/JWSTokenSupport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWSVerifier.php
+++ b/src/Component/Signature/JWSVerifier.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/JWSVerifierFactory.php
+++ b/src/Component/Signature/JWSVerifierFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/CompactSerializer.php
+++ b/src/Component/Signature/Serializer/CompactSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/JSONFlattenedSerializer.php
+++ b/src/Component/Signature/Serializer/JSONFlattenedSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/JSONGeneralSerializer.php
+++ b/src/Component/Signature/Serializer/JSONGeneralSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/JWSSerializer.php
+++ b/src/Component/Signature/Serializer/JWSSerializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/JWSSerializerManager.php
+++ b/src/Component/Signature/Serializer/JWSSerializerManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/JWSSerializerManagerFactory.php
+++ b/src/Component/Signature/Serializer/JWSSerializerManagerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Serializer/Serializer.php
+++ b/src/Component/Signature/Serializer/Serializer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Signature.php
+++ b/src/Component/Signature/Signature.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/ECDSASignatureTest.php
+++ b/src/Component/Signature/Tests/ECDSASignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/EdDSASignatureTest.php
+++ b/src/Component/Signature/Tests/EdDSASignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/ForeignJWTTest.php
+++ b/src/Component/Signature/Tests/ForeignJWTTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/HMACSignatureTest.php
+++ b/src/Component/Signature/Tests/HMACSignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/JWSFlattenedTest.php
+++ b/src/Component/Signature/Tests/JWSFlattenedTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/JWSTest.php
+++ b/src/Component/Signature/Tests/JWSTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/NoneSignatureTest.php
+++ b/src/Component/Signature/Tests/NoneSignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC6979/ECDSASignatureTest.php
+++ b/src/Component/Signature/Tests/RFC6979/ECDSASignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC7520/ECDSASignatureTest.php
+++ b/src/Component/Signature/Tests/RFC7520/ECDSASignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC7520/HMACSignatureTest.php
+++ b/src/Component/Signature/Tests/RFC7520/HMACSignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC7520/MultipleSignaturesTest.php
+++ b/src/Component/Signature/Tests/RFC7520/MultipleSignaturesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC7520/NestingTest.php
+++ b/src/Component/Signature/Tests/RFC7520/NestingTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC7520/RSA15SignatureTest.php
+++ b/src/Component/Signature/Tests/RFC7520/RSA15SignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RFC7520/RSAPSSSignatureTest.php
+++ b/src/Component/Signature/Tests/RFC7520/RSAPSSSignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RSAKeyWithoutAllPrimesTest.php
+++ b/src/Component/Signature/Tests/RSAKeyWithoutAllPrimesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/RSASignatureTest.php
+++ b/src/Component/Signature/Tests/RSASignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/SignatureTest.php
+++ b/src/Component/Signature/Tests/SignatureTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Tests/SignerTest.php
+++ b/src/Component/Signature/Tests/SignerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.

--- a/src/Component/Signature/Util/RSA.php
+++ b/src/Component/Signature/Util/RSA.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Spomky-Labs
+ * Copyright (c) 2014-2018 Spomky-Labs
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v1.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Tests added   |  Yes
| Doc PR        | https://github.com/web-token/jwt-doc/pull/1

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

This PR adds a new method to the JWK Factory (`web-token/jwt-key-mgmt`).
It is now easier to create a JWK from a shared secret:

```php
$jwk = JWKFactory::createFromSecret('My Secret Key');
```

The bundle can also take advantage of this new method:

```yaml
jose:
    keys:
        my_share_key:
            secret: # New key type
                secret: 'This is my secret'
                additional_values:
                    use: 'sig'
                    alg: 'RS512'
                is_public: true
```