### PR TITLE
Encrypter and Decrypter should not pre-encode AAD

### DIFF
--- a/src/Component/Encryption/Algorithm/ContentEncryption/AESCBCHS.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/AESCBCHS.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\ContentEncryption;
 
+use Base64Url\Base64Url;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
 
 abstract class AESCBCHS implements ContentEncryptionAlgorithm
@@ -72,7 +73,7 @@ abstract class AESCBCHS implements ContentEncryptionAlgorithm
     {
         $calculated_aad = $encoded_header;
         if (null !== $aad) {
-            $calculated_aad .= '.'.$aad;
+            $calculated_aad .= '.'.Base64Url::encode($aad);
         }
         $mac_key = mb_substr($cek, 0, $this->getCEKSize() / 16, '8bit');
         $auth_data_length = mb_strlen($encoded_header, '8bit');

--- a/src/Component/Encryption/Algorithm/ContentEncryption/AESGCM.php
+++ b/src/Component/Encryption/Algorithm/ContentEncryption/AESGCM.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\ContentEncryption;
 
+use Base64Url\Base64Url;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
 
 abstract class AESGCM implements ContentEncryptionAlgorithm
@@ -32,7 +33,7 @@ abstract class AESGCM implements ContentEncryptionAlgorithm
     {
         $calculated_aad = $encoded_protected_header;
         if (null !== $aad) {
-            $calculated_aad .= '.'.$aad;
+            $calculated_aad .= '.'.Base64Url::encode($aad);
         }
 
         $C = openssl_encrypt($data, $this->getMode(), $cek, OPENSSL_RAW_DATA, $iv, $tag, $calculated_aad);
@@ -50,7 +51,7 @@ abstract class AESGCM implements ContentEncryptionAlgorithm
     {
         $calculated_aad = $encoded_protected_header;
         if (null !== $aad) {
-            $calculated_aad .= '.'.$aad;
+            $calculated_aad .= '.'.Base64Url::encode($aad);
         }
 
         $P = openssl_decrypt($data, $this->getMode(), $cek, OPENSSL_RAW_DATA, $iv, $tag, $calculated_aad);

--- a/src/Component/Encryption/JWEBuilder.php
+++ b/src/Component/Encryption/JWEBuilder.php
@@ -354,8 +354,7 @@ class JWEBuilder
         $iv_size = $this->contentEncryptionAlgorithm->getIVSize();
         $iv = $this->createIV($iv_size);
         $payload = $this->preparePayload();
-        $aad = $this->aad ? Base64Url::encode($this->aad) : null;
-        $ciphertext = $this->contentEncryptionAlgorithm->encryptContent($payload, $cek, $iv, $aad, $encodedSharedProtectedHeader, $tag);
+        $ciphertext = $this->contentEncryptionAlgorithm->encryptContent($payload, $cek, $iv, $this->aad, $encodedSharedProtectedHeader, $tag);
 
         return [$ciphertext, $iv, $tag];
     }

--- a/src/Component/Encryption/JWEDecrypter.php
+++ b/src/Component/Encryption/JWEDecrypter.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption;
 
-use Base64Url\Base64Url;
 use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
@@ -233,7 +232,7 @@ class JWEDecrypter
      */
     private function decryptPayload(JWE $jwe, string $cek, ContentEncryptionAlgorithm $content_encryption_algorithm, array $completeHeader): string
     {
-        $payload = $content_encryption_algorithm->decryptContent($jwe->getCiphertext(), $cek, $jwe->getIV(), null === $jwe->getAAD() ? null : Base64Url::encode($jwe->getAAD()), $jwe->getEncodedSharedProtectedHeader(), $jwe->getTag());
+        $payload = $content_encryption_algorithm->decryptContent($jwe->getCiphertext(), $cek, $jwe->getIV(), $jwe->getAAD(), $jwe->getEncodedSharedProtectedHeader(), $jwe->getTag());
 
         return $this->decompressIfNeeded($payload, $completeHeader);
     }


### PR DESCRIPTION
If AAD is set, the encrypter and decrypter services should not pre-encode it.
This step should be done by the encryption algorithm itself.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT
| Tests added   | 
| Doc PR        | 

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
