### PR TITLE
Cloudstek/fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ jose.phar.version
 .travis/secrets.tar
 report.md
 composer.lock
+.php_cs
+.php_cs.cache
+vendor/
+src/Bundle/JoseFramework/var/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <server name="KERNEL_CLASS" value="Jose\Bundle\JoseFramework\Tests\AppKernel" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
     </php>
     <filter>
         <whitelist>

--- a/src/Bundle/JoseFramework/DependencyInjection/Configuration.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Configuration.php
@@ -42,8 +42,8 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root($this->alias);
+        $treeBuilder = new TreeBuilder($this->alias);
+        $rootNode = $this->getRootNode($treeBuilder, $this->alias);
 
         foreach ($this->sources as $source) {
             $source->getNodeDefinition($rootNode);
@@ -51,4 +51,14 @@ class Configuration implements ConfigurationInterface
 
         return $treeBuilder;
     }
+    
+     private function getRootNode(TreeBuilder $treeBuilder, $name)
+     {
+         // BC layer for symfony/config 4.1 and older
+         if (! \method_exists($treeBuilder, 'getRootNode')) {
+             return $treeBuilder->root($name);
+         }
+
+         return $treeBuilder->getRootNode();
+     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v1.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

* Fixed deprecation for tree builders without root node in Symfony 4.2 and up in the bundle. Includes a BC fix for older Symfony versions.

* Fixed build failing because of deprecation notices. Set the `SYMFONY_DEPRECATIONS_HELPER` env var to `weak_vendors` in `phpunit.xml.dist` to only exit with code 1 when deprecations occur in our own code, ignoring deprecation notices in vendor libraries. This only affects the exit code and still prints all deprecation notices. Also see the [PHPUnit Bridge documentation](https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail).

* Updated gitignore to ignore `vendor` directory, local PHP-CS-Fixer configuration (`.php_cs`), PHP-CS-Fixer cache file (`.php_cs.cache`) and the auto generated `var` dir containing caches when running tests.