### PR TITLE
Cloudstek/serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ jose.phar.version
 .travis/secrets.tar
 report.md
 composer.lock
+vendor/
+src/Bundle/JoseFramework/var/

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "symfony/browser-kit": "^3.4|^4.0",
         "symfony/finder": "^3.4|^4.0",
         "symfony/phpunit-bridge": "^3.4|^4.0",
+        "symfony/serializer": "^3.3|^4.0",
         "symfony/yaml": "^3.4|^4.0"
     },
     "replace": {
@@ -110,7 +111,8 @@
        "bjeavons/zxcvbn-php": "Adds key quality check for oct keys.",
        "php-http/httplug": "To enable JKU/X5U support.",
        "php-http/httplug-bundle": "To enable JKU/X5U support.",
-       "php-http/message-factory": "To enable JKU/X5U support."
+       "php-http/message-factory": "To enable JKU/X5U support.",
+       "symfony/serializer": "Use the Symfony serializer to serialize/unserialize JWS and JWE tokens."
    },
     "extra": {
         "branch-alias": {

--- a/src/Bundle/JoseFramework/DependencyInjection/Compiler/SymfonySerializerCompilerPass.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Compiler/SymfonySerializerCompilerPass.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\DependencyInjection\Compiler;
+
+use Jose\Bundle\JoseFramework\Normalizer\JWENormalizer;
+use Jose\Bundle\JoseFramework\Normalizer\JWSNormalizer;
+use Jose\Bundle\JoseFramework\Serializer\JWEEncoder;
+use Jose\Bundle\JoseFramework\Serializer\JWSEncoder;
+use Jose\Component\Encryption\Serializer\JWESerializerManagerFactory;
+use Jose\Component\Signature\Serializer\JWSSerializerManagerFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SymfonySerializerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!\class_exists('Symfony\Component\Serializer\Serializer')) {
+            return;
+        }
+
+        if ($container->hasDefinition(JWSSerializerManagerFactory::class)) {
+            $container->autowire(JWSEncoder::class, JWSEncoder::class)
+                ->setPrivate(true)
+                ->addTag('serializer.encoder');
+            $container->autowire(JWSNormalizer::class, JWSNormalizer::class)
+                ->setPrivate(true)
+                ->addTag('serializer.normalizer');
+        }
+
+        if ($container->hasDefinition(JWESerializerManagerFactory::class)) {
+            $container->autowire(JWEEncoder::class, JWEEncoder::class)
+                ->setPrivate(true)
+                ->addTag('serializer.encoder');
+            $container->autowire(JWENormalizer::class, JWENormalizer::class)
+                ->setPrivate(true)
+                ->addTag('serializer.normalizer');
+        }
+    }
+}

--- a/src/Bundle/JoseFramework/JoseFrameworkBundle.php
+++ b/src/Bundle/JoseFramework/JoseFrameworkBundle.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework;
 
+use Jose\Bundle\JoseFramework\DependencyInjection\Compiler\SymfonySerializerCompilerPass;
 use Jose\Bundle\JoseFramework\DependencyInjection\JoseFrameworkExtension;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -46,6 +48,7 @@ class JoseFrameworkBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
         foreach ($this->sources as $source) {
             if ($source instanceof Source\SourceWithCompilerPasses) {
                 $compilerPasses = $source->getCompilerPasses();
@@ -54,6 +57,8 @@ class JoseFrameworkBundle extends Bundle
                 }
             }
         }
+
+        $container->addCompilerPass(new SymfonySerializerCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
     }
 
     /**

--- a/src/Bundle/JoseFramework/Normalizer/JWENormalizer.php
+++ b/src/Bundle/JoseFramework/Normalizer/JWENormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Normalizer;
+
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * JWE normalizer.
+ */
+class JWENormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof JWE && $this->componentInstalled();
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return JWE::class === $type && $this->componentInstalled();
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $object;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return $data;
+    }
+
+    /**
+     * Check if encryption component is installed.
+     */
+    private function componentInstalled(): bool
+    {
+        return class_exists(JWESerializerManager::class);
+    }
+}

--- a/src/Bundle/JoseFramework/Normalizer/JWSNormalizer.php
+++ b/src/Bundle/JoseFramework/Normalizer/JWSNormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Normalizer;
+
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * JWS normalizer.
+ */
+class JWSNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof JWS && $this->componentInstalled();
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return JWS::class === $type && $this->componentInstalled();
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $object;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return $data;
+    }
+
+    /**
+     * Check if encryption component is installed.
+     */
+    private function componentInstalled(): bool
+    {
+        return class_exists(JWSSerializerManager::class);
+    }
+}

--- a/src/Bundle/JoseFramework/Serializer/JWEEncoder.php
+++ b/src/Bundle/JoseFramework/Serializer/JWEEncoder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Serializer;
+
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use Jose\Component\Encryption\Serializer\JWESerializerManagerFactory;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+
+class JWEEncoder implements EncoderInterface, DecoderInterface
+{
+    /**
+     * @var JWESerializerManager
+     */
+    protected $serializerManager;
+
+    public function __construct(
+        JWESerializerManagerFactory $serializerManagerFactory,
+        ?JWESerializerManager $serializerManager = null
+    ) {
+        if (null === $serializerManager) {
+            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->names());
+        }
+
+        $this->serializerManager = $serializerManager;
+    }
+
+    public function supportsEncoding($format)
+    {
+        return \in_array(mb_strtolower($format), $this->serializerManager->list(), true);
+    }
+
+    public function supportsDecoding($format)
+    {
+        return $this->supportsEncoding($format);
+    }
+
+    public function encode($data, $format, array $context = [])
+    {
+        try {
+            return $this->serializerManager->serialize(mb_strtolower($format), $data, $this->getRecipientIndex($context));
+        } catch (\Exception $ex) {
+            throw new NotEncodableValueException(sprintf('Cannot encode JWE to %s format.', $format), 0, $ex);
+        }
+    }
+
+    public function decode($data, $format, array $context = [])
+    {
+        try {
+            return $this->serializerManager->unserialize($data);
+        } catch (\Exception $ex) {
+            throw new NotEncodableValueException(sprintf('Cannot decode JWE from %s format.', $format), 0, $ex);
+        }
+    }
+
+    /**
+     * Get JWE recipient index from context.
+     */
+    protected function getRecipientIndex(array $context): int
+    {
+        $recipientIndex = 0;
+
+        if (isset($context['recipient_index']) && \is_int($context['recipient_index'])) {
+            $recipientIndex = $context['recipient_index'];
+        }
+
+        return $recipientIndex;
+    }
+}

--- a/src/Bundle/JoseFramework/Serializer/JWSEncoder.php
+++ b/src/Bundle/JoseFramework/Serializer/JWSEncoder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Serializer;
+
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Jose\Component\Signature\Serializer\JWSSerializerManagerFactory;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+
+class JWSEncoder implements EncoderInterface, DecoderInterface
+{
+    /**
+     * @var JWSSerializerManager
+     */
+    protected $serializerManager;
+
+    public function __construct(
+        JWSSerializerManagerFactory $serializerManagerFactory,
+        ?JWSSerializerManager $serializerManager = null
+    ) {
+        if (null === $serializerManager) {
+            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->names());
+        }
+
+        $this->serializerManager = $serializerManager;
+    }
+
+    public function supportsEncoding($format)
+    {
+        return \in_array(mb_strtolower($format), $this->serializerManager->list(), true);
+    }
+
+    public function supportsDecoding($format)
+    {
+        return $this->supportsEncoding($format);
+    }
+
+    public function encode($data, $format, array $context = [])
+    {
+        try {
+            return $this->serializerManager->serialize(mb_strtolower($format), $data, $this->getSignatureIndex($context));
+        } catch (\Exception $ex) {
+            throw new NotEncodableValueException(sprintf('Cannot encode JWS to %s format.', $format), 0, $ex);
+        }
+    }
+
+    public function decode($data, $format, array $context = [])
+    {
+        try {
+            return $this->serializerManager->unserialize($data);
+        } catch (\Exception $ex) {
+            throw new NotEncodableValueException(sprintf('Cannot decode JWS from %s format.', $format), 0, $ex);
+        }
+    }
+
+    /**
+     * Get JWS signature index from context.
+     */
+    protected function getSignatureIndex(array $context): int
+    {
+        $signatureIndex = 0;
+
+        if (isset($context['signature_index']) && \is_int($context['signature_index'])) {
+            $signatureIndex = $context['signature_index'];
+        }
+
+        return $signatureIndex;
+    }
+}

--- a/src/Bundle/JoseFramework/Tests/Functional/Normalizer/JWENormalizerTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Normalizer/JWENormalizerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Tests\Functional\Normalizer;
+
+use Jose\Bundle\JoseFramework\Normalizer\JWENormalizer;
+use Jose\Component\Core\JWK;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEBuilderFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @group Bundle
+ * @group Functional
+ */
+class JWENormalizerTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        if (!\class_exists(JWEBuilderFactory::class)) {
+            static::markTestSkipped('The component "web-token/jwt-encryption" is not installed.');
+        }
+
+        if (!\class_exists(Serializer::class)) {
+            static::markTestSkipped('The component "symfony/serializer" is not installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function jWENormalizerIsAvailable()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var Serializer $serializer */
+        $serializer = $container->get('serializer');
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $client->getContainer()->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+        static::assertTrue($serializer->supportsNormalization($jwe));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSNormalizerPassesThrough()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWENormalizer();
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $client->getContainer()->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+        static::assertTrue($serializer->supportsNormalization($jwe));
+        static::assertEquals($jwe, $serializer->normalize($jwe));
+        static::assertEquals($jwe, $serializer->denormalize($jwe, JWE::class));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSNormalizerFromContainerPassesThrough()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var Serializer $serializer */
+        $serializer = $container->get('serializer');
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $client->getContainer()->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+        static::assertTrue($serializer->supportsNormalization($jwe));
+        static::assertEquals($jwe, $serializer->normalize($jwe));
+        static::assertEquals($jwe, $serializer->denormalize($jwe, JWE::class));
+    }
+}

--- a/src/Bundle/JoseFramework/Tests/Functional/Normalizer/JWSNormalizerTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Normalizer/JWSNormalizerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Tests\Functional\Normalizer;
+
+use Jose\Bundle\JoseFramework\Normalizer\JWSNormalizer;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSBuilderFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @group Bundle
+ * @group Functional
+ */
+class JWSNormalizerTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        if (!\class_exists(JWSBuilderFactory::class)) {
+            static::markTestSkipped('The component "web-token/jwt-signature" is not installed.');
+        }
+
+        if (!\class_exists(Serializer::class)) {
+            static::markTestSkipped('The component "symfony/serializer" is not installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function jWSNormalizerIsAvailable()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var Serializer $serializer */
+        $serializer = $container->get('serializer');
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertTrue($serializer->supportsNormalization($jws));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSNormalizerPassesThrough()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWSNormalizer();
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertTrue($serializer->supportsNormalization($jws));
+        static::assertEquals($jws, $serializer->normalize($jws));
+        static::assertEquals($jws, $serializer->denormalize($jws, JWS::class));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSNormalizerFromContainerPassesThrough()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var Serializer $serializer */
+        $serializer = $container->get('serializer');
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertTrue($serializer->supportsNormalization($jws));
+        static::assertEquals($jws, $serializer->normalize($jws));
+        static::assertEquals($jws, $serializer->denormalize($jws, JWS::class));
+    }
+}

--- a/src/Bundle/JoseFramework/Tests/Functional/Serializer/JWEEncoderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Serializer/JWEEncoderTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Tests\Functional\Serializer;
+
+use Jose\Bundle\JoseFramework\Serializer\JWEEncoder;
+use Jose\Component\Core\Converter\StandardConverter;
+use Jose\Component\Core\JWK;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEBuilderFactory;
+use Jose\Component\Encryption\JWELoaderFactory;
+use Jose\Component\Encryption\Serializer\CompactSerializer;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use Jose\Component\Encryption\Serializer\JWESerializerManagerFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @group Bundle
+ * @group Functional
+ */
+class JWEEncoderTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        if (!\class_exists(JWEBuilderFactory::class)) {
+            static::markTestSkipped('The component "web-token/jwt-encryption" is not installed.');
+        }
+
+        if (!\class_exists(Serializer::class)) {
+            static::markTestSkipped('The component "symfony/serializer" is not installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderIsAvailable()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var Serializer $serializer */
+        $serializer = $container->get('serializer');
+
+        static::assertTrue($serializer->supportsEncoding('jwe_compact'));
+        static::assertTrue($serializer->supportsEncoding('jwe_json_flattened'));
+        static::assertTrue($serializer->supportsEncoding('jwe_json_general'));
+
+        static::assertTrue($serializer->supportsDecoding('jwe_compact'));
+        static::assertTrue($serializer->supportsDecoding('jwe_json_flattened'));
+        static::assertTrue($serializer->supportsDecoding('jwe_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderSupportsAllFormatsByDefault()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class));
+
+        static::assertTrue($serializer->supportsEncoding('jwe_compact'));
+        static::assertTrue($serializer->supportsEncoding('jwe_json_flattened'));
+        static::assertTrue($serializer->supportsEncoding('jwe_json_general'));
+
+        static::assertTrue($serializer->supportsDecoding('jwe_compact'));
+        static::assertTrue($serializer->supportsDecoding('jwe_json_flattened'));
+        static::assertTrue($serializer->supportsDecoding('jwe_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderCanEncodeAllFormats()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class));
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $container->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        /** @var JWELoaderFactory $jweLoaderFactory */
+        $jweLoaderFactory = $container->get(JWELoaderFactory::class);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+
+        // Compact
+        $loader = $jweLoaderFactory->create(['jwe_compact'], ['A256KW'], ['A256CBC-HS512'], []);
+
+        $token = $serializer->encode($jwe, 'jwe_compact');
+        static::assertRegExp('/(eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0)\.(.+?)\.(.+?)\.(.+?)\.(.+)/', $token);
+        static::assertInstanceOf(JWE::class, $loader->loadAndDecryptWithKey($token, $jwk, $recipient));
+
+        // Flat
+        $loader = $jweLoaderFactory->create(['jwe_json_flattened'], ['A256KW'], ['A256CBC-HS512'], []);
+
+        $token = $serializer->encode($jwe, 'jwe_json_flattened');
+        static::assertJson($token);
+        static::assertInstanceOf(JWE::class, $loader->loadAndDecryptWithKey($token, $jwk, $recipient));
+
+        // JSON
+        $loader = $jweLoaderFactory->create(['jwe_json_general'], ['A256KW'], ['A256CBC-HS512'], []);
+
+        $token = $serializer->encode($jwe, 'jwe_json_general');
+        static::assertJson($token);
+        static::assertInstanceOf(JWE::class, $loader->loadAndDecryptWithKey($token, $jwk, $recipient));
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderCanDecodeAllFormats()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class));
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $container->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+
+        static::assertInstanceOf(JWE::class, $serializer->decode($this->serializeJWE($jwe, 'jwe_compact', 0), 'jwe_compact'));
+        static::assertInstanceOf(JWE::class, $serializer->decode($this->serializeJWE($jwe, 'jwe_json_flattened', 0), 'jwe_json_flattened'));
+        static::assertInstanceOf(JWE::class, $serializer->decode($this->serializeJWE($jwe, 'jwe_json_general', 0), 'jwe_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderSupportsEncodingWithSpecificSignature()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class));
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $container->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwk2 = JWK::create([
+            'kty' => 'oct',
+            'k' => '1MVYnFKurkDCueAM6FaMlojPPUMrKitzgzCEt3qrQdc',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->addRecipient($jwk2)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+
+        // No context, recipient index = 0
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_compact'), $jwk, $recipient));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_json_flattened'), $jwk, $recipient));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_json_general'), $jwk, $recipient));
+        static::assertEquals(0, $recipient);
+
+        // With context, recipient index = 0
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_compact', ['recipient_index' => 0]), $jwk, $recipient));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_json_flattened', ['recipient_index' => 0]), $jwk, $recipient));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_json_general', ['recipient_index' => 0]), $jwk, $recipient));
+        static::assertEquals(0, $recipient);
+
+        // With context, recipient index = 1
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_compact', ['recipient_index' => 1]), $jwk2, $recipient));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_json_flattened', ['recipient_index' => 1]), $jwk2, $recipient));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_json_general', ['recipient_index' => 1]), $jwk2, $recipient));
+        static::assertEquals(1, $recipient);
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderSupportsCustomSerializerManager()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $jweSerializerManager = JWESerializerManager::create([
+            new CompactSerializer(new StandardConverter()),
+        ]);
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class), $jweSerializerManager);
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $container->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+
+        static::assertTrue($serializer->supportsEncoding('jwe_compact'));
+        static::assertFalse($serializer->supportsEncoding('jwe_json_flattened'));
+        static::assertFalse($serializer->supportsEncoding('jwe_json_general'));
+
+        static::assertTrue($serializer->supportsDecoding('jwe_compact'));
+        static::assertFalse($serializer->supportsDecoding('jwe_json_flattened'));
+        static::assertFalse($serializer->supportsDecoding('jwe_json_general'));
+
+        static::assertInstanceOf(JWE::class, $serializer->decode($this->serializeJWE($jwe, 'jwe_compact', 0), 'jwe_compact'));
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_compact'), $jwk, $recipient));
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderShouldThrowOnUnsupportedFormatWhenEncoding()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $jweSerializerManager = JWESerializerManager::create([
+            new CompactSerializer(new StandardConverter()),
+        ]);
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class), $jweSerializerManager);
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $container->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+        static::assertInstanceOf(JWE::class, $this->loadJWE($serializer->encode($jwe, 'jwe_compact'), $jwk, $recipient));
+
+        $this->expectExceptionMessage('Cannot encode JWE to jwe_json_flattened format.');
+
+        $serializer->encode($jwe, 'jwe_json_flattened');
+    }
+
+    /**
+     * @test
+     */
+    public function jWEEncoderShouldThrowOnUnsupportedFormatWhenDecoding()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $jweSerializerManager = JWESerializerManager::create([
+            new CompactSerializer(new StandardConverter()),
+        ]);
+
+        $serializer = new JWEEncoder($container->get(JWESerializerManagerFactory::class), $jweSerializerManager);
+
+        /** @var JWEBuilderFactory $jweFactory */
+        $jweFactory = $container->get(JWEBuilderFactory::class);
+
+        $builder = $jweFactory->create(['A256KW'], ['A256CBC-HS512'], []);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwe = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ])
+            ->addRecipient($jwk)
+            ->build();
+
+        static::assertInstanceOf(JWE::class, $jwe);
+        static::assertInstanceOf(JWE::class, $serializer->decode($this->serializeJWE($jwe, 'jwe_compact', 0), 'jwe_compact'));
+
+        $this->expectExceptionMessage('Cannot decode JWE from jwe_json_flattened format.');
+
+        $serializer->decode($this->serializeJWE($jwe, 'jwe_json_flattened', 0), 'jwe_json_flattened');
+    }
+
+    /**
+     * Serialize JWKE.
+     *
+     * Use the JWESerializerManager to serialize a JWE.
+     */
+    private function serializeJWE(JWE $jwe, string $format, ?int $recipientIndex = 0): string
+    {
+        /** @var JWESerializerManagerFactory $jweSerializerManagerFactory */
+        $jweSerializerManagerFactory = static::createClient()->getContainer()->get(JWESerializerManagerFactory::class);
+
+        /** @var JWESerializerManager $jweSerializerManager */
+        $jweSerializerManager = $jweSerializerManagerFactory->create($jweSerializerManagerFactory->names());
+
+        return $jweSerializerManager->serialize($format, $jwe, $recipientIndex);
+    }
+
+    /**
+     * Load/unserialize JWE.
+     *
+     * Use the JWELoader to load a JWE from a string.
+     */
+    private function loadJWE(string $token, JWK $jwk, ?int &$recipientIndex): JWE
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var JWESerializerManagerFactory $jweSerializerManagerFactory */
+        $jweSerializerManagerFactory = $container->get(JWESerializerManagerFactory::class);
+
+        /** @var JWELoaderFactory $jweLoaderFactory */
+        $jweLoaderFactory = $container->get(JWELoaderFactory::class);
+
+        $loader = $jweLoaderFactory->create($jweSerializerManagerFactory->names(), ['A256KW'], ['A256CBC-HS512'], []);
+
+        return $loader->loadAndDecryptWithKey($token, $jwk, $recipientIndex);
+    }
+}

--- a/src/Bundle/JoseFramework/Tests/Functional/Serializer/JWSEncoderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Serializer/JWSEncoderTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Bundle\JoseFramework\Tests\Functional\Serializer;
+
+use Jose\Bundle\JoseFramework\Serializer\JWSEncoder;
+use Jose\Component\Core\Converter\StandardConverter;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSBuilderFactory;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Jose\Component\Signature\Serializer\JWSSerializerManagerFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @group Bundle
+ * @group Functional
+ */
+class JWSEncoderTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        if (!\class_exists(JWSBuilderFactory::class)) {
+            static::markTestSkipped('The component "web-token/jwt-signature" is not installed.');
+        }
+
+        if (!\class_exists(Serializer::class)) {
+            static::markTestSkipped('The component "symfony/serializer" is not installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderIsAvailable()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        /** @var Serializer $serializer */
+        $serializer = $container->get('serializer');
+
+        static::assertTrue($serializer->supportsEncoding('jws_compact'));
+        static::assertTrue($serializer->supportsEncoding('jws_json_flattened'));
+        static::assertTrue($serializer->supportsEncoding('jws_json_general'));
+
+        static::assertTrue($serializer->supportsDecoding('jws_compact'));
+        static::assertTrue($serializer->supportsDecoding('jws_json_flattened'));
+        static::assertTrue($serializer->supportsDecoding('jws_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderSupportsAllFormatsByDefault()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class));
+
+        static::assertTrue($serializer->supportsEncoding('jws_compact'));
+        static::assertTrue($serializer->supportsEncoding('jws_json_flattened'));
+        static::assertTrue($serializer->supportsEncoding('jws_json_general'));
+
+        static::assertTrue($serializer->supportsDecoding('jws_compact'));
+        static::assertTrue($serializer->supportsDecoding('jws_json_flattened'));
+        static::assertTrue($serializer->supportsDecoding('jws_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderCanEncodeAllFormats()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class));
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertEquals('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', $serializer->encode($jws, 'jws_compact'));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY"}', $serializer->encode($jws, 'jws_json_flattened'));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","signatures":[{"signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY","protected":"eyJhbGciOiJIUzI1NiJ9"}]}', $serializer->encode($jws, 'jws_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderCanDecodeAllFormats()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class));
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertEquals($jws, $serializer->decode('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', 'jws_compact'));
+        static::assertEquals($jws, $serializer->decode('{"payload":"SGVsbG8gV29ybGQh","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY"}', 'jws_json_flattened'));
+        static::assertEquals($jws, $serializer->decode('{"payload":"SGVsbG8gV29ybGQh","signatures":[{"signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY","protected":"eyJhbGciOiJIUzI1NiJ9"}]}', 'jws_json_general'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderSupportsEncodingWithSpecificSignature()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class));
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jwk2 = JWK::create([
+            'kty' => 'oct',
+            'k' => '45d2aGyfduzrkcmL7duvUTDTlXS2s3u4uMER2feQruU',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->addSignature($jwk2, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        $context = [
+            'signature_index' => 0,
+        ];
+
+        $context2 = [
+            'signature_index' => 1,
+        ];
+
+        static::assertInstanceOf(JWS::class, $jws);
+
+        // No context, signature index = 0
+        static::assertEquals('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', $serializer->encode($jws, 'jws_compact'));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY"}', $serializer->encode($jws, 'jws_json_flattened'));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","signatures":[{"signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY","protected":"eyJhbGciOiJIUzI1NiJ9"},{"signature":"ZIKPsa3NtNoACjvh6fhfg6PZgmKiuss_9sDPtMZxtNU","protected":"eyJhbGciOiJIUzI1NiJ9"}]}', $serializer->encode($jws, 'jws_json_general'));
+
+        // With context, signature index = 0
+        static::assertEquals('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', $serializer->encode($jws, 'jws_compact', $context));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY"}', $serializer->encode($jws, 'jws_json_flattened', $context));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","signatures":[{"signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY","protected":"eyJhbGciOiJIUzI1NiJ9"},{"signature":"ZIKPsa3NtNoACjvh6fhfg6PZgmKiuss_9sDPtMZxtNU","protected":"eyJhbGciOiJIUzI1NiJ9"}]}', $serializer->encode($jws, 'jws_json_general', $context));
+
+        // With context, signature index = 1
+        static::assertEquals('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.ZIKPsa3NtNoACjvh6fhfg6PZgmKiuss_9sDPtMZxtNU', $serializer->encode($jws, 'jws_compact', $context2));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"ZIKPsa3NtNoACjvh6fhfg6PZgmKiuss_9sDPtMZxtNU"}', $serializer->encode($jws, 'jws_json_flattened', $context2));
+        static::assertEquals('{"payload":"SGVsbG8gV29ybGQh","signatures":[{"signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY","protected":"eyJhbGciOiJIUzI1NiJ9"},{"signature":"ZIKPsa3NtNoACjvh6fhfg6PZgmKiuss_9sDPtMZxtNU","protected":"eyJhbGciOiJIUzI1NiJ9"}]}', $serializer->encode($jws, 'jws_json_general', $context2));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderSupportsCustomSerializerManager()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $jwsSerializerManager = JWSSerializerManager::create([
+            new CompactSerializer(new StandardConverter()),
+        ]);
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class), $jwsSerializerManager);
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+
+        static::assertTrue($serializer->supportsEncoding('jws_compact'));
+        static::assertFalse($serializer->supportsEncoding('jws_json_flattened'));
+        static::assertFalse($serializer->supportsEncoding('jws_json_general'));
+
+        static::assertTrue($serializer->supportsDecoding('jws_compact'));
+        static::assertFalse($serializer->supportsDecoding('jws_json_flattened'));
+        static::assertFalse($serializer->supportsDecoding('jws_json_general'));
+
+        static::assertEquals('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', $serializer->encode($jws, 'jws_compact'));
+        static::assertEquals($jws, $serializer->decode('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', 'jws_compact'));
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderShouldThrowOnUnsupportedFormatWhenEncoding()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializerManager = JWSSerializerManager::create([
+            new CompactSerializer(new StandardConverter()),
+        ]);
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class), $serializerManager);
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertEquals('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', $serializer->encode($jws, 'jws_compact'));
+
+        $this->expectExceptionMessage('Cannot encode JWS to jws_json_flattened format.');
+
+        $serializer->encode($jws, 'jws_json_flattened');
+    }
+
+    /**
+     * @test
+     */
+    public function jWSEncoderShouldThrowOnUnsupportedFormatWhenDecoding()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $serializerManager = JWSSerializerManager::create([
+            new CompactSerializer(new StandardConverter()),
+        ]);
+
+        $serializer = new JWSEncoder($container->get(JWSSerializerManagerFactory::class), $serializerManager);
+
+        /** @var JWSBuilderFactory $jwsFactory */
+        $jwsFactory = $client->getContainer()->get(JWSBuilderFactory::class);
+
+        $builder = $jwsFactory->create(['HS256']);
+
+        $jwk = JWK::create([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        $jws = $builder
+            ->create()
+            ->withPayload('Hello World!')
+            ->addSignature($jwk, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertInstanceOf(JWS::class, $jws);
+        static::assertEquals($jws, $serializer->decode('eyJhbGciOiJIUzI1NiJ9.SGVsbG8gV29ybGQh.qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY', 'jws_compact'));
+
+        $this->expectExceptionMessage('Cannot decode JWS from jws_json_flattened format.');
+
+        $serializer->decode('{"payload":"SGVsbG8gV29ybGQh","protected":"eyJhbGciOiJIUzI1NiJ9","signature":"qTzr2HflJbt-MDo1Ye7i5W85avH4hrhvb1U6tbd_mzY"}', 'jws_json_flattened');
+    }
+}

--- a/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSLoaderTest.php
+++ b/src/Bundle/JoseFramework/Tests/Functional/Signature/JWSLoaderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\Tests\Functional\Signature;
 
-use Jose\Component\Signature\JWSBuilderFactory;
 use Jose\Component\Signature\JWSLoader;
 use Jose\Component\Signature\JWSLoaderFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -26,8 +25,8 @@ class JWSLoaderTest extends WebTestCase
 {
     protected function setUp()
     {
-        if (!\class_exists(JWSBuilderFactory::class)) {
-            static::markTestSkipped('The component "web-token/jwt-encryption" is not installed.');
+        if (!\class_exists(JWSLoaderFactory::class)) {
+            static::markTestSkipped('The component "web-token/jwt-signature" is not installed.');
         }
     }
 

--- a/src/Bundle/JoseFramework/composer.json
+++ b/src/Bundle/JoseFramework/composer.json
@@ -26,21 +26,23 @@
         "web-token/jwt-core": "^1.2"
     },
     "require-dev": {
-        "symfony/framework-bundle": "^3.3|^4.0",
-        "symfony/yaml": "^3.3|^4.0",
-        "symfony/browser-kit": "^3.3|^4.0",
-        "phpunit/phpunit": "^6.0|^7.0",
-        "symfony/phpunit-bridge": "^3.3|^4.0",
         "guzzlehttp/psr7": "^1.4",
         "php-http/httplug-bundle": "^1.7",
-        "php-http/mock-client": "^1.0"
+        "php-http/mock-client": "^1.0",
+        "phpunit/phpunit": "^6.0|^7.0",
+        "symfony/browser-kit": "^3.3|^4.0",
+        "symfony/framework-bundle": "^3.3|^4.0",
+        "symfony/phpunit-bridge": "^3.3|^4.0",
+        "symfony/serializer": "^3.3|^4.0",
+        "symfony/yaml": "^3.3|^4.0"
     },
     "suggest": {
         "web-token/jwt-checker": "Add header and claim checker managers as Symfony services.",
         "web-token/jwt-console": "Add Keys (JWK) and Key sets (JWKSet) management commands for your Symfony console.",
         "web-token/jwt-encryption": "Add Encrypted tokens (JWE) support and useful Symfony services.",
         "web-token/jwt-key-mgmt": "Add Keys (JWK) and Key sets (JWKSet) management tools.",
-        "web-token/jwt-signature": "Add signed tokens (JWS) support and useful Symfony services."
+        "web-token/jwt-signature": "Add signed tokens (JWS) support and useful Symfony services.",
+        "symfony/serializer": "Use the Symfony serializer to serialize/unserialize JWS and JWE tokens."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v1.2
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
| Tests added   |  yes
| Doc PR        |  <!--highly recommended for new features-->

This PR adds support for using the Symfony serializer to serialize/unserialize JWS and JWE tokens. It acts as a wrapper and uses the existing serializers internally. It makes it so much easier to use in Symfony applications already relying on the Symfony serializer component.

As the Symfony serializer knows two stages (normalizing and encoding) and the internal serializers only know one stage (encoding), this required writing normalizers which pass on the object untouched. The encoder does all the work and calls the internal serializer based on the given format. The encoders can be provided with a custom serializer manager, otherwise the serializer manager factory will be used to create one with all available serializers.

A compiler pass makes sure the serializers are tagged and  added to the container, based on what components are installed.

Docs have not been updated yet but I can do that if you like.