### PR TITLE
Fix EdDSA to use previously generated private key

### DIFF
--- a/src/SignatureAlgorithm/EdDSA/EdDSA.php
+++ b/src/SignatureAlgorithm/EdDSA/EdDSA.php
@@ -29,9 +29,8 @@ final class EdDSA implements SignatureAlgorithm
         if (!$key->has('d')) {
             throw new \InvalidArgumentException('The key is not private.');
         }
-        $secret = Base64Url::decode($key->get('d'));
-        $keyPair = \sodium_crypto_sign_seed_keypair($secret);
-        $secretKey = \sodium_crypto_sign_secretkey($keyPair);
+
+        $secretKey = Base64Url::decode($key->get('d'));
 
         switch ($key->get('crv')) {
             case 'Ed25519':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v1.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #165
| License       | MIT

Fixes #165. We don't want to regenerate the private key when it's already created when the JWK is created.