### PR TITLE
Native Scalar Multiplication support

### DIFF
--- a/performance/JWE/ECDHESA128KWBench.php
+++ b/performance/JWE/ECDHESA128KWBench.php
@@ -149,7 +149,6 @@ final class ECDHESA128KWBench extends EncryptionBench
                     'crv' => 'X25519',
                     'kty' => 'OKP',
                     'x' => 'LD7PfRPxq03bd0WJyf_1z-LQevmrbcYx7jJafep3gmk',
-                    'd' => 'pSdgXFRYMvOa7giAm3Rrf5Mf8GnvLz7HtZKu_KN06KY',
                 ],
             ],
         ];

--- a/performance/JWE/ECDHESA192KWBench.php
+++ b/performance/JWE/ECDHESA192KWBench.php
@@ -149,7 +149,6 @@ final class ECDHESA192KWBench extends EncryptionBench
                     'crv' => 'X25519',
                     'kty' => 'OKP',
                     'x' => 'LD7PfRPxq03bd0WJyf_1z-LQevmrbcYx7jJafep3gmk',
-                    'd' => 'pSdgXFRYMvOa7giAm3Rrf5Mf8GnvLz7HtZKu_KN06KY',
                 ],
             ],
         ];

--- a/performance/JWE/ECDHESA256KWBench.php
+++ b/performance/JWE/ECDHESA256KWBench.php
@@ -149,7 +149,6 @@ final class ECDHESA256KWBench extends EncryptionBench
                     'crv' => 'X25519',
                     'kty' => 'OKP',
                     'x' => 'LD7PfRPxq03bd0WJyf_1z-LQevmrbcYx7jJafep3gmk',
-                    'd' => 'pSdgXFRYMvOa7giAm3Rrf5Mf8GnvLz7HtZKu_KN06KY',
                 ],
             ],
         ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,7 @@ parameters:
         - '#Parameter \#1 \$value of static method Jose\\Component\\Core\\Util\\BigInteger::createFromGMPResource\(\) expects GMP, resource given\.#'
         - '#Return type \(void\) of method Jose\\Bundle\\JoseFramework\\Routing\\JWKSetLoader::getResolver\(\) should be compatible with return type \(Symfony\\Component\\Config\\Loader\\LoaderResolverInterface\) of method Symfony\\Component\\Config\\Loader\\LoaderInterface::getResolver\(\)#'
         - '#Instanceof between Jose\\Component\\Core\\JWK and Jose\\Component\\Core\\JWK will always evaluate to true\.#'
+        - '#Function openssl_pkey_derive not found\.#'
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -63,20 +63,17 @@ class ECKey
 
     public static function convertPrivateKeyToPEM(JWK $jwk): string
     {
-        $pubKey = unpack('H*', self::getKey($jwk))[1];
-        $pl = (int) (mb_strlen($pubKey, '8bit') / 2);
-
         switch ($jwk->get('crv')) {
             case 'P-256':
-                $der = self::p256PrivateKey($jwk, $pl);
+                $der = self::p256PrivateKey($jwk);
 
                 break;
             case 'P-384':
-                $der = self::p384PrivateKey($jwk, $pl);
+                $der = self::p384PrivateKey($jwk);
 
                 break;
             case 'P-521':
-                $der = self::p521PrivateKey($jwk, $pl);
+                $der = self::p521PrivateKey($jwk);
 
                 break;
             default:
@@ -225,16 +222,15 @@ class ECKey
         );
     }
 
-    private static function p256PrivateKey(JWK $jwk, int $pl): string
+    private static function p256PrivateKey(JWK $jwk): string
     {
-        $d = unpack('H*', Base64Url::decode($jwk->get('d')))[1];
-        $dl = (int) (mb_strlen($d, '8bit') / 2);
+        $d = unpack('H*', str_pad(Base64Url::decode($jwk->get('d')), 32, "\0", STR_PAD_LEFT))[1];
 
         return pack(
             'H*',
-            '30'.dechex(22 + $dl + $pl) // SEQUENCE, length 87+length($d)
+            '3077' // SEQUENCE, length 87+length($d)=32
                 .'020101' // INTEGER, 1
-                .'04'.dechex($dl)   // OCTET STRING, length($d)
+                .'0420'   // OCTET STRING, length($d) = 32
                     .$d
                 .'a00a' // TAGGED OBJECT #0, length 10
                     .'0608' // OID, length 8
@@ -245,16 +241,15 @@ class ECKey
         );
     }
 
-    private static function p384PrivateKey(JWK $jwk, int $pl): string
+    private static function p384PrivateKey(JWK $jwk): string
     {
-        $d = unpack('H*', Base64Url::decode($jwk->get('d')))[1];
-        $dl = (int) (mb_strlen($d, '8bit') / 2);
+        $d = unpack('H*', str_pad(Base64Url::decode($jwk->get('d')), 48, "\0", STR_PAD_LEFT))[1];
 
         return pack(
             'H*',
-            '3081'.dechex(19 + $dl + $pl) // SEQUENCE, length 116 + length($d)
+            '3081a4' // SEQUENCE, length 116 + length($d)=48
                 .'020101' // INTEGER, 1
-                .'04'.dechex($dl)   // OCTET STRING, length($d)
+                .'0430'   // OCTET STRING, length($d) = 30
                     .$d
                 .'a007' // TAGGED OBJECT #0, length 7
                     .'0605' // OID, length 5
@@ -265,16 +260,15 @@ class ECKey
         );
     }
 
-    private static function p521PrivateKey(JWK $jwk, int $pl): string
+    private static function p521PrivateKey(JWK $jwk): string
     {
-        $d = unpack('H*', Base64Url::decode($jwk->get('d')))[1];
-        $dl = (int) (mb_strlen($d, '8bit') / 2);
+        $d = unpack('H*', str_pad(Base64Url::decode($jwk->get('d')), 66, "\0", STR_PAD_LEFT))[1];
 
         return pack(
             'H*',
-            '3081'.dechex(21 + $dl + $pl) // SEQUENCE
+            '3081dc' // SEQUENCE, length 154 + length($d)=66
                 .'020101' // INTEGER, 1
-                .'04'.dechex($dl)   // OCTET STRING, length(d)
+                .'0442'   // OCTET STRING, length(d) = 66
                     .$d
                 .'a007' // TAGGED OBJECT #0, length 7
                     .'0605' // OID, length 5

--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -105,7 +105,7 @@ class ECKey
         return new JWK($values);
     }
 
-    public static function getNistCurve(string $curve): Curve
+    private static function getNistCurve(string $curve): Curve
     {
         switch ($curve) {
             case 'P-256':

--- a/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
+++ b/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
@@ -53,6 +53,17 @@ final class ECDHES implements KeyAgreement
             case 'P-256':
             case 'P-384':
             case 'P-521':
+                if (\function_exists('openssl_pkey_derive')) {
+                    try {
+                        $publicPem = ECKey::convertPublicKeyToPEM($public_key);
+                        $privatePem = ECKey::convertPrivateKeyToPEM($private_key);
+                        $keyLength = mb_strlen(Base64Url::decode($public_key->get('x')), '8bit') * 8;
+
+                        return openssl_pkey_derive($publicPem, $privatePem, $keyLength);
+                    } catch (\Throwable $throwable) {
+                        //Does nothing. Will fallback to the pure PHP function
+                    }
+                }
                 $curve = $this->getCurve($public_key->get('crv'));
 
                 $rec_x = $this->convertBase64ToGmp($public_key->get('x'));

--- a/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
+++ b/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
@@ -53,18 +53,17 @@ final class ECDHES implements KeyAgreement
             case 'P-256':
             case 'P-384':
             case 'P-521':
+                $curve = $this->getCurve($public_key->get('crv'));
                 if (\function_exists('openssl_pkey_derive')) {
                     try {
                         $publicPem = ECKey::convertPublicKeyToPEM($public_key);
                         $privatePem = ECKey::convertPrivateKeyToPEM($private_key);
-                        $keyLength = mb_strlen(Base64Url::decode($public_key->get('x')), '8bit') * 8;
 
-                        return openssl_pkey_derive($publicPem, $privatePem, $keyLength);
+                        return openssl_pkey_derive($publicPem, $privatePem, $curve->getSize());
                     } catch (\Throwable $throwable) {
                         //Does nothing. Will fallback to the pure PHP function
                     }
                 }
-                $curve = $this->getCurve($public_key->get('crv'));
 
                 $rec_x = $this->convertBase64ToGmp($public_key->get('x'));
                 $rec_y = $this->convertBase64ToGmp($public_key->get('y'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v2.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

This PR allows the ECDH-ES algorithm to use the new method `openssl_pkey_derive` introduced in PHP 7.3.

This method is ~50x to ~100x faster depending on the curve.