### PR TITLE
Native Scalar Multiplication support

### DIFF
--- a/performance/JWE/ECDHESA128KWBench.php
+++ b/performance/JWE/ECDHESA128KWBench.php
@@ -154,7 +154,6 @@ final class ECDHESA128KWBench extends EncryptionBench
                     'crv' => 'X25519',
                     'kty' => 'OKP',
                     'x' => 'LD7PfRPxq03bd0WJyf_1z-LQevmrbcYx7jJafep3gmk',
-                    'd' => 'pSdgXFRYMvOa7giAm3Rrf5Mf8GnvLz7HtZKu_KN06KY',
                 ],
             ],
         ];

--- a/performance/JWE/ECDHESA192KWBench.php
+++ b/performance/JWE/ECDHESA192KWBench.php
@@ -154,7 +154,6 @@ final class ECDHESA192KWBench extends EncryptionBench
                     'crv' => 'X25519',
                     'kty' => 'OKP',
                     'x' => 'LD7PfRPxq03bd0WJyf_1z-LQevmrbcYx7jJafep3gmk',
-                    'd' => 'pSdgXFRYMvOa7giAm3Rrf5Mf8GnvLz7HtZKu_KN06KY',
                 ],
             ],
         ];

--- a/performance/JWE/ECDHESA256KWBench.php
+++ b/performance/JWE/ECDHESA256KWBench.php
@@ -154,7 +154,6 @@ final class ECDHESA256KWBench extends EncryptionBench
                     'crv' => 'X25519',
                     'kty' => 'OKP',
                     'x' => 'LD7PfRPxq03bd0WJyf_1z-LQevmrbcYx7jJafep3gmk',
-                    'd' => 'pSdgXFRYMvOa7giAm3Rrf5Mf8GnvLz7HtZKu_KN06KY',
                 ],
             ],
         ];

--- a/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
+++ b/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
@@ -94,6 +94,16 @@ final class ECDHES implements KeyAgreement
             case 'P-384':
             case 'P-521':
                 $curve = $this->getCurve($public_key->get('crv'));
+                if (\function_exists('openssl_pkey_derive')) {
+                    try {
+                        $publicPem = ECKey::convertPublicKeyToPEM($public_key);
+                        $privatePem = ECKey::convertPrivateKeyToPEM($private_key);
+
+                        return openssl_pkey_derive($publicPem, $privatePem, $curve->getSize());
+                    } catch (\Throwable $throwable) {
+                        //Does nothing. Will fallback to the pure PHP function
+                    }
+                }
 
                 $rec_x = $this->convertBase64ToGmp($public_key->get('x'));
                 $rec_y = $this->convertBase64ToGmp($public_key->get('y'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v1.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
This PR allows the ECDH-ES algorithm to use the new method `openssl_pkey_derive` introduced in PHP 7.3.

This method is ~50x to ~100x faster depending on the curve.