### PR TITLE
[Bugfix] Fix JWE serialiser crashing by invalid typehint ⚠️

### DIFF
--- a/src/Component/Encryption/Serializer/JSONFlattenedSerializer.php
+++ b/src/Component/Encryption/Serializer/JSONFlattenedSerializer.php
@@ -88,9 +88,9 @@ final class JSONFlattenedSerializer implements JWESerializer
         );
     }
 
-    private function checkData(array $data): void
+    private function checkData(?array $data): void
     {
-        if (!isset($data['ciphertext']) || isset($data['recipients'])) {
+        if ($data === null || !isset($data['ciphertext']) || isset($data['recipients'])) {
             throw new InvalidArgumentException('Unsupported input.');
         }
     }

--- a/src/Component/Encryption/Serializer/JSONGeneralSerializer.php
+++ b/src/Component/Encryption/Serializer/JSONGeneralSerializer.php
@@ -97,9 +97,9 @@ final class JSONGeneralSerializer implements JWESerializer
         );
     }
 
-    private function checkData(array $data): void
+    private function checkData(?array $data): void
     {
-        if (!isset($data['ciphertext']) || !isset($data['recipients'])) {
+        if ($data === null || !isset($data['ciphertext']) || !isset($data['recipients'])) {
             throw new InvalidArgumentException('Unsupported input.');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v2.0 / v2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

The JWE serialiser crashes when attempting to decode invalid data or even a valid JWS. The JSON serialiser returns null but checkData does not accept a null value and throws an exception as it's typehinted with array.

The v1.3 branch had a `is_array` check here which was removed in `v2.0` but this also prevented null values.