### PR TITLE
ES256K Support added (experimental)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,6 @@ parameters:
         - '#Parameter \#1 \$value of static method Jose\\Component\\Core\\Util\\BigInteger::createFromGMPResource\(\) expects GMP, resource given\.#'
         - '#Return type \(void\) of method Jose\\Bundle\\JoseFramework\\Routing\\JWKSetLoader::getResolver\(\) should be compatible with return type \(Symfony\\Component\\Config\\Loader\\LoaderResolverInterface\) of method Symfony\\Component\\Config\\Loader\\LoaderInterface::getResolver\(\)#'
         - '#Instanceof between Jose\\Component\\Core\\JWK and Jose\\Component\\Core\\JWK will always evaluate to true\.#'
-        - '#Function openssl_pkey_derive not found\.#'
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/Bundle/JoseFramework/Resources/config/Algorithms/signature_experimental.php
+++ b/src/Bundle/JoseFramework/Resources/config/Algorithms/signature_experimental.php
@@ -40,4 +40,8 @@ return function (ContainerConfigurator $container) {
     $container->set(Algorithm\HS256_64::class)
         ->tag('jose.algorithm', ['alias' => 'HS256/64'])
     ;
+
+    $container->set(Algorithm\ES256K::class)
+        ->tag('jose.algorithm', ['alias' => 'ES256K'])
+    ;
 };

--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -39,7 +39,7 @@ class ECKey
                 $der = self::p256PublicKey();
 
                 break;
-            case 'P-256K':
+            case 'secp256k1':
                 $der = self::p256KPublicKey();
 
                 break;
@@ -69,7 +69,7 @@ class ECKey
                 $der = self::p256PrivateKey($jwk);
 
                 break;
-            case 'P-256K':
+            case 'secp256k1':
                 $der = self::p256KPrivateKey($jwk);
 
                 break;
@@ -110,7 +110,7 @@ class ECKey
     {
         switch ($curve) {
             case 'P-256':
-            case 'P-256K':
+            case 'secp256k1':
                 return 256;
             case 'P-384':
                 return 384;
@@ -155,8 +155,8 @@ class ECKey
         switch ($curve) {
             case 'P-256':
                 return 'prime256v1';
-            case 'P-256K':
-                return 'prime256k1';
+            case 'secp256k1':
+                return 'secp256k1';
             case 'P-384':
                 return 'secp384r1';
             case 'P-521':
@@ -245,7 +245,7 @@ class ECKey
         );
     }
 
-    private static function p256kPrivateKey(JWK $jwk): string
+    private static function p256KPrivateKey(JWK $jwk): string
     {
         $d = unpack('H*', str_pad(Base64Url::decode($jwk->get('d')), 32, "\0", STR_PAD_LEFT))[1];
 

--- a/src/SignatureAlgorithm/Experimental/ES256K.php
+++ b/src/SignatureAlgorithm/Experimental/ES256K.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Component\Signature\Algorithm;
+
+final class ES256K extends ECDSA
+{
+    public function name(): string
+    {
+        return 'ES256K';
+    }
+
+    protected function getHashAlgorithm(): string
+    {
+        return 'sha256';
+    }
+
+    protected function getSignaturePartLength(): int
+    {
+        return 64;
+    }
+}

--- a/src/SignatureAlgorithm/Experimental/Tests/P256KSignatureTest.php
+++ b/src/SignatureAlgorithm/Experimental/Tests/P256KSignatureTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Component\Signature\Algorithm\Signature;
+
+use Base64Url\Base64Url;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256K;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group unit
+ * @group NewAlgorithm
+ *
+ * @covers \Jose\Component\Signature\Algorithm\ES256K
+ *
+ * @internal
+ */
+class P256KSignatureTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function es256KVerify()
+    {
+        $key = $this->getKey();
+        $algorithm = new ES256K();
+        $data = 'Hello';
+
+        static::assertTrue($algorithm->verify($key, $data, hex2bin('9c75b9d171d9690a37f2474d4bfab5c234911cb150950ea5cbfc9aedda5ec360725cc47978de95b4efb2a3ed617c7b36b1cd0a26b536662a79d0f3ae873a7924')));
+    }
+
+    /**
+     * @test
+     */
+    public function es256KSignAndVerify()
+    {
+        $key = $this->getKey();
+        $algorithm = new ES256K();
+        $data = 'Hello';
+
+        static::assertEquals('ES256K', $algorithm->name());
+
+        $signature = $algorithm->sign($key, $data);
+
+        static::assertTrue($algorithm->verify($key, $data, $signature));
+    }
+
+    private function getKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256K',
+            'd' => Base64Url::encode(hex2bin('D1592A94BBB9B5D94CDC425FC7DA80B6A47863AE973A9D581FD9D8F29690B659')),
+            'x' => Base64Url::encode(hex2bin('4B4DF318DE05BB8F3A115BF337F9BCBC55CA14B917B46BCB557D3C9A158D4BE0')),
+            'y' => Base64Url::encode(hex2bin('627EB75731A8BBEBC7D9A3C57EC4D7DA2CBA6D2A28E7F45134921861FE1CF5D9')),
+        ]);
+    }
+}

--- a/src/SignatureAlgorithm/Experimental/Tests/P256KSignatureTest.php
+++ b/src/SignatureAlgorithm/Experimental/Tests/P256KSignatureTest.php
@@ -60,7 +60,7 @@ class P256KSignatureTest extends TestCase
     {
         return new JWK([
             'kty' => 'EC',
-            'crv' => 'P-256K',
+            'crv' => 'secp256k1',
             'd' => Base64Url::encode(hex2bin('D1592A94BBB9B5D94CDC425FC7DA80B6A47863AE973A9D581FD9D8F29690B659')),
             'x' => Base64Url::encode(hex2bin('4B4DF318DE05BB8F3A115BF337F9BCBC55CA14B917B46BCB557D3C9A158D4BE0')),
             'y' => Base64Url::encode(hex2bin('627EB75731A8BBEBC7D9A3C57EC4D7DA2CBA6D2A28E7F45134921861FE1CF5D9')),


### PR DESCRIPTION
This PR adds support for ES256K algorithm (EC based on P-256K curve i.e. secp256k1).
It is added in the experimental group as [the associated specification is not approved](https://tools.ietf.org/html/draft-ietf-cose-webauthn-algorithms).