### PR TITLE
Optional ext-sodium

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "ext-sodium": "*",
         "fgrosse/phpasn1": "^2.0",
         "psr/event-dispatcher": "^1.0",
         "psr/http-factory": "^1.0",
@@ -122,6 +121,7 @@
 
     },
    "suggest":{
+       "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
        "bjeavons/zxcvbn-php": "Adds key quality check for oct keys.",
        "php-http/httplug": "To enable JKU/X5U support.",
        "php-http/httplug-bundle": "To enable JKU/X5U support.",

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/SignatureSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/SignatureSource.php
@@ -124,14 +124,19 @@ class SignatureSource implements SourceWithCompilerPasses
 
     private function getAlgorithmsFiles(): array
     {
-        return [
+        $algorithms = [
             RSAPSS::class => 'signature_rsa.php',
             ECDSA::class => 'signature_ecdsa.php',
-            EdDSA::class => 'signature_eddsa.php',
             HMAC::class => 'signature_hmac.php',
             None::class => 'signature_none.php',
             HS1::class => 'signature_experimental.php',
         ];
+
+        if (\extension_loaded('sodium')) {
+            $algorithms[EdDSA::class] = 'signature_eddsa.php';
+        }
+
+        return $algorithms;
     }
 
     private function isEnabled(): bool

--- a/src/Component/KeyManagement/JWKFactory.php
+++ b/src/Component/KeyManagement/JWKFactory.php
@@ -99,6 +99,7 @@ class JWKFactory
      */
     public static function createOKPKey(string $curve, array $values = []): JWK
     {
+        self::checkSodiumIsAvailable();
         switch ($curve) {
             case 'X25519':
                 $keyPair = sodium_crypto_box_keypair();
@@ -296,5 +297,22 @@ class JWKFactory
         $values = array_merge($values, $additional_values);
 
         return new JWK($values);
+    }
+
+    private static function checkSodiumIsAvailable(): void
+    {
+        $requiredFunctions = [
+            'sodium_crypto_box_keypair',
+            'sodium_crypto_box_secretkey',
+            'sodium_crypto_box_publickey',
+            'sodium_crypto_sign_keypair',
+            'sodium_crypto_sign_secretkey',
+            'sodium_crypto_sign_publickey',
+        ];
+        foreach ($requiredFunctions as $function) {
+            if (!\function_exists($function)) {
+                throw new RuntimeException(sprintf('The function "%s" is not available. Have you installed the Sodium extension', $function));
+            }
+        }
     }
 }

--- a/src/Component/KeyManagement/composer.json
+++ b/src/Component/KeyManagement/composer.json
@@ -32,6 +32,7 @@
         "phpunit/phpunit": "^8.0"
     },
     "suggest": {
+        "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
         "web-token/jwt-util-ecc": "To use EC key analyzers.",
         "php-http/message-factory": "To enable JKU/X5U support.",
         "php-http/httplug": "To enable JKU/X5U support."

--- a/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
+++ b/src/EncryptionAlgorithm/KeyEncryption/ECDHES/ECDHES.php
@@ -23,6 +23,7 @@ use Jose\Component\Core\Util\Ecc\NistCurve;
 use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\ConcatKDF;
+use RuntimeException;
 
 final class ECDHES implements KeyAgreement
 {
@@ -74,6 +75,7 @@ final class ECDHES implements KeyAgreement
 
                 return $this->convertDecToBin(EcDH::computeSharedKey($curve, $pub_key, $priv_key));
             case 'X25519':
+                $this->checkSodiumIsAvailable();
                 $sKey = Base64Url::decode($private_key->get('d'));
                 $recipientPublickey = Base64Url::decode($public_key->get('x'));
 
@@ -219,6 +221,7 @@ final class ECDHES implements KeyAgreement
      */
     private function createOKPKey(string $curve): JWK
     {
+        $this->checkSodiumIsAvailable();
         switch ($curve) {
             case 'X25519':
                 $keyPair = sodium_crypto_box_keypair();
@@ -242,5 +245,23 @@ final class ECDHES implements KeyAgreement
             'x' => Base64Url::encode($x),
             'd' => Base64Url::encode($d),
         ]);
+    }
+
+    private function checkSodiumIsAvailable(): void
+    {
+        $requiredFunctions = [
+            'sodium_crypto_scalarmult',
+            'sodium_crypto_box_keypair',
+            'sodium_crypto_box_secretkey',
+            'sodium_crypto_box_publickey',
+            'sodium_crypto_sign_keypair',
+            'sodium_crypto_sign_secretkey',
+            'sodium_crypto_sign_publickey',
+        ];
+        foreach ($requiredFunctions as $function) {
+            if (!\function_exists($function)) {
+                throw new RuntimeException(sprintf('The function "%s" is not available. Have you installed the Sodium extension', $function));
+            }
+        }
     }
 }

--- a/src/EncryptionAlgorithm/KeyEncryption/ECDHES/composer.json
+++ b/src/EncryptionAlgorithm/KeyEncryption/ECDHES/composer.json
@@ -19,6 +19,9 @@
             "Jose\\Component\\Encryption\\Algorithm\\KeyEncryption\\":  ""
         }
     },
+    "suggest": {
+        "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys"
+    },
     "require": {
         "spomky-labs/aes-key-wrap": "^5.0",
         "web-token/jwt-encryption": "^2.0",

--- a/src/EncryptionAlgorithm/KeyEncryption/RSA/Util/RSACrypt.php
+++ b/src/EncryptionAlgorithm/KeyEncryption/RSA/Util/RSACrypt.php
@@ -112,7 +112,7 @@ class RSACrypt
         if (0 >= $length) {
             throw new \RuntimeException();
         }
-        $plaintext = str_split($plaintext, $length);
+        $plaintext = mb_str_split($plaintext, $length);
         $ciphertext = '';
         foreach ($plaintext as $m) {
             $ciphertext .= self::encryptRSAESOAEP($key, $m, $hash);
@@ -130,7 +130,7 @@ class RSACrypt
             throw new RuntimeException();
         }
         $hash = Hash::$hash_algorithm();
-        $ciphertext = str_split($ciphertext, $key->getModulusLength());
+        $ciphertext = mb_str_split($ciphertext, $key->getModulusLength());
         $ciphertext[\count($ciphertext) - 1] = str_pad($ciphertext[\count($ciphertext) - 1], $key->getModulusLength(), \chr(0), STR_PAD_LEFT);
         $plaintext = '';
         foreach ($ciphertext as $c) {

--- a/src/SignatureAlgorithm/EdDSA/EdDSA.php
+++ b/src/SignatureAlgorithm/EdDSA/EdDSA.php
@@ -16,9 +16,23 @@ namespace Jose\Component\Signature\Algorithm;
 use Base64Url\Base64Url;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
+use RuntimeException;
 
 final class EdDSA implements SignatureAlgorithm
 {
+    public function __construct()
+    {
+        $requiredFunctions = [
+            'sodium_crypto_sign_detached',
+            'sodium_crypto_sign_verify_detached',
+        ];
+        foreach ($requiredFunctions as $function) {
+            if (!\function_exists($function)) {
+                throw new RuntimeException(sprintf('The function "%s" is not available. Have you installed the Sodium extension', $function));
+            }
+        }
+    }
+
     public function allowedKeyTypes(): array
     {
         return ['OKP'];

--- a/src/SignatureAlgorithm/EdDSA/composer.json
+++ b/src/SignatureAlgorithm/EdDSA/composer.json
@@ -20,6 +20,7 @@
         }
     },
     "require": {
+        "ext-sodium": "*",
         "web-token/jwt-signature": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Sodium extension is not required anymore, but suggested.
This rule does not applies to the EdDSA signature algorithm.
