### PR TITLE
Fixing bug in JWKSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ composer.lock
 .php_cs.cache
 vendor/
 src/Bundle/JoseFramework/var/
+.idea/

--- a/src/Component/Core/JWKSet.php
+++ b/src/Component/Core/JWKSet.php
@@ -41,7 +41,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
                 unset($keys[$k]);
                 $this->keys[$key->get('kid')] = $key;
             } else {
-                $this->keys[] = $key;
+                $this->keys[$k] = $key;
             }
         }
     }


### PR DESCRIPTION
Added support for user defined key names

```php

$this->keys[$k] = $key;

````

instead of
```php

$this->keys[] = $key;

```

