### PR TITLE
Some fixes

### DIFF
--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/CertificateFile.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/CertificateFile.php
@@ -24,7 +24,7 @@ class CertificateFile extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromCertificateFile',

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWKSet.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/JWKSet.php
@@ -24,7 +24,7 @@ class JWKSet extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromKeySet',

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/KeyFile.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/KeyFile.php
@@ -24,7 +24,7 @@ class KeyFile extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromKeyFile',

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/P12.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/P12.php
@@ -24,7 +24,7 @@ class P12 extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromPKCS12CertificateFile',

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
@@ -24,7 +24,7 @@ class Secret extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromSecret',

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Values.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/Values.php
@@ -24,7 +24,7 @@ class Values extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromValues',

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/X5C.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource/X5C.php
@@ -24,7 +24,7 @@ class X5C extends AbstractSource implements JWKSource
 {
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
-        $definition = new Definition(JWK::class);
+        $definition = new Definition(\Jose\Component\Core\JWK::class);
         $definition->setFactory([
             new Reference(JWKFactory::class),
             'createFromCertificate',

--- a/src/Bundle/JoseFramework/Resources/views/data_collector/tab/keys/jwk.html.twig
+++ b/src/Bundle/JoseFramework/Resources/views/data_collector/tab/keys/jwk.html.twig
@@ -17,7 +17,7 @@
         {% for id, data in collector.getData().key.jwk %}
             <tr>
                 <td>{{ id }}</td>
-                <td>{{ profiler_dump(data.seek('jwk')) }}</td>
+                <td>{{ profiler_dump(data.jwk) }}</td>
                 <td>
                     {% if data.analyze.count() == 0 %}
                         No message. All good!


### PR DESCRIPTION
- source definitions were set for \Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource\JWK instead of \Jose\Component\Core\JWK which is proper instance for Symfony container to register with
- in symfony profiler JWK tab an error occurred because data variable is an array. calling data.jwk directly instead of data.seek('jwk')