### PR TITLE
The method `add` should be public

### DIFF
--- a/src/Component/Core/AlgorithmManager.php
+++ b/src/Component/Core/AlgorithmManager.php
@@ -71,7 +71,7 @@ class AlgorithmManager
     /**
      * Adds an algorithm to the manager.
      */
-    private function add(Algorithm $algorithm): void
+    public function add(Algorithm $algorithm): void
     {
         $name = $algorithm->name();
         $this->algorithms[$name] = $algorithm;


### PR DESCRIPTION
This minor modification changes the visibility of the method `AlgorithmManager::add` from private to public.
This will allow developpers to add algorithms after the contruction of the manager object.
Fix #228