### PR TITLE
symfony 5 compatibility fix

### DIFF
--- a/src/Bundle/JoseFramework/DataCollector/AlgorithmCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/AlgorithmCollector.php
@@ -34,7 +34,7 @@ final class AlgorithmCollector implements Collector
         $this->algorithmManagerFactory = $algorithmManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?\Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $algorithms = $this->algorithmManagerFactory->all();
         $data['algorithm'] = [

--- a/src/Bundle/JoseFramework/DataCollector/CheckerCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/CheckerCollector.php
@@ -74,7 +74,7 @@ class CheckerCollector implements Collector, EventSubscriberInterface
         $this->headerCheckerManagerFactory = $headerCheckerManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?\Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->collectHeaderCheckerManagers($data);
         $this->collectSupportedHeaderCheckers($data);

--- a/src/Bundle/JoseFramework/DataCollector/Collector.php
+++ b/src/Bundle/JoseFramework/DataCollector/Collector.php
@@ -18,5 +18,5 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface Collector
 {
-    public function collect(array &$data, Request $request, Response $response, ?\Exception $exception = null): void;
+    public function collect(array &$data, Request $request, Response $response, ?\Throwable $exception = null): void;
 }

--- a/src/Bundle/JoseFramework/DataCollector/JWECollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JWECollector.php
@@ -80,7 +80,7 @@ class JWECollector implements Collector, EventSubscriberInterface
         $this->jweSerializerManagerFactory = $jweSerializerManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?\Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->collectSupportedCompressionMethods($data);
         $this->collectSupportedJWESerializations($data);

--- a/src/Bundle/JoseFramework/DataCollector/JWSCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JWSCollector.php
@@ -73,7 +73,7 @@ class JWSCollector implements Collector, EventSubscriberInterface
         $this->jwsSerializerManagerFactory = $jwsSerializerManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?\Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->collectSupportedJWSSerializations($data);
         $this->collectSupportedJWSBuilders($data);

--- a/src/Bundle/JoseFramework/DataCollector/JoseCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JoseCollector.php
@@ -25,7 +25,7 @@ class JoseCollector extends DataCollector
      */
     private $collectors = [];
 
-    public function collect(Request $request, Response $response, ?\Exception $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         foreach ($this->collectors as $collector) {
             $collector->collect($this->data, $request, $response, $exception);

--- a/src/Bundle/JoseFramework/DataCollector/KeyCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/KeyCollector.php
@@ -50,7 +50,7 @@ class KeyCollector implements Collector
         $this->jwksetAnalyzerManager = $jwksetAnalyzerManager;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?\Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->collectJWK($data);
         $this->collectJWKSet($data);


### PR DESCRIPTION
This PR fixes a compatibility issue in the Bundle component.

The issue is the following:
- the `web-token/jwt-bundle` package fails to install in a symfony 5 environment (tried with 5.0.2)
- the bundle is incompatible with symfony 5 currently, because the parameter signature of `Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect` [was changed in Symfony 5.0](https://github.com/symfony/http-kernel/commit/75f83183e04fe7952dfeda2b229a04c138b3c7fe).

composer output in sf 5.0.2:

```sh
composer require web-token/jwt-bundle
Using version ^2.1 for web-token/jwt-bundle
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Restricting packages listed in "symfony/symfony" to "5.0.*"

Prefetching 4 packages 🎶 💨
  - Downloading (100%)

Package operations: 4 installs, 0 updates, 0 removals
  - Installing spomky-labs/base64url (v2.0.1): Loading from cache
  - Installing fgrosse/phpasn1 (v2.1.1): Loading from cache
  - Installing web-token/jwt-core (v2.1.4): Loading from cache
  - Installing web-token/jwt-bundle (v2.1.4): Loading from cache
Writing lock file
Generating autoload files
ocramius/package-versions: Generating version class...
ocramius/package-versions: ...done generating version class
Symfony operations: 1 recipe (81cb2dc89949fb258ec4d3e90364bd92)
  - Configuring web-token/jwt-bundle (>=v2.1.4): From auto-generated recipe
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  
!!  Fatal error: Declaration of Jose\Bundle\JoseFramework\DataCollector\JoseCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL): void must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL) in /var/www/html/vendor/web-token/jwt-bundle/DataCollector/JoseCollector.php on line 28
!!  Symfony\Component\ErrorHandler\Error\FatalError {#1789
!!    -error: array:4 [
!!      "type" => 64
!!      "message" => "Declaration of Jose\Bundle\JoseFramework\DataCollector\JoseCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL): void must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL)"
!!      "file" => "/var/www/html/vendor/web-token/jwt-bundle/DataCollector/JoseCollector.php"
!!      "line" => 28
!!    ]
!!    #message: "Compile Error: Declaration of Jose\Bundle\JoseFramework\DataCollector\JoseCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL): void must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL)"
!!    #code: 0
!!    #file: "./vendor/web-token/jwt-bundle/DataCollector/JoseCollector.php"
!!    #line: 28
!!  }
!!  
Script @auto-scripts was called via post-update-cmd

Installation failed, reverting ./composer.json to its original content.
```

I tested the changes by installing the jwt-framework in symfony 4.2, 4.3, 4.4 and 5.0

**Note**: changing only the `JoseCollector::collect` signature would be enough for the fix, as that's the only one actually extending symfony's DataCollector. But I believe changing the JoseFramework's Collector interface accordingly makes it more consistent. Although there is a chance that someone else implements JoseFramework's Collector interface outside of this project, and this change could brake that implementation. I can revert those possible breaking changes if you want.
