### PR TITLE
[JWT-CHECKER] Add missing thrown annotation and create ClaimExceptionInterface

### DIFF
--- a/src/Component/Checker/ClaimCheckerManager.php
+++ b/src/Component/Checker/ClaimCheckerManager.php
@@ -55,6 +55,9 @@ class ClaimCheckerManager
      * It is up to the implementor to decide use the claims that have not been checked.
      *
      * @param string[] $mandatoryClaims
+     *
+     * @throws InvalidClaimException
+     * @throws MissingMandatoryClaimException
      */
     public function check(array $claims, array $mandatoryClaims = []): array
     {
@@ -78,6 +81,8 @@ class ClaimCheckerManager
 
     /**
      * @param string[] $mandatoryClaims
+     *
+     * @throws MissingMandatoryClaimException
      */
     private function checkMandatoryClaims(array $mandatoryClaims, array $claims): void
     {

--- a/src/Component/Checker/ClaimExceptionInterface.php
+++ b/src/Component/Checker/ClaimExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2020 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Jose\Component\Checker;
+
+/**
+ * Exceptions thrown by this component
+ */
+interface ClaimExceptionInterface extends \Throwable
+{
+}

--- a/src/Component/Checker/InvalidClaimException.php
+++ b/src/Component/Checker/InvalidClaimException.php
@@ -18,7 +18,7 @@ use Exception;
 /**
  * This exception is thrown by claim checkers when a claim check failed.
  */
-class InvalidClaimException extends Exception
+class InvalidClaimException extends Exception implements ClaimExceptionInterface
 {
     /**
      * @var string

--- a/src/Component/Checker/MissingMandatoryClaimException.php
+++ b/src/Component/Checker/MissingMandatoryClaimException.php
@@ -15,7 +15,7 @@ namespace Jose\Component\Checker;
 
 use Exception;
 
-class MissingMandatoryClaimException extends Exception
+class MissingMandatoryClaimException extends Exception implements ClaimExceptionInterface
 {
     /**
      * @var string[]


### PR DESCRIPTION
Hi @Spomky 

ClaimCheckerManager::check had no `@throws` annotation, some static-analysis check for unused catch and lead to false-positive.

Moreover, if we want to catch the exception thrown by jwt-checker, an interface can be useful.