### PR TITLE
Add "brick/math" dependency

### DIFF
--- a/src/Component/KeyManagement/composer.json
+++ b/src/Component/KeyManagement/composer.json
@@ -23,7 +23,8 @@
         "ext-openssl": "*",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0",
-        "web-token/jwt-core": "^2.0"
+        "web-token/jwt-core": "^2.0",
+        "brick/math": "^0.8.17|^0.9"
     },
     "require-dev": {
         "php-http/message-factory": "^1.0",


### PR DESCRIPTION
Even though it's used here https://github.com/web-token/jwt-framework/blob/v2.2/src/Component/KeyManagement/Analyzer/ES256KeyAnalyzer.php#L54 the dependancy is not defined