### PR TITLE
Allow to pass a `Throwable`

### DIFF
--- a/src/Bundle/JoseFramework/DataCollector/AlgorithmCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/AlgorithmCollector.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Jose\Bundle\JoseFramework\DataCollector;
 
 use function array_key_exists;
-use Exception;
 use function function_exists;
 use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\AlgorithmManagerFactory;
@@ -24,6 +23,7 @@ use Jose\Component\Signature\Algorithm\MacAlgorithm;
 use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 final class AlgorithmCollector implements Collector
 {
@@ -37,7 +37,7 @@ final class AlgorithmCollector implements Collector
         $this->algorithmManagerFactory = $algorithmManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?Throwable $exception = null): void
     {
         $algorithms = $this->algorithmManagerFactory->all();
         $data['algorithm'] = [

--- a/src/Bundle/JoseFramework/DataCollector/CheckerCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/CheckerCollector.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\DataCollector;
 
-use Exception;
 use Jose\Bundle\JoseFramework\Event\ClaimCheckedFailureEvent;
 use Jose\Bundle\JoseFramework\Event\ClaimCheckedSuccessEvent;
 use Jose\Bundle\JoseFramework\Event\HeaderCheckedFailureEvent;
@@ -26,6 +25,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Throwable;
 
 class CheckerCollector implements Collector, EventSubscriberInterface
 {
@@ -75,7 +75,7 @@ class CheckerCollector implements Collector, EventSubscriberInterface
         $this->headerCheckerManagerFactory = $headerCheckerManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->collectHeaderCheckerManagers($data);
         $this->collectSupportedHeaderCheckers($data);

--- a/src/Bundle/JoseFramework/DataCollector/Collector.php
+++ b/src/Bundle/JoseFramework/DataCollector/Collector.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\DataCollector;
 
-use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 interface Collector
 {
-    public function collect(array &$data, Request $request, Response $response, ?Exception $exception = null): void;
+    public function collect(array &$data, Request $request, Response $response, ?Throwable $exception = null): void;
 }

--- a/src/Bundle/JoseFramework/DataCollector/JWECollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JWECollector.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\DataCollector;
 
-use Exception;
 use Jose\Bundle\JoseFramework\Event\JWEBuiltFailureEvent;
 use Jose\Bundle\JoseFramework\Event\JWEBuiltSuccessEvent;
 use Jose\Bundle\JoseFramework\Event\JWEDecryptionFailureEvent;
@@ -27,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Throwable;
 
 class JWECollector implements Collector, EventSubscriberInterface
 {
@@ -81,7 +81,7 @@ class JWECollector implements Collector, EventSubscriberInterface
         $this->jweSerializerManagerFactory = $jweSerializerManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->collectSupportedCompressionMethods($data);
         $this->collectSupportedJWESerializations($data);

--- a/src/Bundle/JoseFramework/DataCollector/JWSCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/JWSCollector.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\DataCollector;
 
-use Exception;
 use Jose\Bundle\JoseFramework\Event\JWSBuiltFailureEvent;
 use Jose\Bundle\JoseFramework\Event\JWSBuiltSuccessEvent;
 use Jose\Bundle\JoseFramework\Event\JWSVerificationFailureEvent;
@@ -26,6 +25,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Throwable;
 
 class JWSCollector implements Collector, EventSubscriberInterface
 {
@@ -74,7 +74,7 @@ class JWSCollector implements Collector, EventSubscriberInterface
         $this->jwsSerializerManagerFactory = $jwsSerializerManagerFactory;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->collectSupportedJWSSerializations($data);
         $this->collectSupportedJWSBuilders($data);

--- a/src/Bundle/JoseFramework/DataCollector/KeyCollector.php
+++ b/src/Bundle/JoseFramework/DataCollector/KeyCollector.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\DataCollector;
 
-use Exception;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\Analyzer\KeyAnalyzerManager;
@@ -22,6 +21,7 @@ use Jose\Component\KeyManagement\Analyzer\MessageBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Throwable;
 
 class KeyCollector implements Collector
 {
@@ -51,7 +51,7 @@ class KeyCollector implements Collector
         $this->jwksetAnalyzerManager = $jwksetAnalyzerManager;
     }
 
-    public function collect(array &$data, Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(array &$data, Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->collectJWK($data);
         $this->collectJWKSet($data);


### PR DESCRIPTION
Allow to pass a `Throwable` to the data collectors.
See https://github.com/web-token/jwt-framework/issues/275 for details.