### PR TITLE
Remove internal for keys in utils.

### DIFF
--- a/src/Component/Core/Util/ECKey.php
+++ b/src/Component/Core/Util/ECKey.php
@@ -19,9 +19,6 @@ use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use RuntimeException;
 
-/**
- * @internal
- */
 class ECKey
 {
     public static function convertToPEM(JWK $jwk): string

--- a/src/Component/Core/Util/RSAKey.php
+++ b/src/Component/Core/Util/RSAKey.php
@@ -25,9 +25,6 @@ use FG\ASN1\Universal\Sequence;
 use Jose\Component\Core\JWK;
 use RuntimeException;
 
-/**
- * @internal
- */
 class RSAKey
 {
     /**


### PR DESCRIPTION
I am writing a single authentication package. Which will be used in PHP microservice to verify specific JWT tokens, with additional headers, bodies and more. This package will give people the possibility to use different kind of JWT packages. Depending on what they like best. This is done with the adaptor pattern. We have a specific PEM fetcher. Which will return an array of PEMS. 
To do this, I also want to use the classes ECKey and RSAKey. It is working with the internal. I do not really like the message that it is internal. 
Therefor this pull request.