### PR TITLE
Fix checker DI defintions

### DIFF
--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/ClaimChecker.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/ClaimChecker.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Checker;
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
+use Jose\Bundle\JoseFramework\Services\ClaimCheckerManager;
 use Jose\Bundle\JoseFramework\Services\ClaimCheckerManagerFactory;
-use Jose\Component\Signature\JWSVerifier as JWSVerifierService;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -32,7 +32,7 @@ class ClaimChecker implements Source
     {
         foreach ($configs[$this->name()] as $name => $itemConfig) {
             $service_id = sprintf('jose.claim_checker.%s', $name);
-            $definition = new Definition(JWSVerifierService::class);
+            $definition = new Definition(ClaimCheckerManager::class);
             $definition
                 ->setFactory([new Reference(ClaimCheckerManagerFactory::class), 'create'])
                 ->setArguments([

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/HeaderChecker.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/HeaderChecker.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Checker;
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
+use Jose\Bundle\JoseFramework\Services\HeaderCheckerManager;
 use Jose\Bundle\JoseFramework\Services\HeaderCheckerManagerFactory;
-use Jose\Component\Signature\JWSVerifier as JWSVerifierService;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -32,7 +32,7 @@ class HeaderChecker implements Source
     {
         foreach ($configs[$this->name()] as $name => $itemConfig) {
             $service_id = sprintf('jose.header_checker.%s', $name);
-            $definition = new Definition(JWSVerifierService::class);
+            $definition = new Definition(HeaderCheckerManager::class);
             $definition
                 ->setFactory([new Reference(HeaderCheckerManagerFactory::class), 'create'])
                 ->setArguments([


### PR DESCRIPTION
Claim and header checker managers were incorrectly defined as `JWSVerifierService` which made it impossible to lint the container via `bin/console lint:container`.