### PR TITLE
Register autowire argument aliases

### DIFF
--- a/src/Bundle/JoseFramework/DependencyInjection/Source/AbstractSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/AbstractSource.php
@@ -28,6 +28,7 @@ abstract class AbstractSource
             $definition->addTag($id, $attributes);
         }
         $container->setDefinition($service_id, $definition);
+        $container->registerAliasForArgument($service_id, $definition->getClass(), $name.' '.$type);
     }
 
     public function addConfiguration(NodeDefinition $node): void

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/ClaimChecker.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/ClaimChecker.php
@@ -45,6 +45,7 @@ class ClaimChecker implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, ClaimCheckerManager::class, $name.'ClaimCheckerManager');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/HeaderChecker.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/HeaderChecker.php
@@ -45,6 +45,7 @@ class HeaderChecker implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, HeaderCheckerManager::class, $name.'HeaderCheckerManager');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEBuilder.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEBuilder.php
@@ -45,6 +45,7 @@ class JWEBuilder extends AbstractEncryptionSource
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWEBuilderService::class, $name.'JweBuilder');
         }
     }
 }

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEDecrypter.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWEDecrypter.php
@@ -45,6 +45,7 @@ class JWEDecrypter extends AbstractEncryptionSource
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWEDecrypterService::class, $name.'JweDecrypter');
         }
     }
 }

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWELoader.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWELoader.php
@@ -50,6 +50,7 @@ class JWELoader implements Source
             }
 
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWELoaderService::class, $name.'JweLoader');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWESerializer.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Encryption/JWESerializer.php
@@ -43,6 +43,7 @@ class JWESerializer implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWESerializerManager::class, $name.'JweSerializer');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKUriSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKUriSource.php
@@ -42,6 +42,11 @@ class JWKUriSource implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument(
+                $service_id,
+                JWKSetController::class,
+                $name.'JwkSetController'
+            );
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
@@ -49,6 +49,7 @@ class NestedTokenBuilder implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, self::class, $name.'NestedTokenBuilder');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
@@ -51,6 +51,7 @@ class NestedTokenLoader implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, self::class, $name.'NestedTokenLoader');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSBuilder.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSBuilder.php
@@ -41,6 +41,7 @@ class JWSBuilder extends AbstractSignatureSource
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWSBuilderService::class, $name.'JwsBuilder');
         }
     }
 }

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSLoader.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSLoader.php
@@ -48,6 +48,7 @@ class JWSLoader implements Source
             }
 
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWSLoaderService::class, $name.'JwsLoader');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSSerializer.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSSerializer.php
@@ -43,6 +43,7 @@ class JWSSerializer implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWSSerializerManager::class, $name.'JwsSerializer');
         }
     }
 

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSVerifier.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Signature/JWSVerifier.php
@@ -43,6 +43,7 @@ class JWSVerifier extends AbstractSignatureSource
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
+            $container->registerAliasForArgument($service_id, JWSVerifierService::class, $name.'JwsVerifier');
         }
     }
 }


### PR DESCRIPTION
This PR register aliases for arguments to make autowiring a lot easier with multiple instances of say JWS builders. The accompanying Symfony documentation on the subject can be found here: https://symfony.com/doc/current/service_container/autowiring.html#dealing-with-multiple-implementations-of-the-same-type

For example this allows you to define JWS builders named `foo` and `bar` and choose which one to autowire by their variable name and type. For example argument `JWSBuilder $fooJwsBuilder` will autowire the `foo` JWS builder and `JWSBuilder $barJwsBuilder` will autowire the `bar` JWS builder.

This also works for other services. Here is a list of suffixes and their types given that a configuration has been named `foo`:

| Class                                                                                        | Argument                 |
|----------------------------------------------------------------------------------------------|--------------------------|
| Jose\Bundle\JoseFramework\Services\ClaimCheckerManager                                       | $fooClaimCheckerManager  |
| Jose\Bundle\JoseFramework\Services\HeaderCheckerManager                                      | $fooHeaderCheckerManager |
| Jose\Component\Encryption\JWEBuilder                                                         | $fooJweBuilder           |
| Jose\Component\Encryption\JWEDecrypter                                                       | $fooJweDecrypter         |
| Jose\Component\Encryption\JWELoader                                                          | $fooJweLoader            |
| Jose\Component\Encryption\Serializer\JWESerializerManager                                    | $fooJweSerializer        |
| Jose\Component\NestedToken\NestedTokenBuilder                                        | $fooNestedTokenBuilder   |
| Jose\Component\NestedToken\NestedTokenLoader                                         | $fooNestedTokenLoader    |
| Jose\Component\Encryption\JWSBuilder                                                         | $fooJwsBuilder           |
| Jose\Component\Encryption\JWSLoader                                                          | $fooJwsLoader            |
| Jose\Component\Signature\Serializer\JWSSerializerManager                                     | $fooJwsSerializer        |
| Jose\Component\Encryption\JWSVerifier                                                        | $fooJwsVerifier          |
| Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSetSource\JWKSetSource | $fooKeySet               |
| Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource\JWKSource       | $fooKey                  |