### PR TITLE
[Bugfix] Fix nested token builder/loader service definition

### DIFF
--- a/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
@@ -15,6 +15,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\NestedToken;
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\NestedTokenBuilderFactory;
+use Jose\Component\NestedToken\NestedTokenBuilder as NestedTokenBuilderService;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -31,7 +32,7 @@ class NestedTokenBuilder implements Source
     {
         foreach ($configs[$this->name()] as $name => $itemConfig) {
             $service_id = sprintf('jose.nested_token_builder.%s', $name);
-            $definition = new Definition(self::class);
+            $definition = new Definition(NestedTokenBuilderService::class);
             $definition
                 ->setFactory([new Reference(NestedTokenBuilderFactory::class), 'create'])
                 ->setArguments([

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
@@ -15,6 +15,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\NestedToken;
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\NestedTokenLoaderFactory;
+use Jose\Component\NestedToken\NestedTokenLoader as NestedTokenLoaderService;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -31,7 +32,7 @@ class NestedTokenLoader implements Source
     {
         foreach ($configs[$this->name()] as $name => $itemConfig) {
             $service_id = sprintf('jose.nested_token_loader.%s', $name);
-            $definition = new Definition(self::class);
+            $definition = new Definition(NestedTokenLoaderService::class);
             $definition
                 ->setFactory([new Reference(NestedTokenLoaderFactory::class), 'create'])
                 ->setArguments([


### PR DESCRIPTION
Whilst working on #311 I noticed that the service definition seemed off for the `NestedTokenBuilder` and `NestedTokenLoader` but I decided to open a separate PR to attempt to fix this.

The tests ran fine before the fix and still do after the fix. So either some magic happens or these definitions are not tested properly. Looking at the JWS builder and loader for example, they are defined like my fix so I assume it was a bug.

Please let me know what you think 👍🏻 