### PR TITLE
Fix Symfony 5.1 deprecation

### DIFF
--- a/src/Bundle/JoseFramework/Resources/config/jku_source.php
+++ b/src/Bundle/JoseFramework/Resources/config/jku_source.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 use Jose\Component\KeyManagement;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return function (ContainerConfigurator $container): void {
     $container = $container->services()->defaults()
@@ -22,19 +24,25 @@ return function (ContainerConfigurator $container): void {
         ->autowire()
     ;
 
+    $serviceClosure = static function (string $serviceId): ReferenceConfigurator {
+        return function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service')
+            ? service($serviceId)
+            : ref($serviceId);
+    };
+
     $container->set(KeyManagement\JKUFactory::class)
         ->public()
         ->args([
-            ref('jose.http_client'),
-            ref('jose.request_factory'),
+            ($serviceClosure)('jose.http_client'),
+            ($serviceClosure)('jose.request_factory'),
         ])
     ;
 
     $container->set(KeyManagement\X5UFactory::class)
         ->public()
         ->args([
-            ref('jose.http_client'),
-            ref('jose.request_factory'),
+            ($serviceClosure)('jose.http_client'),
+            ($serviceClosure)('jose.request_factory'),
         ])
     ;
 };


### PR DESCRIPTION
This adds a conditional to use service() if existing with fallback to ref() otherwise to support Symfony 4.4.

I'm not sure if this is the best way to "fix" this tbh, feel free to suggest something else. It doesn't even make problems currently but I wanted to get rid of the deprecations there :)