### PR TITLE
adds `withEncodedPayload` to `JWSBuilder`

### DIFF
--- a/src/Component/Signature/JWSBuilder.php
+++ b/src/Component/Signature/JWSBuilder.php
@@ -105,6 +105,27 @@ class JWSBuilder
     }
 
     /**
+     * Set the payload to an already-encoded value.
+     * This method will return a new JWSBuilder object.
+     *
+     * @throws InvalidArgumentException if the payload is not UTF-8 encoded
+     *
+     * @return JWSBuilder
+     */
+    public function withEncodedPayload(string $payload, bool $isPayloadDetached = false): self
+    {
+        if (false === mb_detect_encoding($payload, 'UTF-8', true)) {
+            throw new InvalidArgumentException('The payload must be encoded in UTF-8');
+        }
+        $clone = clone $this;
+        $clone->payload = $payload;
+        $clone->isPayloadDetached = $isPayloadDetached;
+        $clone->isPayloadEncoded = false;
+
+        return $clone;
+    }
+
+    /**
      * Adds the information needed to compute the signature.
      * This method will return a new JWSBuilder object.
      *
@@ -177,7 +198,10 @@ class JWSBuilder
 
     private function checkIfPayloadIsEncoded(array $protectedHeader): bool
     {
-        return !array_key_exists('b64', $protectedHeader) || true === $protectedHeader['b64'];
+        if(null === $this->isPayloadEncoded)
+          return !array_key_exists('b64', $protectedHeader) || true === $protectedHeader['b64'];
+        else
+          return $this->isPayloadEncoded;
     }
 
     /**

--- a/tests/Component/Signature/SignerTest.php
+++ b/tests/Component/Signature/SignerTest.php
@@ -747,6 +747,30 @@ class SignerTest extends SignatureTest
     /**
      * @test
      */
+    public function jWSWithExternallyEncodedPayload(): void
+    {
+        $payload = 'aaaaaaa';
+        $jwsBuilder = $this->getJWSBuilderFactory()->create(['HS512']);
+
+        $expected_result = [
+          'payload' => $payload,
+          'protected' => 'eyJhbGciOiJIUzUxMiJ9',
+          'signature' => '_CzoyjQh6gCXWY01DbJwXBJ5yZzeSgYTF5VbHpLRePP3Xt300n4yTEflj8xrrPNrvjApk6YpjTLX-CYX6YzsbA'
+        ];
+
+        $jws = $jwsBuilder
+            ->create()->withEncodedPayload($payload)
+            ->addSignature($this->getKey1(), ['alg' => 'HS512'])
+            ->build()
+        ;
+        $jws = $this->getJWSSerializerManager()->serialize('jws_json_flattened', $jws, 0);
+
+        static::assertEquals($expected_result, json_decode($jws, true));
+    }
+
+    /**
+     * @test
+     */
     public function signAndLoadWithoutAlgParameterInTheHeader(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
You can use the new `withEncodedPayload` method when you have already externally encoded the payload before passing it to the library for signing.

I'm not particularly attached to the particular implementation here, so suggestions are welcome if there's a better way to do this.

The goal here is to be able to pass in an already-encoded payload and avoid the library doing the base64 encoding on the payload. I realize there's already a method to sort of do that by changing the `b64` header value, but that isn't always possible.

For example, in [this draft](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-7.3.3) you're expected to pass in a base64-url-encoded sha256 hash of a POST body a the JWS payload. In order to build a JWS that validates according to this spec, I needed to do that hash myself and pass in the exact payload contents to the JWS builder.