### PR TITLE
cast keyset generation console arguments to int and remove dangerous …

### DIFF
--- a/src/Component/Console/EcKeysetGeneratorCommand.php
+++ b/src/Component/Console/EcKeysetGeneratorCommand.php
@@ -28,10 +28,7 @@ final class EcKeysetGeneratorCommand extends GeneratorCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $quantity = $input->getArgument('quantity');
-        if (! is_int($quantity)) {
-            $quantity = 1;
-        }
+        $quantity = (int)$input->getArgument('quantity');
         if ($quantity < 1) {
             throw new InvalidArgumentException('Invalid quantity');
         }

--- a/src/Component/Console/OctKeyGeneratorCommand.php
+++ b/src/Component/Console/OctKeyGeneratorCommand.php
@@ -25,10 +25,7 @@ final class OctKeyGeneratorCommand extends GeneratorCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $size = $input->getArgument('size');
-        if (! is_int($size)) {
-            $size = 1;
-        }
+        $size = (int)$input->getArgument('size');
         if ($size < 1) {
             throw new InvalidArgumentException('Invalid size');
         }

--- a/src/Component/Console/OctKeysetGeneratorCommand.php
+++ b/src/Component/Console/OctKeysetGeneratorCommand.php
@@ -27,15 +27,8 @@ final class OctKeysetGeneratorCommand extends GeneratorCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $quantity = $input->getArgument('quantity');
-        if (! is_int($quantity)) {
-            $quantity = 1;
-        }
-
-        $size = $input->getArgument('size');
-        if (! is_int($size)) {
-            $size = 1;
-        }
+        $quantity = (int)$input->getArgument('quantity');
+        $size = (int)$input->getArgument('size');
         if ($quantity < 1) {
             throw new InvalidArgumentException('Invalid quantity');
         }

--- a/src/Component/Console/OkpKeysetGeneratorCommand.php
+++ b/src/Component/Console/OkpKeysetGeneratorCommand.php
@@ -28,10 +28,7 @@ final class OkpKeysetGeneratorCommand extends GeneratorCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $quantity = $input->getArgument('quantity');
-        if (! is_int($quantity)) {
-            $quantity = 1;
-        }
+        $quantity = (int)$input->getArgument('quantity');
         $curve = $input->getArgument('curve');
         if ($quantity < 1) {
             throw new InvalidArgumentException('Invalid quantity');

--- a/src/Component/Console/RsaKeyGeneratorCommand.php
+++ b/src/Component/Console/RsaKeyGeneratorCommand.php
@@ -25,10 +25,7 @@ final class RsaKeyGeneratorCommand extends GeneratorCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $size = $input->getArgument('size');
-        if (! is_int($size)) {
-            $size = 1;
-        }
+        $size = (int)$input->getArgument('size');
         $args = $this->getOptions($input);
         if ($size < 1) {
             throw new InvalidArgumentException('Invalid size');

--- a/src/Component/Console/RsaKeysetGeneratorCommand.php
+++ b/src/Component/Console/RsaKeysetGeneratorCommand.php
@@ -27,14 +27,8 @@ final class RsaKeysetGeneratorCommand extends GeneratorCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $quantity = $input->getArgument('quantity');
-        if (! is_int($quantity)) {
-            $quantity = 1;
-        }
-        $size = $input->getArgument('size');
-        if (! is_int($size)) {
-            $size = 1;
-        }
+        $quantity = (int)$input->getArgument('quantity');
+        $size = (int)$input->getArgument('size');
         if ($quantity < 1) {
             throw new InvalidArgumentException('Invalid quantity');
         }


### PR DESCRIPTION
…defaults

| Q             | A
| ------------- | ---
| Branch?       | <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #338
| License       | MIT

Console commands for generating keysets uses `is_int()` which always fails. These changes uses casts instead and removes dangerous defaults for size. More information in the issue.