### PR TITLE
Use `AsCommand` attribute to prevent Symfony 6.1 deprecations

### DIFF
--- a/src/Component/Console/AddKeyIntoKeysetCommand.php
+++ b/src/Component/Console/AddKeyIntoKeysetCommand.php
@@ -10,18 +10,21 @@ use function is_string;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:add:key',
+    description: 'Add a key into a key set.',
+)]
 final class AddKeyIntoKeysetCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'keyset:add:key';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Add a key into a key set.')
+        $this
             ->setHelp('This command adds a key at the end of a key set.')
             ->addArgument('jwkset', InputArgument::REQUIRED, 'The JWKSet object')
             ->addArgument('jwk', InputArgument::REQUIRED, 'The new JWK object')

--- a/src/Component/Console/EcKeyGeneratorCommand.php
+++ b/src/Component/Console/EcKeyGeneratorCommand.php
@@ -7,18 +7,21 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:generate:ec',
+    description: 'Generate an EC key (JWK format)',
+)]
 final class EcKeyGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:generate:ec';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate an EC key (JWK format)')
+        $this
             ->addArgument('curve', InputArgument::REQUIRED, 'Curve of the key.')
         ;
     }

--- a/src/Component/Console/EcKeysetGeneratorCommand.php
+++ b/src/Component/Console/EcKeysetGeneratorCommand.php
@@ -8,18 +8,21 @@ use InvalidArgumentException;
 use function is_string;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:generate:ec',
+    description: 'Generate an EC key set (JWKSet format)',
+)]
 final class EcKeysetGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'keyset:generate:ec';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate an EC key set (JWKSet format)')
+        $this
             ->addArgument('quantity', InputArgument::REQUIRED, 'Quantity of keys in the key set.')
             ->addArgument('curve', InputArgument::REQUIRED, 'Curve of the keys.')
         ;

--- a/src/Component/Console/GetThumbprintCommand.php
+++ b/src/Component/Console/GetThumbprintCommand.php
@@ -9,19 +9,22 @@ use function is_array;
 use function is_string;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:thumbprint',
+    description: 'Get the thumbprint of a JWK key.',
+)]
 final class GetThumbprintCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'key:thumbprint';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Get the thumbprint of a JWK key.')
+        $this
             ->addArgument('jwk', InputArgument::REQUIRED, 'The JWK key.')
             ->addOption('hash', null, InputOption::VALUE_OPTIONAL, 'The hashing algorithm.', 'sha256')
         ;

--- a/src/Component/Console/JKULoaderCommand.php
+++ b/src/Component/Console/JKULoaderCommand.php
@@ -7,25 +7,27 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\JKUFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:load:jku',
+    description: 'Loads a key set from an url.',
+)]
 final class JKULoaderCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'keyset:load:jku';
-
     public function __construct(
         private JKUFactory $jkuFactory,
-        ?string $name = null
     ) {
-        parent::__construct($name);
+        parent::__construct();
     }
 
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Loads a key set from an url.')
+        $this
             ->setHelp('This command will try to get a key set from an URL. The distant key set is a JWKSet.')
             ->addArgument('url', InputArgument::REQUIRED, 'The URL')
         ;

--- a/src/Component/Console/KeyAnalyzerCommand.php
+++ b/src/Component/Console/KeyAnalyzerCommand.php
@@ -10,27 +10,29 @@ use function is_string;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\Analyzer\KeyAnalyzerManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:analyze',
+    description: 'JWK quality analyzer.',
+)]
 final class KeyAnalyzerCommand extends Command
 {
-    protected static $defaultName = 'key:analyze';
-
     public function __construct(
         private KeyAnalyzerManager $analyzerManager,
-        string $name = null
     ) {
-        parent::__construct($name);
+        parent::__construct();
     }
 
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('JWK quality analyzer.')
+        $this
             ->setHelp('This command will analyze a JWK object and find security issues.')
             ->addArgument('jwk', InputArgument::REQUIRED, 'The JWK object')
         ;

--- a/src/Component/Console/KeyFileLoaderCommand.php
+++ b/src/Component/Console/KeyFileLoaderCommand.php
@@ -7,19 +7,22 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:load:key',
+    description: 'Loads a key from a key file (JWK format)',
+)]
 final class KeyFileLoaderCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:load:key';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Loads a key from a key file (JWK format)')
+        $this
             ->addArgument('file', InputArgument::REQUIRED, 'Filename of the key.')
             ->addOption('secret', 's', InputOption::VALUE_OPTIONAL, 'Secret if the key is encrypted.', null)
         ;

--- a/src/Component/Console/KeysetAnalyzerCommand.php
+++ b/src/Component/Console/KeysetAnalyzerCommand.php
@@ -12,28 +12,30 @@ use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\Analyzer\KeyAnalyzerManager;
 use Jose\Component\KeyManagement\Analyzer\KeysetAnalyzerManager;
 use Jose\Component\KeyManagement\Analyzer\MessageBag;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:analyze',
+    description: 'JWKSet quality analyzer.',
+)]
 final class KeysetAnalyzerCommand extends Command
 {
-    protected static $defaultName = 'keyset:analyze';
-
     public function __construct(
         private KeysetAnalyzerManager $keysetAnalyzerManager,
         private KeyAnalyzerManager $keyAnalyzerManager,
-        string $name = null
     ) {
-        parent::__construct($name);
+        parent::__construct();
     }
 
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('JWKSet quality analyzer.')
+        $this
             ->setHelp('This command will analyze a JWKSet object and find security issues.')
             ->addArgument('jwkset', InputArgument::REQUIRED, 'The JWKSet object')
         ;

--- a/src/Component/Console/MergeKeysetCommand.php
+++ b/src/Component/Console/MergeKeysetCommand.php
@@ -8,18 +8,21 @@ use InvalidArgumentException;
 use function is_array;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:merge',
+    description: 'Merge several key sets into one.',
+)]
 final class MergeKeysetCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'keyset:merge';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Merge several key sets into one.')
+        $this
             ->setHelp(
                 'This command merges several key sets into one. It is very useful when you generate e.g. RSA, EC and OKP keys and you want only one key set to rule them all.'
             )

--- a/src/Component/Console/NoneKeyGeneratorCommand.php
+++ b/src/Component/Console/NoneKeyGeneratorCommand.php
@@ -5,22 +5,16 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:generate:none',
+    description: 'Generate a none key (JWK format). This key type is only supposed to be used with the "none" algorithm.',
+)]
 final class NoneKeyGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:generate:none';
-
-    protected function configure(): void
-    {
-        parent::configure();
-        $this->setDescription(
-            'Generate a none key (JWK format). This key type is only supposed to be used with the "none" algorithm.'
-        )
-        ;
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $args = $this->getOptions($input);

--- a/src/Component/Console/OctKeyGeneratorCommand.php
+++ b/src/Component/Console/OctKeyGeneratorCommand.php
@@ -6,18 +6,21 @@ namespace Jose\Component\Console;
 
 use InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:generate:oct',
+    description: 'Generate an octet key (JWK format)',
+)]
 final class OctKeyGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:generate:oct';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate an octet key (JWK format)')
+        $this
             ->addArgument('size', InputArgument::REQUIRED, 'Key size.')
         ;
     }

--- a/src/Component/Console/OctKeysetGeneratorCommand.php
+++ b/src/Component/Console/OctKeysetGeneratorCommand.php
@@ -7,18 +7,21 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:generate:oct',
+    description: 'Generate a key set with octet keys (JWK format)',
+)]
 final class OctKeysetGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'keyset:generate:oct';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate a key set with octet keys (JWK format)')
+        $this
             ->addArgument('quantity', InputArgument::REQUIRED, 'Quantity of keys in the key set.')
             ->addArgument('size', InputArgument::REQUIRED, 'Key size.')
         ;

--- a/src/Component/Console/OkpKeyGeneratorCommand.php
+++ b/src/Component/Console/OkpKeyGeneratorCommand.php
@@ -7,18 +7,21 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:generate:okp',
+    description: 'Generate an Octet Key Pair key (JWK format)',
+)]
 final class OkpKeyGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:generate:okp';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate an Octet Key Pair key (JWK format)')
+        $this
             ->addArgument('curve', InputArgument::REQUIRED, 'Curve of the key.')
         ;
     }

--- a/src/Component/Console/OkpKeysetGeneratorCommand.php
+++ b/src/Component/Console/OkpKeysetGeneratorCommand.php
@@ -8,18 +8,21 @@ use InvalidArgumentException;
 use function is_string;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:generate:okp',
+    description: 'Generate a key set with Octet Key Pairs keys (JWKSet format)',
+)]
 final class OkpKeysetGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'keyset:generate:okp';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate a key set with Octet Key Pairs keys (JWKSet format)')
+        $this
             ->addArgument('quantity', InputArgument::REQUIRED, 'Quantity of keys in the key set.')
             ->addArgument('curve', InputArgument::REQUIRED, 'Curve of the keys.')
         ;

--- a/src/Component/Console/OptimizeRsaKeyCommand.php
+++ b/src/Component/Console/OptimizeRsaKeyCommand.php
@@ -10,18 +10,21 @@ use function is_string;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\KeyConverter\RSAKey;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:optimize',
+    description: 'Optimize a RSA key by calculating additional primes (CRT).',
+)]
 final class OptimizeRsaKeyCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'key:optimize';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Optimize a RSA key by calculating additional primes (CRT).')
+        $this
             ->addArgument('jwk', InputArgument::REQUIRED, 'The RSA key.')
         ;
     }

--- a/src/Component/Console/P12CertificateLoaderCommand.php
+++ b/src/Component/Console/P12CertificateLoaderCommand.php
@@ -7,19 +7,22 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:load:p12',
+    description: 'Load a key from a P12 certificate file.',
+)]
 final class P12CertificateLoaderCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:load:p12';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Load a key from a P12 certificate file.')
+        $this
             ->addArgument('file', InputArgument::REQUIRED, 'Filename of the P12 certificate.')
             ->addOption('secret', 's', InputOption::VALUE_OPTIONAL, 'Secret if the key is encrypted.', null)
         ;

--- a/src/Component/Console/PemConverterCommand.php
+++ b/src/Component/Console/PemConverterCommand.php
@@ -11,18 +11,21 @@ use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Core\Util\RSAKey;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:convert:pkcs1',
+    description: 'Converts a RSA or EC key into PKCS#1 key.',
+)]
 final class PemConverterCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'key:convert:pkcs1';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Converts a RSA or EC key into PKCS#1 key.')
+        $this
             ->addArgument('jwk', InputArgument::REQUIRED, 'The key')
         ;
     }

--- a/src/Component/Console/PublicKeyCommand.php
+++ b/src/Component/Console/PublicKeyCommand.php
@@ -9,18 +9,21 @@ use function is_array;
 use function is_string;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:convert:public',
+    description: 'Convert a private key into public key. Symmetric keys (shared keys) are not changed.',
+)]
 final class PublicKeyCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'key:convert:public';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Convert a private key into public key. Symmetric keys (shared keys) are not changed.')
+        $this
             ->setHelp('This command converts a private key into a public key.')
             ->addArgument('jwk', InputArgument::REQUIRED, 'The JWK object')
         ;

--- a/src/Component/Console/PublicKeysetCommand.php
+++ b/src/Component/Console/PublicKeysetCommand.php
@@ -9,20 +9,21 @@ use function is_array;
 use function is_string;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:convert:public',
+    description: 'Convert private keys in a key set into public keys. Symmetric keys (shared keys) are not changed.',
+)]
 final class PublicKeysetCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'keyset:convert:public';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription(
-            'Convert private keys in a key set into public keys. Symmetric keys (shared keys) are not changed.'
-        )
+        $this
             ->setHelp('This command converts private keys in a key set into public keys.')
             ->addArgument('jwkset', InputArgument::REQUIRED, 'The JWKSet object')
         ;

--- a/src/Component/Console/RotateKeysetCommand.php
+++ b/src/Component/Console/RotateKeysetCommand.php
@@ -11,18 +11,21 @@ use function is_string;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:rotate',
+    description: 'Rotate a key set.',
+)]
 final class RotateKeysetCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'keyset:rotate';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Rotate a key set.')
+        $this
             ->setHelp('This command removes the last key in a key set a place a new one at the beginning.')
             ->addArgument('jwkset', InputArgument::REQUIRED, 'The JWKSet object')
             ->addArgument('jwk', InputArgument::REQUIRED, 'The new JWK object')

--- a/src/Component/Console/RsaKeyGeneratorCommand.php
+++ b/src/Component/Console/RsaKeyGeneratorCommand.php
@@ -6,18 +6,21 @@ namespace Jose\Component\Console;
 
 use InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:generate:rsa',
+    description: 'Generate a RSA key (JWK format)',
+)]
 final class RsaKeyGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:generate:rsa';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate a RSA key (JWK format)')
+        $this
             ->addArgument('size', InputArgument::REQUIRED, 'Key size.')
         ;
     }

--- a/src/Component/Console/RsaKeysetGeneratorCommand.php
+++ b/src/Component/Console/RsaKeysetGeneratorCommand.php
@@ -7,18 +7,21 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:generate:rsa',
+    description: 'Generate a key set with RSA keys (JWK format)',
+)]
 final class RsaKeysetGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'keyset:generate:rsa';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate a key set with RSA keys (JWK format)')
+        $this
             ->addArgument('quantity', InputArgument::REQUIRED, 'Quantity of keys in the key set.')
             ->addArgument('size', InputArgument::REQUIRED, 'Key size.')
         ;

--- a/src/Component/Console/SecretKeyGeneratorCommand.php
+++ b/src/Component/Console/SecretKeyGeneratorCommand.php
@@ -8,19 +8,22 @@ use InvalidArgumentException;
 use function is_bool;
 use function is_string;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:generate:from_secret',
+    description: 'Generate an octet key (JWK format) using an existing secret',
+)]
 final class SecretKeyGeneratorCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:generate:from_secret';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Generate an octet key (JWK format) using an existing secret')
+        $this
             ->addArgument('secret', InputArgument::REQUIRED, 'The secret')
             ->addOption(
                 'is_b64',

--- a/src/Component/Console/X509CertificateLoaderCommand.php
+++ b/src/Component/Console/X509CertificateLoaderCommand.php
@@ -7,18 +7,21 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'key:load:x509',
+    description: 'Load a key from a X.509 certificate file.',
+)]
 final class X509CertificateLoaderCommand extends GeneratorCommand
 {
-    protected static $defaultName = 'key:load:x509';
-
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Load a key from a X.509 certificate file.')
+        $this
             ->addArgument('file', InputArgument::REQUIRED, 'Filename of the X.509 certificate.')
         ;
     }

--- a/src/Component/Console/X5ULoaderCommand.php
+++ b/src/Component/Console/X5ULoaderCommand.php
@@ -7,25 +7,27 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use function is_string;
 use Jose\Component\KeyManagement\X5UFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'keyset:load:x5u',
+    description: 'Loads a key set from an url.',
+)]
 final class X5ULoaderCommand extends ObjectOutputCommand
 {
-    protected static $defaultName = 'keyset:load:x5u';
-
     public function __construct(
         private X5UFactory $x5uFactory,
-        ?string $name = null
     ) {
-        parent::__construct($name);
+        parent::__construct();
     }
 
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Loads a key set from an url.')
+        $this
             ->setHelp(
                 'This command will try to get a key set from an URL. The distant key set is list of X.509 certificates.'
             )


### PR DESCRIPTION
Since 6.1 the `Command::$defaultName` property is deprecated.