### PR TITLE
Add missing context parameters for supportsEncoding() and supportsDecoding()

### DIFF
--- a/src/Bundle/JoseFramework/Serializer/JWEEncoder.php
+++ b/src/Bundle/JoseFramework/Serializer/JWEEncoder.php
@@ -32,12 +32,12 @@ final class JWEEncoder implements EncoderInterface, DecoderInterface, Normalizat
         $this->serializerManager = $serializerManager;
     }
 
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format, array $context = []): bool
     {
         return class_exists(JWESerializerManager::class) && $this->formatSupported($format);
     }
 
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format, array $context = []): bool
     {
         return class_exists(JWESerializerManager::class) && $this->formatSupported($format);
     }

--- a/src/Bundle/JoseFramework/Serializer/JWSEncoder.php
+++ b/src/Bundle/JoseFramework/Serializer/JWSEncoder.php
@@ -31,12 +31,12 @@ final class JWSEncoder implements EncoderInterface, DecoderInterface, Normalizat
         $this->serializerManager = $serializerManager;
     }
 
-    public function supportsEncoding(string $format): bool
+    public function supportsEncoding(string $format, array $context = []): bool
     {
         return class_exists(JWSSerializerManager::class) && $this->formatSupported($format);
     }
 
-    public function supportsDecoding(string $format): bool
+    public function supportsDecoding(string $format, array $context = []): bool
     {
         return class_exists(JWSSerializerManager::class) && $this->formatSupported($format);
     }


### PR DESCRIPTION
This Makes the encoders forward-compatible, by adding the $context parameter.