### PR TITLE
Add missing context parameters for supportsDenormalization()

### DIFF
--- a/src/Bundle/JoseFramework/Serializer/JWESerializer.php
+++ b/src/Bundle/JoseFramework/Serializer/JWESerializer.php
@@ -26,7 +26,7 @@ final class JWESerializer implements DenormalizerInterface
         $this->serializerManager = $serializerManager;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return $type === JWE::class
             && class_exists(JWESerializerManager::class)

--- a/src/Bundle/JoseFramework/Serializer/JWSSerializer.php
+++ b/src/Bundle/JoseFramework/Serializer/JWSSerializer.php
@@ -26,7 +26,7 @@ final class JWSSerializer implements DenormalizerInterface
         $this->serializerManager = $serializerManager;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return $type === JWS::class
             && class_exists(JWSSerializerManager::class)


### PR DESCRIPTION
Like in #357, the serializers also will get a $contexts array