### PR TITLE
Support PSR-20 (clock)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,9 @@
         "sort-packages": true,
         "allow-plugins": {
             "infection/extension-installer": true,
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "phpstan/extension-installer": false,
+            "php-http/discovery": false
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "ext-sodium": "*",
         "brick/math": "^0.9|^0.10|^0.11",
         "paragonie/constant_time_encoding": "^2.4",
+        "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $config): void {
         DoctrineSetList::DOCTRINE_CODE_QUALITY,
         DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
         PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD,
-        PHPUnitLevelSetList::UP_TO_PHPUNIT_100,
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         PHPUnitSetList::PHPUNIT_EXCEPTION,
         PHPUnitSetList::REMOVE_MOCKS,

--- a/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/CheckerSource.php
+++ b/src/Bundle/JoseFramework/DependencyInjection/Source/Checker/CheckerSource.php
@@ -45,6 +45,7 @@ class CheckerSource implements SourceWithCompilerPasses
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../../Resources/config'));
         $loader->load('checkers.php');
 
+        $container->setAlias('jose.clock', $configs['clock']);
         if (array_key_exists('checkers', $configs)) {
             foreach ($this->sources as $source) {
                 $source->load($configs['checkers'], $container);
@@ -57,6 +58,13 @@ class CheckerSource implements SourceWithCompilerPasses
         if (! $this->isEnabled()) {
             return;
         }
+        $node->children()
+            ->scalarNode('clock')
+            ->defaultValue('jose.internal_clock')
+            ->cannotBeEmpty()
+            ->info('PSR-20 clock')
+            ->end()
+            ->end();
         $childNode = $node
             ->children()
             ->arrayNode($this->name())

--- a/src/Bundle/JoseFramework/Resources/config/checkers.php
+++ b/src/Bundle/JoseFramework/Resources/config/checkers.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 use Jose\Bundle\JoseFramework\Services\ClaimCheckerManagerFactory;
 use Jose\Bundle\JoseFramework\Services\HeaderCheckerManagerFactory;
 use Jose\Component\Checker\ExpirationTimeChecker;
+use Jose\Component\Checker\InternalClock;
 use Jose\Component\Checker\IssuedAtChecker;
 use Jose\Component\Checker\NotBeforeChecker;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 /*
  * The MIT License (MIT)
@@ -17,7 +20,6 @@ use Jose\Component\Checker\NotBeforeChecker;
  * of the MIT license.  See the LICENSE file for details.
  */
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $container): void {
     $container = $container->services()
@@ -33,6 +35,7 @@ return function (ContainerConfigurator $container): void {
         ->public();
 
     $container->set(ExpirationTimeChecker::class)
+        ->arg('$clock', service('jose.internal_clock'))
         ->tag('jose.checker.claim', [
             'alias' => 'exp',
         ])
@@ -41,6 +44,7 @@ return function (ContainerConfigurator $container): void {
         ]);
 
     $container->set(IssuedAtChecker::class)
+        ->arg('$clock', service('jose.internal_clock'))
         ->tag('jose.checker.claim', [
             'alias' => 'iat',
         ])
@@ -49,10 +53,20 @@ return function (ContainerConfigurator $container): void {
         ]);
 
     $container->set(NotBeforeChecker::class)
+        ->arg('$clock', service('jose.internal_clock'))
         ->tag('jose.checker.claim', [
             'alias' => 'nbf',
         ])
         ->tag('jose.checker.header', [
             'alias' => 'nbf',
         ]);
+
+    $container->set('jose.internal_clock')
+        ->class(InternalClock::class)
+        ->deprecate(
+            'web-token/jwt-bundle',
+            '3.2.0',
+            'The service "%service_id%" is an internal service that will be removed in 4.0.0. Please use a PSR-20 compatible service as clock.'
+        )
+        ->private();
 };

--- a/src/Component/Checker/ExpirationTimeChecker.php
+++ b/src/Component/Checker/ExpirationTimeChecker.php
@@ -15,11 +15,22 @@ final class ExpirationTimeChecker implements ClaimChecker, HeaderChecker
 {
     private const NAME = 'exp';
 
+    private readonly ClockInterface $clock;
+
     public function __construct(
         private readonly int $allowedTimeDrift = 0,
         private readonly bool $protectedHeaderOnly = false,
-        private readonly ClockInterface $clock = new InternalClock(),
+        ?ClockInterface $clock = null,
     ) {
+        if ($clock === null) {
+            trigger_deprecation(
+                'web-token/jwt-checker',
+                '3.2.0',
+                'The parameter "$clock" will become mandatory in 4.0.0. Please set a valid PSR Clock implementation instead of "null".'
+            );
+            $clock = new InternalClock();
+        }
+        $this->clock = $clock;
     }
 
     /**

--- a/src/Component/Checker/ExpirationTimeChecker.php
+++ b/src/Component/Checker/ExpirationTimeChecker.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Checker;
 
 use function is_float;
 use function is_int;
+use Psr\Clock\ClockInterface;
 
 /**
  * This class is a claim checker. When the "exp" is present, it will compare the value with the current timestamp.
@@ -16,7 +17,8 @@ final class ExpirationTimeChecker implements ClaimChecker, HeaderChecker
 
     public function __construct(
         private readonly int $allowedTimeDrift = 0,
-        private readonly bool $protectedHeaderOnly = false
+        private readonly bool $protectedHeaderOnly = false,
+        private readonly ClockInterface $clock = new InternalClock(),
     ) {
     }
 
@@ -28,7 +30,10 @@ final class ExpirationTimeChecker implements ClaimChecker, HeaderChecker
         if (! is_float($value) && ! is_int($value)) {
             throw new InvalidClaimException('"exp" must be an integer.', self::NAME, $value);
         }
-        if (time() > $value + $this->allowedTimeDrift) {
+
+        $now = $this->clock->now()
+            ->getTimestamp();
+        if ($now > $value + $this->allowedTimeDrift) {
             throw new InvalidClaimException('The token expired.', self::NAME, $value);
         }
     }
@@ -43,7 +48,10 @@ final class ExpirationTimeChecker implements ClaimChecker, HeaderChecker
         if (! is_float($value) && ! is_int($value)) {
             throw new InvalidHeaderException('"exp" must be an integer.', self::NAME, $value);
         }
-        if (time() > $value + $this->allowedTimeDrift) {
+
+        $now = $this->clock->now()
+            ->getTimestamp();
+        if ($now > $value + $this->allowedTimeDrift) {
             throw new InvalidHeaderException('The token expired.', self::NAME, $value);
         }
     }

--- a/src/Component/Checker/InternalClock.php
+++ b/src/Component/Checker/InternalClock.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Checker;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+/**
+ * @internal
+ */
+final class InternalClock implements ClockInterface
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/Component/Checker/IssuedAtChecker.php
+++ b/src/Component/Checker/IssuedAtChecker.php
@@ -15,11 +15,22 @@ final class IssuedAtChecker implements ClaimChecker, HeaderChecker
 {
     private const NAME = 'iat';
 
+    private readonly ClockInterface $clock;
+
     public function __construct(
         private readonly int $allowedTimeDrift = 0,
         private readonly bool $protectedHeaderOnly = false,
-        private readonly ClockInterface $clock = new InternalClock(),
+        ?ClockInterface $clock = null,
     ) {
+        if ($clock === null) {
+            trigger_deprecation(
+                'web-token/jwt-checker',
+                '3.2.0',
+                'The parameter "$clock" will become mandatory in 4.0.0. Please set a valid PSR Clock implementation instead of "null".'
+            );
+            $clock = new InternalClock();
+        }
+        $this->clock = $clock;
     }
 
     /**

--- a/src/Component/Checker/IssuedAtChecker.php
+++ b/src/Component/Checker/IssuedAtChecker.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Checker;
 
 use function is_float;
 use function is_int;
+use Psr\Clock\ClockInterface;
 
 /**
  * This class is a claim checker. When the "iat" is present, it will compare the value with the current timestamp.
@@ -16,7 +17,8 @@ final class IssuedAtChecker implements ClaimChecker, HeaderChecker
 
     public function __construct(
         private readonly int $allowedTimeDrift = 0,
-        private readonly bool $protectedHeaderOnly = false
+        private readonly bool $protectedHeaderOnly = false,
+        private readonly ClockInterface $clock = new InternalClock(),
     ) {
     }
 
@@ -28,7 +30,10 @@ final class IssuedAtChecker implements ClaimChecker, HeaderChecker
         if (! is_float($value) && ! is_int($value)) {
             throw new InvalidClaimException('"iat" must be an integer.', self::NAME, $value);
         }
-        if (time() < $value - $this->allowedTimeDrift) {
+
+        $now = $this->clock->now()
+            ->getTimestamp();
+        if ($now < $value - $this->allowedTimeDrift) {
             throw new InvalidClaimException('The JWT is issued in the future.', self::NAME, $value);
         }
     }
@@ -43,7 +48,10 @@ final class IssuedAtChecker implements ClaimChecker, HeaderChecker
         if (! is_float($value) && ! is_int($value)) {
             throw new InvalidHeaderException('The header "iat" must be an integer.', self::NAME, $value);
         }
-        if (time() < $value - $this->allowedTimeDrift) {
+
+        $now = $this->clock->now()
+            ->getTimestamp();
+        if ($now < $value - $this->allowedTimeDrift) {
             throw new InvalidHeaderException('The JWT is issued in the future.', self::NAME, $value);
         }
     }

--- a/src/Component/Checker/NotBeforeChecker.php
+++ b/src/Component/Checker/NotBeforeChecker.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Checker;
 
 use function is_float;
 use function is_int;
+use Psr\Clock\ClockInterface;
 
 /**
  * This class is a claim checker. When the "nbf" is present, it will compare the value with the current timestamp.
@@ -16,7 +17,8 @@ final class NotBeforeChecker implements ClaimChecker, HeaderChecker
 
     public function __construct(
         private readonly int $allowedTimeDrift = 0,
-        private readonly bool $protectedHeaderOnly = false
+        private readonly bool $protectedHeaderOnly = false,
+        private readonly ClockInterface $clock = new InternalClock(),
     ) {
     }
 
@@ -28,7 +30,10 @@ final class NotBeforeChecker implements ClaimChecker, HeaderChecker
         if (! is_float($value) && ! is_int($value)) {
             throw new InvalidClaimException('"nbf" must be an integer.', self::NAME, $value);
         }
-        if (time() < $value - $this->allowedTimeDrift) {
+
+        $now = $this->clock->now()
+            ->getTimestamp();
+        if ($now < $value - $this->allowedTimeDrift) {
             throw new InvalidClaimException('The JWT can not be used yet.', self::NAME, $value);
         }
     }
@@ -43,7 +48,10 @@ final class NotBeforeChecker implements ClaimChecker, HeaderChecker
         if (! is_float($value) && ! is_int($value)) {
             throw new InvalidHeaderException('"nbf" must be an integer.', self::NAME, $value);
         }
-        if (time() < $value - $this->allowedTimeDrift) {
+
+        $now = $this->clock->now()
+            ->getTimestamp();
+        if ($now < $value - $this->allowedTimeDrift) {
             throw new InvalidHeaderException('The JWT can not be used yet.', self::NAME, $value);
         }
     }

--- a/src/Component/Checker/NotBeforeChecker.php
+++ b/src/Component/Checker/NotBeforeChecker.php
@@ -15,11 +15,22 @@ final class NotBeforeChecker implements ClaimChecker, HeaderChecker
 {
     private const NAME = 'nbf';
 
+    private readonly ClockInterface $clock;
+
     public function __construct(
         private readonly int $allowedTimeDrift = 0,
         private readonly bool $protectedHeaderOnly = false,
-        private readonly ClockInterface $clock = new InternalClock(),
+        ?ClockInterface $clock = null,
     ) {
+        if ($clock === null) {
+            trigger_deprecation(
+                'web-token/jwt-checker',
+                '3.2.0',
+                'The parameter "$clock" will become mandatory in 4.0.0. Please set a valid PSR Clock implementation instead of "null".'
+            );
+            $clock = new InternalClock();
+        }
+        $this->clock = $clock;
     }
 
     /**

--- a/src/Component/Checker/composer.json
+++ b/src/Component/Checker/composer.json
@@ -39,6 +39,7 @@
     },
     "require": {
         "php": ">=8.1",
+        "psr/clock": "^1.0",
         "web-token/jwt-core": "^3.0"
     }
 }

--- a/tests/Component/Checker/ExpirationTimeClaimCheckerTest.php
+++ b/tests/Component/Checker/ExpirationTimeClaimCheckerTest.php
@@ -6,6 +6,7 @@ namespace Jose\Tests\Component\Checker;
 
 use Jose\Component\Checker\ExpirationTimeChecker;
 use Jose\Component\Checker\InvalidClaimException;
+use Jose\Tests\Component\Checker\Stub\MockClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,8 @@ final class ExpirationTimeClaimCheckerTest extends TestCase
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('"exp" must be an integer.');
 
-        $checker = new ExpirationTimeChecker();
+        $clock = new MockClock();
+        $checker = new ExpirationTimeChecker(clock: $clock);
         $checker->checkClaim('foo');
     }
 
@@ -33,8 +35,9 @@ final class ExpirationTimeClaimCheckerTest extends TestCase
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('The token expired.');
 
-        $checker = new ExpirationTimeChecker();
-        $checker->checkClaim(time() - 1);
+        $clock = new MockClock();
+        $checker = new ExpirationTimeChecker(clock: $clock);
+        $checker->checkClaim($clock->now()->getTimestamp() - 1);
     }
 
     /**
@@ -42,8 +45,9 @@ final class ExpirationTimeClaimCheckerTest extends TestCase
      */
     public function theExpirationTimeIsInTheFutur(): void
     {
-        $checker = new ExpirationTimeChecker();
-        $checker->checkClaim(time() + 3600);
+        $clock = new MockClock();
+        $checker = new ExpirationTimeChecker(clock: $clock);
+        $checker->checkClaim($clock->now()->getTimestamp() + 3600);
         static::assertSame('exp', $checker->supportedClaim());
     }
 }

--- a/tests/Component/Checker/IssuedAtClaimCheckerTest.php
+++ b/tests/Component/Checker/IssuedAtClaimCheckerTest.php
@@ -6,6 +6,7 @@ namespace Jose\Tests\Component\Checker;
 
 use Jose\Component\Checker\InvalidClaimException;
 use Jose\Component\Checker\IssuedAtChecker;
+use Jose\Tests\Component\Checker\Stub\MockClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,8 @@ final class IssuedAtClaimCheckerTest extends TestCase
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('"iat" must be an integer.');
 
-        $checker = new IssuedAtChecker();
+        $clock = new MockClock();
+        $checker = new IssuedAtChecker(clock: $clock);
         $checker->checkClaim('foo');
     }
 
@@ -33,8 +35,9 @@ final class IssuedAtClaimCheckerTest extends TestCase
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('The JWT is issued in the future.');
 
-        $checker = new IssuedAtChecker();
-        $checker->checkClaim(time() + 3600);
+        $clock = new MockClock();
+        $checker = new IssuedAtChecker(clock: $clock);
+        $checker->checkClaim($clock->now()->getTimestamp() + 3600);
     }
 
     /**
@@ -42,8 +45,9 @@ final class IssuedAtClaimCheckerTest extends TestCase
      */
     public function theIssuedAtClaimIsInThePast(): void
     {
-        $checker = new IssuedAtChecker();
-        $checker->checkClaim(time() - 3600);
+        $clock = new MockClock();
+        $checker = new IssuedAtChecker(clock: $clock);
+        $checker->checkClaim($clock->now()->getTimestamp() - 3600);
         static::assertSame('iat', $checker->supportedClaim());
     }
 }

--- a/tests/Component/Checker/NotBeforeClaimCheckerTest.php
+++ b/tests/Component/Checker/NotBeforeClaimCheckerTest.php
@@ -6,6 +6,7 @@ namespace Jose\Tests\Component\Checker;
 
 use Jose\Component\Checker\InvalidClaimException;
 use Jose\Component\Checker\NotBeforeChecker;
+use Jose\Tests\Component\Checker\Stub\MockClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,8 @@ final class NotBeforeClaimCheckerTest extends TestCase
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('"nbf" must be an integer.');
 
-        $checker = new NotBeforeChecker();
+        $clock = new MockClock();
+        $checker = new NotBeforeChecker(clock: $clock);
         $checker->checkClaim('foo');
     }
 
@@ -33,8 +35,9 @@ final class NotBeforeClaimCheckerTest extends TestCase
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('The JWT can not be used yet.');
 
-        $checker = new NotBeforeChecker();
-        $checker->checkClaim(time() + 3600);
+        $clock = new MockClock();
+        $checker = new NotBeforeChecker(clock: $clock);
+        $checker->checkClaim($clock->now()->getTimestamp() + 3600);
     }
 
     /**
@@ -42,8 +45,9 @@ final class NotBeforeClaimCheckerTest extends TestCase
      */
     public function theNotBeforeClaimIsInThePast(): void
     {
-        $checker = new NotBeforeChecker();
-        $checker->checkClaim(time() - 3600);
+        $clock = new MockClock();
+        $checker = new NotBeforeChecker(clock: $clock);
+        $checker->checkClaim($clock->now()->getTimestamp() - 3600);
         static::assertSame('nbf', $checker->supportedClaim());
     }
 }

--- a/tests/Component/Checker/Stub/MockClock.php
+++ b/tests/Component/Checker/Stub/MockClock.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Checker\Stub;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+final class MockClock implements ClockInterface
+{
+    public function __construct(
+        private readonly DateTimeImmutable $now = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| License       | MIT

Hi there

To simplify testing of systems that use the time based checkers (exp, iat, nbf), I'd like to introduce support for [PSR-20](https://www.php-fig.org/psr/psr-20/) (psr/clock). This would remove the necessity for cumbersome `time()`-mocking.

Depending on your preferences, I could adjust the implementation.
- I chose to add `symfony/clock` as the `psr/clock` implementation, but we could just as well use another one, implement an internal one (it's trivial after all), or none (and default to `time()`).
  The benefit of not adding an implementation dependency is that users wouldn't be forced to add one they might otherwise not use.
- There are some more "unrelated" `time()` usages in `EncrypterTest` and `JWSTest` that could also use a clock implementation for consistency, though it wouldn't have any value beyond that.
