### PR TITLE
Add IsEqualChecker and CallableChecker

### DIFF
--- a/src/Component/Checker/CallableChecker.php
+++ b/src/Component/Checker/CallableChecker.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
+use function call_user_func;
 use InvalidArgumentException;
-use Jose\Component\Checker\ClaimChecker;
-use Jose\Component\Checker\HeaderChecker;
-use Jose\Component\Checker\InvalidClaimException;
-use Jose\Component\Checker\InvalidHeaderException;
+use function is_callable;
 
 /**
  * @see \Jose\Tests\Component\Checker\CallableCheckerTest
@@ -24,15 +22,15 @@ final class CallableChecker implements ClaimChecker, HeaderChecker
         private $callable,
         private readonly bool $protectedHeaderOnly = true
     ) {
-        if (!\is_callable($this->callable)) { // @phpstan-ignore-line
+        if (! is_callable($this->callable)) { // @phpstan-ignore-line
             throw new InvalidArgumentException('The $callable argument must be a callable.');
         }
     }
 
     public function checkClaim(mixed $value): void
     {
-        if (\call_user_func($this->callable, $value) !== true) {
-            throw new InvalidClaimException(\sprintf('The "%s" claim is invalid.', $this->key), $this->key, $value);
+        if (call_user_func($this->callable, $value) !== true) {
+            throw new InvalidClaimException(sprintf('The "%s" claim is invalid.', $this->key), $this->key, $value);
         }
     }
 
@@ -43,8 +41,8 @@ final class CallableChecker implements ClaimChecker, HeaderChecker
 
     public function checkHeader(mixed $value): void
     {
-        if (\call_user_func($this->callable, $value) !== true) {
-            throw new InvalidHeaderException(\sprintf('The "%s" header is invalid.', $this->key), $this->key, $value);
+        if (call_user_func($this->callable, $value) !== true) {
+            throw new InvalidHeaderException(sprintf('The "%s" header is invalid.', $this->key), $this->key, $value);
         }
     }
 

--- a/src/Component/Checker/CallableChecker.php
+++ b/src/Component/Checker/CallableChecker.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Checker;
+
+use InvalidArgumentException;
+use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Checker\HeaderChecker;
+use Jose\Component\Checker\InvalidClaimException;
+use Jose\Component\Checker\InvalidHeaderException;
+
+/**
+ * @see \Jose\Tests\Component\Checker\CallableCheckerTest
+ */
+final class CallableChecker implements ClaimChecker, HeaderChecker
+{
+    /**
+     * @param string     $key      The claim or header parameter name to check.
+     * @param callable(mixed $value): bool $callable The callable function that will be invoked.
+     */
+    public function __construct(
+        private readonly string $key,
+        private $callable,
+        private readonly bool $protectedHeaderOnly = true
+    ) {
+        if (!\is_callable($this->callable)) { // @phpstan-ignore-line
+            throw new InvalidArgumentException('The $callable argument must be a callable.');
+        }
+    }
+
+    public function checkClaim(mixed $value): void
+    {
+        if (\call_user_func($this->callable, $value) !== true) {
+            throw new InvalidClaimException(\sprintf('The "%s" claim is invalid.', $this->key), $this->key, $value);
+        }
+    }
+
+    public function supportedClaim(): string
+    {
+        return $this->key;
+    }
+
+    public function checkHeader(mixed $value): void
+    {
+        if (\call_user_func($this->callable, $value) !== true) {
+            throw new InvalidHeaderException(\sprintf('The "%s" header is invalid.', $this->key), $this->key, $value);
+        }
+    }
+
+    public function supportedHeader(): string
+    {
+        return $this->key;
+    }
+
+    public function protectedHeaderOnly(): bool
+    {
+        return $this->protectedHeaderOnly;
+    }
+}

--- a/src/Component/Checker/IsEqualChecker.php
+++ b/src/Component/Checker/IsEqualChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Checker;
+
+use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Checker\HeaderChecker;
+use Jose\Component\Checker\InvalidClaimException;
+use Jose\Component\Checker\InvalidHeaderException;
+
+/**
+ * @see \Jose\Tests\Component\Checker\IsEqualCheckerTest
+ */
+final class IsEqualChecker implements ClaimChecker, HeaderChecker
+{
+    /**
+     * @param string $key                 The claim or header parameter name to check.
+     * @param mixed  $value               The expected value.
+     * @param bool   $protectedHeaderOnly [optional] Whether the header parameter MUST be protected.
+     *                                    This option has no effect for claim checkers.
+     */
+    public function __construct(
+        private readonly string $key,
+        private readonly mixed $value,
+        private readonly bool $protectedHeaderOnly = true
+    ) {
+    }
+
+    public function checkClaim(mixed $value): void
+    {
+        if ($value !== $this->value) {
+            throw new InvalidClaimException(\sprintf('The "%s" claim is invalid.', $this->key), $this->key, $value);
+        }
+    }
+
+    public function supportedClaim(): string
+    {
+        return $this->key;
+    }
+
+    public function checkHeader(mixed $value): void
+    {
+        if ($value !== $this->value) {
+            throw new InvalidHeaderException(\sprintf('The "%s" header is invalid.', $this->key), $this->key, $value);
+        }
+    }
+
+    public function supportedHeader(): string
+    {
+        return $this->key;
+    }
+
+    public function protectedHeaderOnly(): bool
+    {
+        return $this->protectedHeaderOnly;
+    }
+}

--- a/src/Component/Checker/IsEqualChecker.php
+++ b/src/Component/Checker/IsEqualChecker.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use Jose\Component\Checker\ClaimChecker;
-use Jose\Component\Checker\HeaderChecker;
-use Jose\Component\Checker\InvalidClaimException;
-use Jose\Component\Checker\InvalidHeaderException;
-
 /**
  * @see \Jose\Tests\Component\Checker\IsEqualCheckerTest
  */
@@ -30,7 +25,7 @@ final class IsEqualChecker implements ClaimChecker, HeaderChecker
     public function checkClaim(mixed $value): void
     {
         if ($value !== $this->value) {
-            throw new InvalidClaimException(\sprintf('The "%s" claim is invalid.', $this->key), $this->key, $value);
+            throw new InvalidClaimException(sprintf('The "%s" claim is invalid.', $this->key), $this->key, $value);
         }
     }
 
@@ -42,7 +37,7 @@ final class IsEqualChecker implements ClaimChecker, HeaderChecker
     public function checkHeader(mixed $value): void
     {
         if ($value !== $this->value) {
-            throw new InvalidHeaderException(\sprintf('The "%s" header is invalid.', $this->key), $this->key, $value);
+            throw new InvalidHeaderException(sprintf('The "%s" header is invalid.', $this->key), $this->key, $value);
         }
     }
 

--- a/tests/Component/Checker/CallableCheckerTest.php
+++ b/tests/Component/Checker/CallableCheckerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Checker;
+
+use InvalidArgumentException;
+use Jose\Component\Checker\CallableChecker;
+use Jose\Component\Checker\InvalidClaimException;
+use Jose\Component\Checker\InvalidHeaderException;
+use Jose\Component\Checker\IsEqualChecker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class CallableCheckerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function theCallableIsCallable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The $callable argument must be a callable.');
+
+        new CallableChecker('foo', 'not_a_callable');
+    }
+
+    /**
+     * @test
+     */
+    public function theCallableDoesNotReturnABoolean(): void
+    {
+        $this->expectException(InvalidClaimException::class);
+
+        $checker = new CallableChecker('foo', fn (mixed $value) => 1);
+        $checker->checkClaim('baz');
+
+        $this->expectException(InvalidHeaderException::class);
+
+        $checker = new CallableChecker('foo', fn (mixed $value) => 0);
+        $checker->checkHeader('baz');
+    }
+
+    /**
+     * @test
+     */
+    public function theClaimIsInvalid(): void
+    {
+        $this->expectException(InvalidClaimException::class);
+
+        $checker = new CallableChecker('foo', fn (mixed $value) => $value === 'bar');
+        $checker->checkClaim('baz');
+    }
+
+    /**
+     * @test
+     */
+    public function theHeaderIsInvalid(): void
+    {
+        $this->expectException(InvalidHeaderException::class);
+
+        $checker = new CallableChecker('foo', fn (mixed $value) => $value === 'bar');
+        $checker->checkHeader('baz');
+    }
+
+    /**
+     * @test
+     */
+    public function theClaimIsSupported(): void
+    {
+        $checker = new CallableChecker('foo', fn (mixed $value) => $value === 'bar');
+        $checker->checkClaim('bar');
+
+        static::assertSame('foo', $checker->supportedClaim());
+    }
+
+    /**
+     * @test
+     */
+    public function theHeaderIsSupported(): void
+    {
+        $checker = new CallableChecker('foo', fn (mixed $value) => $value === 'bar');
+        $checker->checkHeader('bar');
+
+        static::assertSame('foo', $checker->supportedHeader());
+    }
+}

--- a/tests/Component/Checker/CallableCheckerTest.php
+++ b/tests/Component/Checker/CallableCheckerTest.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 use Jose\Component\Checker\CallableChecker;
 use Jose\Component\Checker\InvalidClaimException;
 use Jose\Component\Checker\InvalidHeaderException;
-use Jose\Component\Checker\IsEqualChecker;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Component/Checker/IsEqualCheckerTest.php
+++ b/tests/Component/Checker/IsEqualCheckerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Checker;
+
+use Jose\Component\Checker\InvalidClaimException;
+use Jose\Component\Checker\InvalidHeaderException;
+use Jose\Component\Checker\IsEqualChecker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class IsEqualCheckerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function theClaimIsInvalid(): void
+    {
+        $this->expectException(InvalidClaimException::class);
+
+        $checker = new IsEqualChecker('foo', 'bar');
+        $checker->checkClaim('baz');
+    }
+
+    /**
+     * @test
+     */
+    public function theHeaderIsInvalid(): void
+    {
+        $this->expectException(InvalidHeaderException::class);
+
+        $checker = new IsEqualChecker('foo', 'bar');
+        $checker->checkHeader('baz');
+    }
+
+    /**
+     * @test
+     */
+    public function theClaimIsSupported(): void
+    {
+        $checker = new IsEqualChecker('foo', 'bar');
+        $checker->checkClaim('bar');
+        static::assertSame('foo', $checker->supportedClaim());
+    }
+
+    /**
+     * @test
+     */
+    public function theHeaderIsSupported(): void
+    {
+        $checker = new IsEqualChecker('foo', 'bar');
+        $checker->checkHeader('bar');
+        static::assertSame('foo', $checker->supportedHeader());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | yes (Changelog.md doesnt exist)
| Deprecations? | no 
| Tickets       | None
| License       | MIT

I find myself recreating these checkers in pretty much all of my applications.

The `IsEqualChecker` checks if the header/claim value EXACTLY matches the given value.
The `CallableChecker` passes the header/claim value to the callable and checks that the return is TRUE.