### PR TITLE
Support new symfony serializer's getSupportedTypes

### DIFF
--- a/src/Bundle/JoseFramework/Serializer/JWESerializer.php
+++ b/src/Bundle/JoseFramework/Serializer/JWESerializer.php
@@ -26,6 +26,13 @@ final class JWESerializer implements DenormalizerInterface
         $this->serializerManager = $serializerManager;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            JWE::class => class_exists(JWESerializerManager::class) && $this->formatSupported($format),
+        ];
+    }
+
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return $type === JWE::class

--- a/src/Bundle/JoseFramework/Serializer/JWSSerializer.php
+++ b/src/Bundle/JoseFramework/Serializer/JWSSerializer.php
@@ -26,6 +26,13 @@ final class JWSSerializer implements DenormalizerInterface
         $this->serializerManager = $serializerManager;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            JWS::class => class_exists(JWSSerializerManager::class) && $this->formatSupported($format),
+        ];
+    }
+
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return $type === JWS::class


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

With Symfony 6.3 a new serializer improvement has been released (https://symfony.com/blog/new-in-symfony-6-3-performance-improvements).
This PR implements `getSupportedTypes` method to be able to leverage latest serializer's perfomance improvements