### PR TITLE
ensure JWS serializers only throw InvalidArgumentException

### DIFF
--- a/src/Component/Signature/Serializer/JSONFlattenedSerializer.php
+++ b/src/Component/Signature/Serializer/JSONFlattenedSerializer.php
@@ -52,7 +52,12 @@ final class JSONFlattenedSerializer extends Serializer
 
     public function unserialize(string $input): JWS
     {
-        $data = JsonConverter::decode($input);
+        try {
+            $data = JsonConverter::decode($input);
+        }
+        catch(\Exception $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
         if (! is_array($data)) {
             throw new InvalidArgumentException('Unsupported input.');
         }

--- a/src/Component/Signature/Serializer/JSONGeneralSerializer.php
+++ b/src/Component/Signature/Serializer/JSONGeneralSerializer.php
@@ -64,7 +64,12 @@ final class JSONGeneralSerializer extends Serializer
 
     public function unserialize(string $input): JWS
     {
-        $data = JsonConverter::decode($input);
+        try {
+            $data = JsonConverter::decode($input);
+        }
+        catch(\Exception $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
         if (! is_array($data)) {
             throw new InvalidArgumentException('Unsupported input.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | 
| License       | MIT

SerializerManager tries one serializer after another but expects the individual serializer only to throw InvalidArgumentException in ::unserialize - if any other Exception is thrown,  unserialization (and JWS verification) fails directly.

The JSON serializers (global and flattened) try JSON-decoding using JsonConverter. The latter, however, throws a RuntimeException. Therefore, if a *later* serializer in the SerializerManager is applicable to the token, it's never reached.

This PR encapsulates the call to JsonEncoder and converts the exception to InvalidArgumentException.