### PR TITLE
Fix missing attribute import

### DIFF
--- a/src/Component/Console/NoneKeyGeneratorCommand.php
+++ b/src/Component/Console/NoneKeyGeneratorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Component/Console/PublicKeyCommand.php
+++ b/src/Component/Console/PublicKeyCommand.php
@@ -7,6 +7,7 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT

Add missing import statement for `AsCommand` attribute.

Fixed warning in Symfony:
```
[WARNING] Some commands could not be registered:                                                                       
The command defined in "Jose\Component\Console\NoneKeyGeneratorCommand" cannot have an empty name.  
The command defined in "Jose\Component\Console\PublicKeyCommand" cannot have an empty name. 
```