### PR TITLE
Add missing AsCommand attributes for commands

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1206,11 +1206,6 @@ parameters:
 			path: src/Library/Console/KeysetAnalyzerCommand.php
 
 		-
-			message: "#^Attribute class Jose\\\\Component\\\\Console\\\\AsCommand does not exist\\.$#"
-			count: 1
-			path: src/Library/Console/NoneKeyGeneratorCommand.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: src/Library/Console/OctKeyGeneratorCommand.php
@@ -1226,11 +1221,6 @@ parameters:
 			path: src/Library/Console/OkpKeysetGeneratorCommand.php
 
 		-
-			message: "#^Attribute class Jose\\\\Component\\\\Console\\\\AsCommand does not exist\\.$#"
-			count: 1
-			path: src/Library/Console/PublicKeyCommand.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: src/Library/Console/RsaKeyGeneratorCommand.php
@@ -1239,11 +1229,6 @@ parameters:
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 2
 			path: src/Library/Console/RsaKeysetGeneratorCommand.php
-
-		-
-			message: "#^Attribute class Jose\\\\Component\\\\Console\\\\AsCommand does not exist\\.$#"
-			count: 1
-			path: src/Library/Console/X5ULoaderCommand.php
 
 		-
 			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"

--- a/src/Library/Console/NoneKeyGeneratorCommand.php
+++ b/src/Library/Console/NoneKeyGeneratorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\KeyManagement\JWKFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Library/Console/PublicKeyCommand.php
+++ b/src/Library/Console/PublicKeyCommand.php
@@ -7,6 +7,7 @@ namespace Jose\Component\Console;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Library/Console/X5ULoaderCommand.php
+++ b/src/Library/Console/X5ULoaderCommand.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Console;
 
 use InvalidArgumentException;
 use Jose\Component\KeyManagement\X5UFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
Target branch: 3.3x
Resolves issue -

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

Three commands were missing the import for the AsCommand attribute:

```
The command defined in "Jose\Component\Console\NoneKeyGeneratorCommand" cannot have an empty name.
The command defined in "Jose\Component\Console\PublicKeyCommand" cannot have an empty name.
The command defined in "Jose\Component\Console\X5ULoaderCommand" cannot have an empty name.
```