### PR TITLE
Remove UTF-8 encoding check in JWEBuilder

### DIFF
--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -132,9 +132,6 @@ class JWEBuilder
      */
     public function withPayload(string $payload): self
     {
-        if (mb_detect_encoding($payload, 'UTF-8', true) !== 'UTF-8') {
-            throw new InvalidArgumentException('The payload must be encoded in UTF-8');
-        }
         $clone = clone $this;
         $clone->payload = $payload;
 


### PR DESCRIPTION
The UTF-8 encoding validation for the payload in the JWEBuilder has been removed. This modification was necessary because the check was unnecessarily restrictive and caused issues in certain use-cases. Now, any string can be used as the payload without throwing an InvalidArgumentException.

Target branch:
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
