### PR TITLE
Avoid PHP warnings about undefined array keys when sanitizing malformed PEMs

### DIFF
--- a/src/Library/KeyManagement/KeyConverter/KeyConverter.php
+++ b/src/Library/KeyManagement/KeyConverter/KeyConverter.php
@@ -365,7 +365,11 @@ final class KeyConverter
      */
     private static function sanitizePEM(string &$pem): void
     {
-        preg_match_all('#(-.*-)#', $pem, $matches, PREG_PATTERN_ORDER);
+        $number = preg_match_all('#(-.*-)#', $pem, $matches, PREG_PATTERN_ORDER);
+        if ($number !== 2) {
+            throw new InvalidArgumentException('Unable to load the key');
+        }
+
         $ciphertext = preg_replace('#-.*-|\r|\n| #', '', $pem);
 
         $pem = $matches[0][0] . PHP_EOL;

--- a/tests/Component/KeyManagement/Keys/ECKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/ECKeysTest.php
@@ -209,6 +209,31 @@ final class ECKeysTest extends TestCase
     }
 
     #[Test]
+    public function loadInvalidPEMKey(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to load the key');
+
+        // Given
+        $private_pem = trim(<<<PEM
+MIIB0jCCAXegAwIBAgIJAK2o1kQ5JwpUMAoGCCqGSM49BAMCMEUxCzAJBgNVBAYT
+AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn
+aXRzIFB0eSBMdGQwHhcNMTUxMTA4MTUxMTU2WhcNMTYxMTA3MTUxMTU2WjBFMQsw
+CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu
+ZXQgV2lkZ2l0cyBQdHkgTHRkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExEsr
+/55aqgFXdrbRNz1/WSNI8UaSUxCka2kGEN1bXsJIzjkeyv12dRHo7H5OmY2/Z9sN
+fgKhWj7elq0xSlcA0KNQME4wHQYDVR0OBBYEFKIGgCZoS388STT0qjoX/swKYBXh
+MB8GA1UdIwQYMBaAFKIGgCZoS388STT0qjoX/swKYBXhMAwGA1UdEwQFMAMBAf8w
+CgYIKoZIzj0EAwIDSQAwRgIhAK5OqQoBGR/pj2NOb+PyRKK4k4d3Muj9z/6LsJK+
+kkgUAiEA+FY4SWKv4mfe0gsOBId0Aah/HtVZxDBe3bCXOQM8MMM=
+PEM);
+
+        // When
+        KeyConverter::loadFromKey($private_pem, 'test');
+    }
+
+    #[Test]
     public function convertPrivateKeyToPublic(): void
     {
         $jwk = new JWK([


### PR DESCRIPTION
Target branch: ~`4.0.x`~ `3.4.x`

- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

When given a malformed PEM string, `sanitizePEM()` triggers two PHP warnings: `Undefined array key 0` and `Undefined array key 1`.