### PR TITLE
Fix broken link to contribution guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or
 
 # Contributing
 
-Requests for new features, bug fixed and all other ideas to make this library useful are welcome. [Please follow these best practices](doc/Contributing.md).
+Requests for new features, bug fixed and all other ideas to make this library useful are welcome. [Please follow these best practices](.github/CONTRIBUTING.md).
 
 If you discover a security vulnerability within the project, please **don't use the bug tracker and don't publish it publicly**.
 Instead, all security issues must be sent to security [at] spomky-labs.com.


### PR DESCRIPTION
Target branch: `3.4.x`

- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

I was looking for this file earlier and couldn't find it, but now I realized it's under the `.github/` directory. The link in the README was changed from `.github/CONTRIBUTING.md` to the current `doc/Contributing.md` in https://github.com/web-token/jwt-framework/commit/de5231f0e740b41174fda7fafc1dba539a0906a8. But there's no `doc/` directory, now or then.
