### PR TITLE
Add explicit nullable type where needed

### DIFF
--- a/src/Bundle/JoseFramework/Routing/JWKSetLoader.php
+++ b/src/Bundle/JoseFramework/Routing/JWKSetLoader.php
@@ -32,7 +32,7 @@ final class JWKSetLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load(mixed $resource, string $type = null): RouteCollection
+    public function load(mixed $resource, ?string $type = null): RouteCollection
     {
         return $this->routes;
     }
@@ -40,7 +40,7 @@ final class JWKSetLoader implements LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(mixed $resource, string $type = null): bool
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return $type === 'jwkset';
     }

--- a/src/Bundle/JoseFramework/Serializer/JWESerializer.php
+++ b/src/Bundle/JoseFramework/Serializer/JWESerializer.php
@@ -26,14 +26,14 @@ final class JWESerializer implements DenormalizerInterface
         $this->serializerManager = $serializerManager;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === JWE::class
             && class_exists(JWESerializerManager::class)
             && $this->formatSupported($format);
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): JWE
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): JWE
     {
         if ($data instanceof JWE === false) {
             throw new LogicException('Expected data to be a JWE.');

--- a/src/Bundle/JoseFramework/Serializer/JWSSerializer.php
+++ b/src/Bundle/JoseFramework/Serializer/JWSSerializer.php
@@ -26,14 +26,14 @@ final class JWSSerializer implements DenormalizerInterface
         $this->serializerManager = $serializerManager;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === JWS::class
             && class_exists(JWSSerializerManager::class)
             && $this->formatSupported($format);
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): JWS
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): JWS
     {
         if ($data instanceof JWS === false) {
             throw new LogicException('Expected data to be a JWS.');

--- a/src/Bundle/JoseFramework/Services/JWEDecrypter.php
+++ b/src/Bundle/JoseFramework/Services/JWEDecrypter.php
@@ -29,7 +29,7 @@ final class JWEDecrypter extends BaseJWEDecrypter
         JWE &$jwe,
         JWKSet $jwkset,
         int $recipient,
-        JWK &$jwk = null,
+        ?JWK &$jwk = null,
         ?JWK $senderKey = null
     ): bool {
         $success = parent::decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);

--- a/src/Bundle/JoseFramework/Services/JWSVerifier.php
+++ b/src/Bundle/JoseFramework/Services/JWSVerifier.php
@@ -27,7 +27,7 @@ final class JWSVerifier extends BaseJWSVerifier
         JWKSet $jwkset,
         int $signatureIndex,
         ?string $detachedPayload = null,
-        JWK &$jwk = null
+        ?JWK &$jwk = null
     ): bool {
         $success = parent::verifyWithKeySet($jws, $jwkset, $signatureIndex, $detachedPayload, $jwk);
         if ($success) {

--- a/src/Component/Console/KeyAnalyzerCommand.php
+++ b/src/Component/Console/KeyAnalyzerCommand.php
@@ -24,7 +24,7 @@ final class KeyAnalyzerCommand extends Command
 
     public function __construct(
         private readonly KeyAnalyzerManager $analyzerManager,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($name);
     }

--- a/src/Component/Console/KeysetAnalyzerCommand.php
+++ b/src/Component/Console/KeysetAnalyzerCommand.php
@@ -27,7 +27,7 @@ final class KeysetAnalyzerCommand extends Command
     public function __construct(
         private readonly KeysetAnalyzerManager $keysetAnalyzerManager,
         private readonly KeyAnalyzerManager $keyAnalyzerManager,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($name);
     }

--- a/src/Component/Encryption/JWEDecrypter.php
+++ b/src/Component/Encryption/JWEDecrypter.php
@@ -74,14 +74,14 @@ class JWEDecrypter
      *
      * @param JWE $jwe A JWE object to decrypt
      * @param JWKSet $jwkset The key set used to decrypt the input
-     * @param JWK $jwk The key used to decrypt the token in case of success
+     * @param JWK|null $jwk The key used to decrypt the token in case of success
      * @param int $recipient The recipient used to decrypt the token in case of success
      */
     public function decryptUsingKeySet(
         JWE &$jwe,
         JWKSet $jwkset,
         int $recipient,
-        JWK &$jwk = null,
+        ?JWK &$jwk = null,
         ?JWK $senderKey = null
     ): bool {
         if ($jwkset->count() === 0) {
@@ -108,7 +108,7 @@ class JWEDecrypter
         JWE $jwe,
         JWKSet $jwkset,
         int $i,
-        JWK &$successJwk = null,
+        ?JWK &$successJwk = null,
         ?JWK $senderKey = null
     ): ?string {
         $recipient = $jwe->getRecipient($i);

--- a/src/Component/Signature/JWSVerifier.php
+++ b/src/Component/Signature/JWSVerifier.php
@@ -49,7 +49,7 @@ class JWSVerifier
      *
      * @param JWS $jws A JWS object
      * @param JWKSet $jwkset The signature will be verified using keys in the key set
-     * @param JWK $jwk The key used to verify the signature in case of success
+     * @param JWK|null $jwk The key used to verify the signature in case of success
      * @param string|null $detachedPayload If not null, the value must be the detached payload encoded in Base64 URL safe. If the input contains a payload, throws an exception.
      *
      * @return bool true if the verification of the signature succeeded, else false
@@ -59,7 +59,7 @@ class JWSVerifier
         JWKSet $jwkset,
         int $signatureIndex,
         ?string $detachedPayload = null,
-        JWK &$jwk = null
+        ?JWK &$jwk = null
     ): bool {
         if ($jwkset->count() === 0) {
             throw new InvalidArgumentException('There is no key in the key set.');
@@ -78,7 +78,7 @@ class JWSVerifier
         JWKSet $jwkset,
         Signature $signature,
         ?string $detachedPayload = null,
-        JWK &$successJwk = null
+        ?JWK &$successJwk = null
     ): bool {
         $input = $this->getInputToVerify($jws, $signature, $detachedPayload);
         $algorithm = $this->getAlgorithm($signature);


### PR DESCRIPTION
Target branch: 3.1.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

In the effort of making [the Symfony CI green](https://github.com/symfony/symfony/issues/54180) for 8.4 and make this library also deprecation-free for the next PHP version, here is a PR that adds nullable explicit types to the codebase.