### PR TITLE
Update trigger for gitsplit workflow

### DIFF
--- a/.github/workflows/gitsplit.yml
+++ b/.github/workflows/gitsplit.yml
@@ -1,10 +1,8 @@
 name: gitsplit
 on:
   push:
-    tags:
-      - '*'
-  release:
-    types: [published]
+    branches:
+      - "*.x"
 
 jobs:
   gitsplit:


### PR DESCRIPTION
The gitsplit workflow trigger has been updated from running on any tag push and release publication to running only on push to any branch ending in ".x". This should create a more targeted and efficient workflow.

Target branch:
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
