### PR TITLE
better error message

### DIFF
--- a/src/Library/KeyManagement/KeyConverter/KeyConverter.php
+++ b/src/Library/KeyManagement/KeyConverter/KeyConverter.php
@@ -219,7 +219,7 @@ final readonly class KeyConverter
             $res = openssl_pkey_get_public($pem);
         }
         if ($res === false) {
-            throw new InvalidArgumentException('Unable to load the key.');
+            throw new InvalidArgumentException('Unable to load the key. Error: ' . openssl_error_string());
         }
 
         $details = openssl_pkey_get_details($res);


### PR DESCRIPTION
Target branch: 4.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

The error message if a key fails is not very informational. The openssl extension provides more details, so we need that in the exception thrown.