### PR TITLE
Add RangeException to Base64UrlSafe

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -57,5 +57,5 @@ splits:
     target: "https://${GH_TOKEN}@github.com/web-token/signature-pack.git"
 
 origins:
-  - ^\d+\.\d+\.x$
-  - ^\d+\.\d+\.\d+$
+  - ^(1|2|3)\.\d+\.x$
+  - ^(1|2|3)\.\d+\.\d+$

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1674,11 +1674,6 @@ parameters:
 			path: src/Library/Core/Util/Base64UrlSafe.php
 
 		-
-			message: "#^Instantiated class Jose\\\\Component\\\\Core\\\\Util\\\\RangeException not found\\.$#"
-			count: 3
-			path: src/Library/Core/Util/Base64UrlSafe.php
-
-		-
 			message: "#^Method Jose\\\\Component\\\\Core\\\\Util\\\\Base64UrlSafe\\:\\:safeSubstr\\(\\) has parameter \\$length with no type specified\\.$#"
 			count: 1
 			path: src/Library/Core/Util/Base64UrlSafe.php
@@ -1686,11 +1681,6 @@ parameters:
 		-
 			message: "#^Throwing object of an unknown class Jose\\\\Component\\\\Core\\\\Util\\\\InvalidArgumentException\\.$#"
 			count: 2
-			path: src/Library/Core/Util/Base64UrlSafe.php
-
-		-
-			message: "#^Throwing object of an unknown class Jose\\\\Component\\\\Core\\\\Util\\\\RangeException\\.$#"
-			count: 3
 			path: src/Library/Core/Util/Base64UrlSafe.php
 
 		-

--- a/src/Library/Core/Util/Base64UrlSafe.php
+++ b/src/Library/Core/Util/Base64UrlSafe.php
@@ -27,6 +27,8 @@ namespace Jose\Component\Core\Util;
  *  SOFTWARE.
  */
 
+use RangeException;
+
 /**
  * @readonly
  */


### PR DESCRIPTION
The code in src/Library/Core/Util/Base64UrlSafe.php has been updated to include the use of RangeException. This will further expand its capability in terms of handling exceptional scenarios.

Target branch:
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
