### PR TITLE
Fix call function on null

### DIFF
--- a/src/Bundle/DataCollector/JWECollector.php
+++ b/src/Bundle/DataCollector/JWECollector.php
@@ -169,7 +169,7 @@ class JWECollector implements Collector, EventSubscriberInterface
                 'content_encryption_algorithms' => $jweBuilder->getContentEncryptionAlgorithmManager()
                     ->list(),
                 'compression_methods' => $jweBuilder->getCompressionMethodManager()
-                    ->list(),
+                    ?->list(),
             ];
         }
     }
@@ -187,7 +187,7 @@ class JWECollector implements Collector, EventSubscriberInterface
                 'content_encryption_algorithms' => $jweDecrypter->getContentEncryptionAlgorithmManager()
                     ->list(),
                 'compression_methods' => $jweDecrypter->getCompressionMethodManager()
-                    ->list(),
+                    ?->list(),
             ];
         }
     }
@@ -210,7 +210,7 @@ class JWECollector implements Collector, EventSubscriberInterface
                     ->list(),
                 'compression_methods' => $jweLoader->getJweDecrypter()
                     ->getCompressionMethodManager()
-                    ->list(),
+                    ?->list(),
             ];
         }
     }

--- a/tests/Bundle/JoseFramework/Functional/Encryption/JWECollectorTest.php
+++ b/tests/Bundle/JoseFramework/Functional/Encryption/JWECollectorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Functional\Encryption;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Jose\Bundle\JoseFramework\DataCollector\JWECollector;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Jose\Bundle\JoseFramework\Services\JWELoaderFactory as JWELoaderFactoryAlias;
+use Jose\Bundle\JoseFramework\Services\JWEBuilderFactory as JWEBuilderFactoryService;
+use Jose\Bundle\JoseFramework\Services\JWEDecrypterFactory as JWEDecrypterFactoryService;
+
+/**
+ * @internal
+ */
+final class JWECollectorTest extends WebTestCase
+{
+    #[Test]
+    public function aJWEBuilderCanBeCollectedWithoutACompressionMethodManager(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+        $container = $client->getContainer();
+        static::assertInstanceOf(ContainerInterface::class, $container);
+
+        $jweFactory = $container->get(JWEBuilderFactoryService::class);
+        static::assertInstanceOf(JWEBuilderFactoryService::class, $jweFactory);
+
+        $jweBuilder = $jweFactory->create(['RSA1_5', 'A256GCM']);
+
+        $jweCollector = new JWECollector();
+        $jweCollector->addJWEBuilder('builder2', $jweBuilder);
+
+        $data = [];
+        $jweCollector->collect($data, new Request(), new Response());
+
+        static::assertArrayHasKey('jwe', $data);
+        static::assertArrayHasKey('compression_methods', $data['jwe']);
+        static::assertSame([], $data['jwe']['compression_methods']);
+        static::assertArrayHasKey('jwe_builders', $data['jwe']);
+        static::assertArrayHasKey('builder2', $data['jwe']['jwe_builders']);
+    }
+
+
+    #[Test]
+    public function aJWEDecrypterCanBeCollectedWithoutACompressionMethodManager(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+        $container = $client->getContainer();
+        static::assertInstanceOf(ContainerInterface::class, $container);
+
+        $jweDecrypterFactory = $container->get(JWEDecrypterFactoryService::class);
+        static::assertInstanceOf(JWEDecrypterFactoryService::class, $jweDecrypterFactory);
+
+        $jweDecrypter = $jweDecrypterFactory->create(['RSA1_5', 'A256GCM']);
+
+        $jweCollector = new JWECollector();
+        $jweCollector->addJWEDecrypter('decrypter2', $jweDecrypter);
+
+        $data = [];
+        $jweCollector->collect($data, new Request(), new Response());
+
+        static::assertArrayHasKey('jwe', $data);
+        static::assertArrayHasKey('compression_methods', $data['jwe']);
+        static::assertSame([], $data['jwe']['compression_methods']);
+        static::assertArrayHasKey('jwe_decrypters', $data['jwe']);
+        static::assertArrayHasKey('decrypter2', $data['jwe']['jwe_decrypters']);
+    }
+
+    #[Test]
+    public function aJWELoaderCanBeCollectedWithoutACompressionMethodManager(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+        $container = $client->getContainer();
+        static::assertInstanceOf(ContainerInterface::class, $container);
+
+        $jweLoaderFactory = $container->get(JWELoaderFactoryAlias::class);
+        static::assertInstanceOf(JWELoaderFactoryAlias::class, $jweLoaderFactory);
+
+        $jweLoader = $jweLoaderFactory->create(['jwe_compact'], ['RSA1_5'], ['A256GCM']);
+
+        $jweCollector = new JWECollector();
+        $jweCollector->addJWELoader('loader2', $jweLoader);
+
+        $data = [];
+        $jweCollector->collect($data, new Request(), new Response());
+
+        static::assertArrayHasKey('jwe', $data);
+        static::assertArrayHasKey('compression_methods', $data['jwe']);
+        static::assertSame([], $data['jwe']['compression_methods']);
+        static::assertArrayHasKey('jwe_loaders', $data['jwe']);
+        static::assertArrayHasKey('loader2', $data['jwe']['jwe_loaders']);
+    }
+}


### PR DESCRIPTION
Target branch: 3.4.x
Resolves issue #595

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
Fix error in `JWECollector` when JWEs are used without the deprecated compression method manager.