### PR TITLE
Add support for brick/math 0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "php": ">=8.2",
         "ext-json": "*",
         "ext-openssl": "*",
-        "brick/math": "^0.12",
+        "brick/math": "^0.12 || ^0.13",
         "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1",

--- a/src/Library/composer.json
+++ b/src/Library/composer.json
@@ -40,7 +40,7 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "brick/math": "^0.12",
+        "brick/math": "^0.12 || ^0.13",
         "psr/clock": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1"
     },


### PR DESCRIPTION
Target branch: 4.0.x
Resolves issue: n/a

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [x] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

The BC break mentioned in https://github.com/brick/math/releases/tag/0.13.0 does not impact this project as it only uses `BigInteger`, not `BigDecimal`.