### PR TITLE
Use correct base class for JoseFrameworkExtension

### DIFF
--- a/src/Bundle/DependencyInjection/JoseFrameworkExtension.php
+++ b/src/Bundle/DependencyInjection/JoseFrameworkExtension.php
@@ -9,7 +9,7 @@ use Override;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use function count;
 
 final class JoseFrameworkExtension extends Extension implements PrependExtensionInterface


### PR DESCRIPTION
Target branch:
Resolves issue #600 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [x] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations
