### PR TITLE
Add deprecation notice for enabledCache method

### DIFF
--- a/src/Library/KeyManagement/UrlKeySetFactory.php
+++ b/src/Library/KeyManagement/UrlKeySetFactory.php
@@ -25,6 +25,9 @@ abstract class UrlKeySetFactory
         $this->cacheItemPool = new NullAdapter();
     }
 
+    /**
+     * @deprecated since 4.1 and will be removed in 5.0. Please use the Http Client to cache the responses instead.
+     */
     public function enabledCache(CacheItemPoolInterface $cacheItemPool, int $expiresAfter = 3600): void
     {
         $this->cacheItemPool = $cacheItemPool;


### PR DESCRIPTION
Target branch: 4.1
Resolves issue #605

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [x] It is related to dependencies

Includes:
- [ ] Breaks BC
- [x] Deprecations

The enabledCache method is now marked as deprecated starting from version 4.1 and will be removed in version 5.0. Users are encouraged to use the Http Client for caching responses instead. This change aligns with the planned removal of this method in the next  major release.
