### PR TITLE
Allow `psr/cache` v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "brick/math": "^0.9|^0.10|^0.11|^0.12",
         "paragonie/constant_time_encoding": "^2.6|^3.0",
         "paragonie/sodium_compat": "^1.20|^2.0",
-        "psr/cache": "^3.0",
+        "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",

--- a/src/Library/composer.json
+++ b/src/Library/composer.json
@@ -44,7 +44,7 @@
         "brick/math": "^0.9|^0.10|^0.11|^0.12",
         "paragonie/constant_time_encoding": "^2.6|^3.0",
         "paragonie/sodium_compat": "^1.20|^2.0",
-        "psr/cache": "^3.0",
+        "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0",


### PR DESCRIPTION
Target branch: `3.4.x`

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [x] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

Allow `psr/cache` v2 to be compatible with `symfony/cache` `^5.4` which only allows `psr/cache`  `^1.0|^2.0` (see: https://github.com/symfony/cache/blob/5.4/composer.json#L25)