### PR TITLE
Add 'private_key_bits' option to EC key generation

### DIFF
--- a/src/Library/Core/Util/ECKey.php
+++ b/src/Library/Core/Util/ECKey.php
@@ -92,6 +92,7 @@ final readonly class ECKey
         $key = openssl_pkey_new([
             'curve_name' => self::getOpensslCurveName($curve),
             'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'private_key_bits' => 2048, // Not used for EC keys. See https://github.com/php/php-src/pull/19103
         ]);
         if ($key === false) {
             throw new RuntimeException('Unable to create the key');


### PR DESCRIPTION
Documented the addition of the 'private_key_bits' option with a comment clarifying its non-standard usage for EC keys.

Target branch: 4.0.x
Resolves issue #611

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

This bug is not related to the Web Token Suite, but can be resolved with this simple tweak.