### PR TITLE
Fix key derivation by removing curve size parameter from openssl_pkey_derive

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2365,7 +2365,7 @@ parameters:
 			path: src/Bundle/DependencyInjection/Source/NestedToken/NestedToken.php
 
 		-
-			message: '#^Parameter \#1 \$configs of method Jose\\Bundle\\JoseFramework\\DependencyInjection\\Source\\NestedToken\\NestedTokenBuilder\:\:load\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$configs of method Jose\\Bundle\\JoseFramework\\DependencyInjection\\Source\\NestedToken\\NestedTokenLoader\:\:load\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Bundle/DependencyInjection/Source/NestedToken/NestedToken.php
@@ -3797,6 +3797,12 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: src/Bundle/Resources/config/Algorithms/signature_experimental.php
+
+		-
+			message: '#^Access to constant on internal class Jose\\Component\\Core\\Util\\Ecc\\NistCurve\.$#'
+			identifier: classConstant.internalClass
+			count: 1
+			path: src/Bundle/Resources/config/analyzers.php
 
 		-
 			message: '#^Method Jose\\Bundle\\JoseFramework\\Serializer\\JWEEncoder\:\:getRecipientIndex\(\) has parameter \$context with no value type specified in iterable type array\.$#'
@@ -5597,6 +5603,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Library/Signature/Algorithm/ECDSA.php
+
+		-
+			message: '#^Call to internal static method ParagonIE_Sodium_Core_Ed25519\:\:publickey_from_secretkey\(\)\.$#'
+			identifier: staticMethod.internal
+			count: 1
+			path: src/Library/Signature/Algorithm/EdDSA.php
 
 		-
 			message: '#^Method Jose\\Component\\Signature\\Algorithm\\RSAPKCS1\:\:sign\(\) should return string but returns mixed\.$#'

--- a/src/Bundle/DependencyInjection/JoseFrameworkExtension.php
+++ b/src/Bundle/DependencyInjection/JoseFrameworkExtension.php
@@ -8,8 +8,8 @@ use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Override;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use function count;
 
 final class JoseFrameworkExtension extends Extension implements PrependExtensionInterface

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
@@ -89,7 +89,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
                         $publicPem = ECKey::convertPublicKeyToPEM($public_key);
                         $privatePem = ECKey::convertPrivateKeyToPEM($private_key);
 
-                        $res = openssl_pkey_derive($publicPem, $privatePem, $curve->getSize());
+                        $res = openssl_pkey_derive($publicPem, $privatePem);
                         if ($res === false) {
                             throw new RuntimeException('Unable to derive the key');
                         }

--- a/tests/EncryptionAlgorithm/ContentEncryption/AESCBC/AESCBC_HSContentEncryptionTest.php
+++ b/tests/EncryptionAlgorithm/ContentEncryption/AESCBC/AESCBC_HSContentEncryptionTest.php
@@ -320,10 +320,8 @@ final class AESCBC_HSContentEncryptionTest extends TestCase
     protected static function getMethod(string $class, string $name): ReflectionMethod
     {
         $class = new ReflectionClass($class);
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
 
-        return $method;
+        return $class->getMethod($name);
     }
 
     private function convertArrayToBinString(array $data): string


### PR DESCRIPTION
Target branch: 4.0.x
Resolves issue none

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [x] Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
Fix PHP8.5 deprecation