### PR TITLE
Add support for brick/math 0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require": {
         "php": ">=8.2",
         "ext-openssl": "*",
-        "brick/math": "^0.12|^0.13",
+        "brick/math": "^0.12|^0.13|^0.14",
         "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1",

--- a/src/Library/composer.json
+++ b/src/Library/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "php": ">=8.2",
-        "brick/math": "^0.12|^0.13",
+        "brick/math": "^0.12|^0.13|^0.14",
         "psr/clock": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1"
     },


### PR DESCRIPTION
Target branch: 4.1.x

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [x] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

This adds support for the latest version of brick/math: https://github.com/brick/math/releases/tag/0.14.0

This package is not affected by BC breaks:
 -  the PHP min version change is not actually a BC break (unlike in the npm ecosystem) as Composer takes the PHP requirement into account during dependency resolution. Thus, it does not affect this library (which already requires PHP 8.2+)
 -  this library uses classes from brick/math but does not extend them (and so is unaffected by the actual BC breaks)


Requires https://github.com/Spomky-Labs/pki-framework/pull/69 to make it possible to _actually_ use the new version when resolving dependencies.
