### PR TITLE
Improve Base64UrlSafe performance when ext-sodium is installed

### DIFF
--- a/src/Library/Core/Util/Base64UrlSafe.php
+++ b/src/Library/Core/Util/Base64UrlSafe.php
@@ -6,7 +6,18 @@ namespace Jose\Component\Core\Util;
 
 use InvalidArgumentException;
 use RangeException;
+use SensitiveParameter;
+use SodiumException;
+use function extension_loaded;
+use function pack;
+use function rtrim;
+use function sodium_base642bin;
+use function sodium_bin2base64;
 use function strlen;
+use function substr;
+use function unpack;
+use const SODIUM_BASE64_VARIANT_URLSAFE;
+use const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
 
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
@@ -33,17 +44,31 @@ use function strlen;
 
 final readonly class Base64UrlSafe
 {
-    public static function encode(string $binString): string
+    public static function encode(#[SensitiveParameter] string $binString): string
     {
+        if (extension_loaded('sodium')) {
+            try {
+                return sodium_bin2base64($binString, SODIUM_BASE64_VARIANT_URLSAFE);
+            } catch (SodiumException $ex) {
+                throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+            }
+        }
         return static::doEncode($binString, true);
     }
 
-    public static function encodeUnpadded(string $src): string
+    public static function encodeUnpadded(#[SensitiveParameter] string $src): string
     {
+        if (extension_loaded('sodium')) {
+            try {
+                return sodium_bin2base64($src, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+            } catch (SodiumException $ex) {
+                throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+            }
+        }
         return static::doEncode($src, false);
     }
 
-    public static function decode(string $encodedString, bool $strictPadding = false): string
+    public static function decode(#[SensitiveParameter] string $encodedString, bool $strictPadding = false): string
     {
         $srcLen = self::safeStrlen($encodedString);
         if ($srcLen === 0) {
@@ -64,6 +89,16 @@ final readonly class Base64UrlSafe
             }
             if ($encodedString[$srcLen - 1] === '=') {
                 throw new RangeException('Incorrect padding');
+            }
+            if (extension_loaded('sodium')) {
+                try {
+                    return sodium_base642bin(
+                        self::safeSubstr($encodedString, 0, $srcLen),
+                        SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+                    );
+                } catch (SodiumException $ex) {
+                    throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+                }
             }
         } else {
             $encodedString = rtrim($encodedString, '=');
@@ -120,26 +155,21 @@ final readonly class Base64UrlSafe
         return $dest;
     }
 
-    public static function decodeNoPadding(string $encodedString): string
+    public static function decodeNoPadding(#[SensitiveParameter] string $encodedString): string
     {
         $srcLen = self::safeStrlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }
         if (($srcLen & 3) === 0) {
-            if ($encodedString[$srcLen - 1] === '=') {
+            if ($encodedString[$srcLen - 1] === '=' || $encodedString[$srcLen - 2] === '=') {
                 throw new InvalidArgumentException("decodeNoPadding() doesn't tolerate padding");
-            }
-            if (($srcLen & 3) > 1) {
-                if ($encodedString[$srcLen - 2] === '=') {
-                    throw new InvalidArgumentException("decodeNoPadding() doesn't tolerate padding");
-                }
             }
         }
         return static::decode($encodedString, true);
     }
 
-    private static function doEncode(string $src, bool $pad = true): string
+    private static function doEncode(#[SensitiveParameter] string $src, bool $pad = true): string
     {
         $dest = '';
         $srcLen = self::safeStrlen($src);
@@ -204,12 +234,12 @@ final readonly class Base64UrlSafe
         return pack('C', $src + $diff);
     }
 
-    private static function safeStrlen(string $str): int
+    private static function safeStrlen(#[SensitiveParameter] string $str): int
     {
         return strlen($str);
     }
 
-    private static function safeSubstr(string $str, int $start = 0, $length = null): string
+    private static function safeSubstr(#[SensitiveParameter] string $str, int $start = 0, $length = null): string
     {
         if ($length === 0) {
             return '';


### PR DESCRIPTION
Target branch: 4.1.x

- [ ] It is a Bug fix
- [ ] It is a New feature
- [x] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

`Base64UrlSafe` has potential for significant performance improvements by using `ext-sodium`. This in turn improves JWT decoding performance.

These adjustments are only applying the changes made in paragonie/constant_time_encoding between 2.6.3 and 2.8.2. It's essentially a dependency update.
See: https://github.com/paragonie/constant_time_encoding/compare/v2.6.3..v2.8.2, https://github.com/paragonie/constant_time_encoding/pull/61

Side effects from the direct application of all changes up to 2.8.2 include:
- Adding `#[SensitiveParameter]`
- Adding `use function` statements for existing PHP function usages
- A logic change in `decodeNoPadding()`