### PR TITLE
adds support for brainpoolP256r1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ infection.txt
 .castor.stub.php
 /tmp*
 /.ci-tools/coverage
+/var/cache

--- a/src/Library/Core/Util/ECKey.php
+++ b/src/Library/Core/Util/ECKey.php
@@ -7,10 +7,12 @@ namespace Jose\Component\Core\Util;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use RuntimeException;
+
 use function extension_loaded;
 use function is_array;
 use function is_string;
 use function sprintf;
+
 use const OPENSSL_KEYTYPE_EC;
 use const STR_PAD_LEFT;
 

--- a/src/Library/Core/Util/ECKey.php
+++ b/src/Library/Core/Util/ECKey.php
@@ -32,6 +32,7 @@ final readonly class ECKey
     {
         $der = match ($jwk->get('crv')) {
             'P-256' => self::p256PublicKey(),
+            'BP-256' => self::p256PublicKey(),
             'secp256k1' => self::p256KPublicKey(),
             'P-384' => self::p384PublicKey(),
             'P-521' => self::p521PublicKey(),
@@ -48,6 +49,7 @@ final readonly class ECKey
     {
         $der = match ($jwk->get('crv')) {
             'P-256' => self::p256PrivateKey($jwk),
+            'BP-256' => self::p256PrivateKey($jwk),
             'secp256k1' => self::p256KPrivateKey($jwk),
             'P-384' => self::p384PrivateKey($jwk),
             'P-521' => self::p521PrivateKey($jwk),
@@ -77,7 +79,7 @@ final readonly class ECKey
     private static function getNistCurveSize(string $curve): int
     {
         return match ($curve) {
-            'P-256', 'secp256k1' => 256,
+            'P-256', 'BP-256', 'secp256k1' => 256,
             'P-384' => 384,
             'P-521' => 521,
             default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
@@ -130,6 +132,7 @@ final readonly class ECKey
     {
         return match ($curve) {
             'P-256' => 'prime256v1',
+            'BP-256' => 'brainpoolP256r1',
             'secp256k1' => 'secp256k1',
             'P-384' => 'secp384r1',
             'P-521' => 'secp521r1',

--- a/src/Library/Core/Util/Ecc/BrainpoolCurve.php
+++ b/src/Library/Core/Util/Ecc/BrainpoolCurve.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Util\Ecc;
+
+use Brick\Math\BigInteger;
+
+/**
+ * Copyright (C) 2024 Robert Böser.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @internal
+ */
+final class BrainpoolCurve
+{
+    /**
+     * Returns an Brainpool BP-256 curve.
+     * RFC 5639 - brainpoolP256r1
+     */
+    public static function curve256(): Curve
+    {
+        $p = BigInteger::fromBase('A9FB57DBA1EEA9BC3E660A909D838D726E3BF623D52620282013481D1F6E5377', 16);
+        $a = BigInteger::fromBase('7D5A0975FC2C3057EEF67530417AFFE7FB8055C126DC5C6CE94A4B44F330B5D9', 16);
+        $b = BigInteger::fromBase('26DC5C6CE94A4B44F330B5D9BBD77CBF958416295CF7E1CE6BCCDC18FF8C07B6', 16);
+        $x = BigInteger::fromBase('8BD2AEB9CB7E57CB2C4B482FFC81B7AFB9DE27E1E3BD23C23A4453BD9ACE3262', 16);
+        $y = BigInteger::fromBase('547EF835C3DAC4FD97F8461A14611DC9C27745132DED8E545C1D54C72F046997', 16);
+        $n = BigInteger::fromBase('A9FB57DBA1EEA9BC3E660A909D838D718C397AA3B561A6F7901E0E82974856A7', 16);
+        $generator = Point::create($x, $y, $n);
+
+        return new Curve(256, $p, $a, $b, $generator);
+    }
+
+}

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
@@ -11,6 +11,7 @@ use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\Ecc\Curve;
 use Jose\Component\Core\Util\Ecc\EcDH;
 use Jose\Component\Core\Util\Ecc\NistCurve;
+use Jose\Component\Core\Util\Ecc\BrainpoolCurve;
 use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\ConcatKDF;
@@ -83,6 +84,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
             case 'P-256':
             case 'P-384':
             case 'P-521':
+            case 'BP-256':
                 $curve = $this->getCurve($crv);
                 if (function_exists('openssl_pkey_derive')) {
                     try {
@@ -158,7 +160,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
             throw new InvalidArgumentException('Invalid key parameter "crv"');
         }
         $private_key = match ($crv) {
-            'P-256', 'P-384', 'P-521' => $senderKey ?? ECKey::createECKey($crv),
+            'P-256', 'P-384', 'P-521', 'BP-256' => $senderKey ?? ECKey::createECKey($crv),
             'X25519' => $senderKey ?? $this->createOKPKey('X25519'),
             default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported', $crv)),
         };
@@ -221,6 +223,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
             case 'P-256':
             case 'P-384':
             case 'P-521':
+            case 'BP-256':
                 if (! $key->has('y')) {
                     throw new InvalidArgumentException('The key parameter "y" is missing.');
                 }
@@ -244,6 +247,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
             'P-256' => NistCurve::curve256(),
             'P-384' => NistCurve::curve384(),
             'P-521' => NistCurve::curve521(),
+            'BP-256' => BrainpoolCurve::curve256(),
             default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported', $crv)),
         };
     }

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
@@ -8,16 +8,17 @@ use Brick\Math\BigInteger;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\Ecc\BrainpoolCurve;
 use Jose\Component\Core\Util\Ecc\Curve;
 use Jose\Component\Core\Util\Ecc\EcDH;
 use Jose\Component\Core\Util\Ecc\NistCurve;
-use Jose\Component\Core\Util\Ecc\BrainpoolCurve;
 use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\ConcatKDF;
 use Override;
 use RuntimeException;
 use Throwable;
+
 use function array_key_exists;
 use function extension_loaded;
 use function function_exists;


### PR DESCRIPTION
Target branch: 4.2.x

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

I needed support for the brainpool curve, so I added support for it. Maybe it is useful for somebody else, too.