### PR TITLE
Update brick/math constraint and remove dev minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require": {
         "php": ">=8.2",
         "ext-openssl": "*",
-        "brick/math": "^0.12|^0.13|^0.14",
+        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
         "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1",
@@ -92,6 +92,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
## Summary
- Extend `brick/math` version constraint to support `^0.15|^0.16|^0.17`
- Remove `minimum-stability: dev` from `composer.json`

## Test plan
- [ ] Verify CI passes with the updated dependency constraints
- [ ] Confirm `composer install` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)