### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,6 @@
         "ext-gmp": "*",
         "ext-sodium": "*",
         "matthiasnoback/symfony-config-test": "^6.0",
-        "paragonie/sodium_compat": "^1.20|^2.0",
         "phpbench/phpbench": "^1.2",
         "roave/security-advisories": "dev-latest",
         "spomky-labs/aes-key-wrap": "^7.0|^8.0",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^1.20|^2.0`, but also `php: >=8.1`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?