### PR TITLE
Update signature tests for the protected-header "alg" requirement

### DIFF
--- a/tests/Component/Signature/RFC7520/MultipleSignaturesTest.php
+++ b/tests/Component/Signature/RFC7520/MultipleSignaturesTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Jose\Tests\Component\Signature\RFC7520;
 
+use InvalidArgumentException;
 use Jose\Component\Core\JWK;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSVerifier;
 use Jose\Tests\Component\Signature\SignatureTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -81,9 +84,9 @@ final class MultipleSignaturesTest extends SignatureTestCase
 
         static::assertSame(3, $jws->countSignatures());
 
-        static::assertTrue($jwsVerifier->verifyWithKey($jws, $ecdsa_private_key, 0));
         static::assertTrue($jwsVerifier->verifyWithKey($jws, $rsa_private_key, 1));
         static::assertTrue($jwsVerifier->verifyWithKey($jws, $symmetric_key, 2));
+        $this->assertUnprotectedAlgIsRejected($jwsVerifier, $jws, $ecdsa_private_key, 0);
 
         /** @see https://tools.ietf.org/html/rfc7520#section-4.8.5 */
         $expected_json = '{"payload":"SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4","signatures":[{"protected":"eyJhbGciOiJSUzI1NiJ9","header":{"kid":"bilbo.baggins@hobbiton.example"},"signature":"MIsjqtVlOpa71KE-Mss8_Nq2YH4FGhiocsqrgi5NvyG53uoimic1tcMdSg-qptrzZc7CG6Svw2Y13TDIqHzTUrL_lR2ZFcryNFiHkSw129EghGpwkpxaTn_THJTCglNbADko1MZBCdwzJxwqZc-1RlpO2HibUYyXSwO97BSe0_evZKdjvvKSgsIqjytKSeAMbhMBdMma622_BG5t4sdbuCHtFjp9iJmkio47AIwqkZV1aIZsv33uPUqBBCXbYoQJwt7mxPftHmNlGoOSMxR_3thmXTCm4US-xiNOyhbm8afKK64jU6_TPtQHiJeQJxz9G3Tx-083B745_AfYOnlC9w"},{"header":{"alg":"ES512","kid":"bilbo.baggins@hobbiton.example"},"signature":"ARcVLnaJJaUWG8fG-8t5BREVAuTY8n8YHjwDO1muhcdCoFZFFjfISu0Cdkn9Ybdlmi54ho0x924DUz8sK7ZXkhc7AFM8ObLfTvNCrqcI3Jkl2U5IX3utNhODH6v7xgy1Qahsn0fyb4zSAkje8bAWz4vIfj5pCMYxxm4fgV3q7ZYhm5eD"},{"protected":"eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9","signature":"s0h6KThzkfBBBkLspW1h84VsJZFTsPPqMDA7g1Md7p0"}]}';
@@ -94,7 +97,21 @@ final class MultipleSignaturesTest extends SignatureTestCase
         static::assertSame($payload, $loaded_json->getPayload());
 
         static::assertTrue($jwsVerifier->verifyWithKey($loaded_json, $rsa_private_key, 0));
-        static::assertTrue($jwsVerifier->verifyWithKey($loaded_json, $ecdsa_private_key, 1));
         static::assertTrue($jwsVerifier->verifyWithKey($loaded_json, $symmetric_key, 2));
+        $this->assertUnprotectedAlgIsRejected($jwsVerifier, $loaded_json, $ecdsa_private_key, 1);
+    }
+
+    private function assertUnprotectedAlgIsRejected(
+        JWSVerifier $jwsVerifier,
+        JWS $jws,
+        JWK $key,
+        int $signature
+    ): void {
+        try {
+            $jwsVerifier->verifyWithKey($jws, $key, $signature);
+            static::fail('A signature whose "alg" is not in the protected header must be rejected.');
+        } catch (InvalidArgumentException $e) {
+            static::assertSame('No "alg" parameter set in the protected header.', $e->getMessage());
+        }
     }
 }

--- a/tests/Component/Signature/SignerTest.php
+++ b/tests/Component/Signature/SignerTest.php
@@ -930,7 +930,7 @@ final class SignerTest extends SignatureTestCase
     public function signAndLoadWithoutAlgParameterInTheHeader(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No "alg" parameter set in the header.');
+        $this->expectExceptionMessage('No "alg" parameter set in the protected header.');
 
         $payload = "It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.";
         $jws = 'eyJraWQiOiJiaWxiby5iYWdnaW5zQGhvYmJpdG9uLmV4YW1wbGUifQ.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4.MRjdkly7_-oTPTS3AXP41iQIGKa80A0ZmTuV5MEaHoxnW2e5CZ5NlKtainoFmKZopdHM1O2U4mwzJdQx996ivp83xuglII7PNDi84wnB-BDkoBwA78185hX-Es4JIwmDLJK3lfWRa-XtL0RnltuYv746iYTh_qHRD68BNt1uSNCrUCTJDt5aAE6x8wW1Kt9eRo4QPocSadnHXFxnt8Is9UzpERV0ePPQdLuW3IS_de3xyIrDaLGdjluPxUAhb6L2aXic1U12podGU0KLUQSE_oI-ZnmKJ3F4uOZDnd6QZWJushZ41Axf_fcIe8u9ipH84ogoree7vjbU5y18kDquDg';

--- a/tests/SignatureAlgorithm/HMAC/HMACFromRFC7520Test.php
+++ b/tests/SignatureAlgorithm/HMAC/HMACFromRFC7520Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Tests\SignatureAlgorithm\HMAC;
 
+use InvalidArgumentException;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Signature\Algorithm\HS256;
@@ -302,9 +303,10 @@ final class HMACFromRFC7520Test extends TestCase
         );
 
         $loaded_flattened_json = $jsonFlattenedSerializer->unserialize($expected_flattened_json);
-        static::assertTrue($jwsVerifier->verifyWithKey($loaded_flattened_json, $key, 0));
-
         $loaded_json = $jsonGeneralSerializer->unserialize($expected_json);
-        static::assertTrue($jwsVerifier->verifyWithKey($loaded_json, $key, 0));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No "alg" parameter set in the protected header.');
+        $jwsVerifier->verifyWithKey($loaded_flattened_json, $key, 0);
     }
 }


### PR DESCRIPTION
## Contexte

Le correctif **GHSA-jc38-x7x8-2xc8** (algorithm confusion) a durci `JWSVerifier::getAlgorithm()` : le paramètre `alg` est désormais lu **uniquement** dans le header protégé en intégrité (RFC 7515 §4.1.1), et un JWS dont le `alg` n'y figure pas est rejeté.

Trois tests existants validaient l'ancien comportement (cas RFC 7520 §4.7 / §4.8 où `alg` provient du header **non protégé**) et étaient donc rouges sur `3.4.x` depuis le merge de l'advisory (release `3.4.10`).

## Changements

- `SignerTest::signAndLoadWithoutAlgParameterInTheHeader` : message d'exception attendu mis à jour (`No "alg" parameter set in the protected header.`).
- `HMACFromRFC7520Test::hS256WithoutProtectedHeader` : la construction/sérialisation du token RFC §4.7 reste vérifiée ; la **vérification** d'un `alg` non protégé est désormais attendue comme **rejetée**.
- `MultipleSignaturesTest::multipleSignatures` : les signatures avec `alg` protégé (RS256, HS256) restent valides ; la signature ES512 (alg non protégé) est attendue comme **rejetée**.

Aucun code de production modifié : seuls des tests sont mis à jour pour refléter le comportement sécurisé.

## Validation

- Suite signature complète verte : `OK (111 tests, 313 assertions)`.
- Pas de commentaire inline ajouté (uniquement docblocks classe/méthode).

> Cible `3.4.x` → sera cascadée vers `4.0.x` / `4.1.x` / `4.2.x`. À publier en `3.4.11`.