### PR TITLE
fix(core): correct the parameter types of the nested token builder

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -7933,12 +7933,6 @@ parameters:
 			path: ../src/Library/Encryption/JWEBuilder.php
 
 		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEBuilder::addRecipient() has parameter $recipientHeader with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Encryption/JWEBuilder.php
-
-		-
 			rawMessage: 'Method Jose\Component\Encryption\JWEBuilder::checkAndSetContentEncryptionAlgorithm() has parameter $completeHeader with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -8097,18 +8091,6 @@ parameters:
 		-
 			rawMessage: 'Method Jose\Component\Encryption\JWEBuilder::withAAD() has parameter $aad with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Library/Encryption/JWEBuilder.php
-
-		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEBuilder::withSharedHeader() has parameter $sharedHeader with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Encryption/JWEBuilder.php
-
-		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEBuilder::withSharedProtectedHeader() has parameter $sharedProtectedHeader with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
 			count: 1
 			path: ../src/Library/Encryption/JWEBuilder.php
 
@@ -9667,32 +9649,8 @@ parameters:
 			path: ../src/Library/Signature/JWS.php
 
 		-
-			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<string, mixed> given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Signature/JWS.php
-
-		-
-			rawMessage: 'Parameter #4 $header of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<string, mixed> given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Signature/JWS.php
-
-		-
 			rawMessage: Class Jose\Component\Signature\JWSBuilder is neither abstract nor final.
 			identifier: ergebnis.final
-			count: 1
-			path: ../src/Library/Signature/JWSBuilder.php
-
-		-
-			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<string, mixed> given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Signature/JWSBuilder.php
-
-		-
-			rawMessage: 'Parameter #4 $header of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<string, mixed> given.'
-			identifier: argument.type
 			count: 1
 			path: ../src/Library/Signature/JWSBuilder.php
 
@@ -9949,7 +9907,7 @@ parameters:
 			path: ../src/Library/Signature/Serializer/CompactSerializer.php
 
 		-
-			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<mixed, mixed> given.'
+			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array<string, mixed>, array<mixed, mixed> given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Signature/Serializer/CompactSerializer.php
@@ -10003,7 +9961,7 @@ parameters:
 			path: ../src/Library/Signature/Serializer/JSONFlattenedSerializer.php
 
 		-
-			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<mixed> given.'
+			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array<string, mixed>, array<mixed> given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Signature/Serializer/JSONFlattenedSerializer.php
@@ -10015,7 +9973,7 @@ parameters:
 			path: ../src/Library/Signature/Serializer/JSONFlattenedSerializer.php
 
 		-
-			rawMessage: 'Parameter #4 $header of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, array<mixed> given.'
+			rawMessage: 'Parameter #4 $header of method Jose\Component\Signature\JWS::addSignature() expects array<string, mixed>, array<mixed> given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Signature/Serializer/JSONFlattenedSerializer.php
@@ -10105,7 +10063,7 @@ parameters:
 			path: ../src/Library/Signature/Serializer/JSONGeneralSerializer.php
 
 		-
-			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, mixed given.'
+			rawMessage: 'Parameter #2 $protectedHeader of method Jose\Component\Signature\JWS::addSignature() expects array<string, mixed>, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Signature/Serializer/JSONGeneralSerializer.php
@@ -10123,7 +10081,7 @@ parameters:
 			path: ../src/Library/Signature/Serializer/JSONGeneralSerializer.php
 
 		-
-			rawMessage: 'Parameter #4 $header of method Jose\Component\Signature\JWS::addSignature() expects array{alg?: string, string?: mixed}, mixed given.'
+			rawMessage: 'Parameter #4 $header of method Jose\Component\Signature\JWS::addSignature() expects array<string, mixed>, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Signature/Serializer/JSONGeneralSerializer.php

--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -118,6 +118,8 @@ class JWEBuilder
 
     /**
      * Set the shared protected header of the JWE to build.
+     *
+     * @param array<string, mixed> $sharedProtectedHeader
      */
     public function withSharedProtectedHeader(array $sharedProtectedHeader): self
     {
@@ -133,6 +135,8 @@ class JWEBuilder
 
     /**
      * Set the shared header of the JWE to build.
+     *
+     * @param array<string, mixed> $sharedHeader
      */
     public function withSharedHeader(array $sharedHeader): self
     {
@@ -148,6 +152,8 @@ class JWEBuilder
 
     /**
      * Adds a recipient to the JWE to build.
+     *
+     * @param array<string, mixed> $recipientHeader
      */
     public function addRecipient(JWK $recipientKey, array $recipientHeader = []): self
     {

--- a/src/Library/NestedToken/NestedTokenBuilder.php
+++ b/src/Library/NestedToken/NestedTokenBuilder.php
@@ -24,10 +24,10 @@ class NestedTokenBuilder
     /**
      * Creates a nested token.
      *
-     * @param array{array{key: JWK, protected_header?: array<string, mixed>, header?: array<string, mixed>}} $signatures
-     * @param array{alg?: string, string?: mixed} $jweSharedProtectedHeader
-     * @param array{alg?: string, string?: mixed} $jweSharedHeader
-     * @param array{array{key: JWK, header?: array<string, mixed>}} $recipients
+     * @param array<array{key: JWK, protected_header?: array<string, mixed>, header?: array<string, mixed>}> $signatures
+     * @param array<string, mixed> $jweSharedProtectedHeader
+     * @param array<string, mixed> $jweSharedHeader
+     * @param array<array{key: JWK, header?: array<string, mixed>}> $recipients
      */
     public function create(
         string $payload,

--- a/src/Library/Signature/JWS.php
+++ b/src/Library/Signature/JWS.php
@@ -79,8 +79,8 @@ class JWS implements JWT
      *
      * @internal
      *
-     * @param array{alg?: string, string?: mixed} $protectedHeader
-     * @param array{alg?: string, string?: mixed} $header
+     * @param array<string, mixed> $protectedHeader
+     * @param array<string, mixed> $header
      */
     public function addSignature(
         string $signature,

--- a/src/Library/Signature/Signature.php
+++ b/src/Library/Signature/Signature.php
@@ -18,8 +18,8 @@ class Signature
     private readonly array $protectedHeader;
 
     /**
-     * @param array{alg?: string, string?: mixed} $protectedHeader
-     * @param array{alg?: string, string?: mixed} $header
+     * @param array<string, mixed> $protectedHeader
+     * @param array<string, mixed> $header
      */
     public function __construct(
         private readonly string $signature,


### PR DESCRIPTION
Fixes #662.

## Problem

`NestedTokenBuilder::create()` declared sealed array shapes that reject the [documented usage](https://web-token.spomky-labs.com/advanced-topics/nested-tokens#nested-token-building). Analysing the documentation snippet with PHPStan (bleeding edge) or Psalm produced:

```
Parameter #4 $jweSharedProtectedHeader of method NestedTokenBuilder::create()
expects array{alg?: string, string?: mixed}, array{alg: 'RSA-OAEP', enc: 'A128GCM'} given.
💡 Sealed array shape does not accept array with extra key 'enc'.

Parameter #5 $jweSharedHeader of method NestedTokenBuilder::create()
expects array{alg?: string, string?: mixed}, array{foo: 'bar'} given.
💡 Sealed array shape does not accept array with extra key 'foo'.
```

Three distinct mistakes were involved:

1. `array{alg?: string, string?: mixed}` declares a shape with two optional keys, `alg` and one literally named `string`. It was clearly meant to be `array<string, mixed>`. Every other header parameter — `enc`, `zip`, `cty`, `kid`, … — was rejected.
2. `array{array{key: JWK, ...}}` declares a shape holding *exactly one* element at key `0`, not a list. Building a token with two signatures or two recipients was reported as an error too:
   ```
   Parameter #2 $signatures of method NestedTokenBuilder::create() expects
   array{array{key: JWK, protected_header?: ..., header?: ...}}, array{array{...}, array{...}} given.
   💡 Sealed array shape does not accept array with extra key 1.
   ```
3. As noted in the report, the JWE layer the builder delegates to declared no value type at all for its header parameters, so nothing downstream could have caught this.

## Changes

- `NestedTokenBuilder::create()`: `$jweSharedProtectedHeader` and `$jweSharedHeader` are `array<string, mixed>`; `$signatures` and `$recipients` are `array<array{...}>`.
- `JWEBuilder::withSharedProtectedHeader()`, `withSharedHeader()` and `addRecipient()` now declare `array<string, mixed>` for their header parameters (their `missingType.iterableValue` entries are dropped from the PHPStan baseline).
- `JWS::addSignature()` and `Signature::__construct()` carried the same `array{alg?: string, string?: mixed}` shape and are corrected the same way. The baseline entries that quoted the old shape are updated accordingly.

Documentation only — no runtime behaviour changes.

## Verification

The documented snippet, extended with a second signature, was analysed at level max with bleeding edge against both the old and the new signatures: 3 errors before, none after.

- `castor phpstan`: 43 errors, identical to the ones already present on `4.1.x` before this branch (the QA tooling breakage repaired on `4.2.x` by #669 is not backported here). No new error, no unmatched baseline entry.
- `castor phpunit`: 752 tests, 2223 assertions, green.
- `castor ecs` cannot run on `4.1.x` (`Undefined constant SetList::PHPUNIT`), pre-existing and unrelated — this change touches docblocks only.