### PR TITLE
fix(bundle): alias the nested token services with their own class

### DIFF
--- a/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
+++ b/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
@@ -42,7 +42,11 @@ final readonly class NestedTokenBuilder implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
-            $container->registerAliasForArgument($service_id, self::class, $name . 'NestedTokenBuilder');
+            $container->registerAliasForArgument(
+                $service_id,
+                NestedTokenBuilderService::class,
+                $name . 'NestedTokenBuilder'
+            );
         }
     }
 

--- a/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
+++ b/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
@@ -44,7 +44,11 @@ final readonly class NestedTokenLoader implements Source
                 $definition->addTag($id, $attributes);
             }
             $container->setDefinition($service_id, $definition);
-            $container->registerAliasForArgument($service_id, self::class, $name . 'NestedTokenLoader');
+            $container->registerAliasForArgument(
+                $service_id,
+                NestedTokenLoaderService::class,
+                $name . 'NestedTokenLoader'
+            );
         }
     }
 

--- a/tests/Bundle/JoseFramework/Functional/AutowiringAliasesTest.php
+++ b/tests/Bundle/JoseFramework/Functional/AutowiringAliasesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Functional;
+
+use Jose\Bundle\JoseFramework\JoseFrameworkBundle;
+use Jose\Component\NestedToken\NestedTokenBuilder;
+use Jose\Component\NestedToken\NestedTokenLoader;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
+use function explode;
+use function is_a;
+use function iterator_to_array;
+use function sprintf;
+use function str_contains;
+use function str_starts_with;
+
+/**
+ * The bundle registers an autowiring alias for every service it creates from the configuration. The nested token
+ * sources used to alias their own class - the class of the configuration source - instead of the class of the service
+ * they create, so nothing could ever be autowired through those aliases.
+ *
+ * @internal
+ */
+final class AutowiringAliasesTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('autowiringAliases')]
+    public function theAliasedServiceIsAnInstanceOfTheAliasedType(
+        string $type,
+        string $serviceId,
+        string $class
+    ): void {
+        static::assertTrue(
+            is_a($class, $type, true),
+            sprintf('The service "%s" is a "%s" and cannot be autowired as a "%s".', $serviceId, $class, $type)
+        );
+    }
+
+    #[Test]
+    public function theNestedTokenServicesAreAliasedWithTheClassOfTheServiceTheyCreate(): void
+    {
+        $aliases = iterator_to_array(self::autowiringAliases());
+
+        static::assertArrayHasKey(
+            NestedTokenLoader::class . ' $nestedTokenLoader1NestedTokenLoader',
+            $aliases
+        );
+        static::assertArrayHasKey(
+            NestedTokenBuilder::class . ' $nestedTokenBuilder1NestedTokenBuilder',
+            $aliases
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function autowiringAliases(): iterable
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        (new JoseFrameworkBundle())->getContainerExtension()
+            ->load([Yaml::parseFile(__DIR__ . '/../config/config_test.yml')['jose']], $container);
+
+        foreach ($container->getAliases() as $id => $alias) {
+            if (str_starts_with($id, '.') || ! str_contains($id, ' $')) {
+                continue;
+            }
+            $serviceId = (string) $alias;
+
+            yield $id => [
+                explode(' $', $id, 2)[0],
+                $serviceId,
+                $container->findDefinition($serviceId)
+                    ->getClass() ?? '',
+            ];
+        }
+    }
+}

--- a/tests/Bundle/JoseFramework/Functional/NestedToken/NestedTokenBuilderTest.php
+++ b/tests/Bundle/JoseFramework/Functional/NestedToken/NestedTokenBuilderTest.php
@@ -7,6 +7,7 @@ namespace Jose\Tests\Bundle\JoseFramework\Functional\NestedToken;
 use Jose\Bundle\JoseFramework\Services\NestedTokenBuilderFactory;
 use Jose\Component\Core\JWK;
 use Jose\Component\NestedToken\NestedTokenBuilder;
+use Jose\Tests\Bundle\JoseFramework\TestBundle\Service\NestedTokenServiceConsumer;
 use Jose\Tests\Bundle\JoseFramework\WebTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -43,6 +44,23 @@ final class NestedTokenBuilderTest extends WebTestCase
         $container = $client->getContainer();
         static::assertNotNull($container);
         static::assertTrue($container->has('jose.nested_token_builder.nested_token_builder_2'));
+    }
+
+    #[Test]
+    public static function theNestedTokenBuilderFromTheConfigurationCanBeAutowired(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+        $container = $client->getContainer();
+        static::assertNotNull($container);
+
+        /** @var NestedTokenServiceConsumer $consumer */
+        $consumer = $container->get(NestedTokenServiceConsumer::class);
+
+        static::assertSame(
+            $container->get('jose.nested_token_builder.nested_token_builder_1'),
+            $consumer->getBuilder()
+        );
     }
 
     #[Test]

--- a/tests/Bundle/JoseFramework/Functional/NestedToken/NestedTokenLoaderTest.php
+++ b/tests/Bundle/JoseFramework/Functional/NestedToken/NestedTokenLoaderTest.php
@@ -8,6 +8,7 @@ use Jose\Bundle\JoseFramework\Services\NestedTokenLoaderFactory;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\NestedToken\NestedTokenLoader;
+use Jose\Tests\Bundle\JoseFramework\TestBundle\Service\NestedTokenServiceConsumer;
 use Jose\Tests\Bundle\JoseFramework\WebTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -44,6 +45,23 @@ final class NestedTokenLoaderTest extends WebTestCase
         $container = $client->getContainer();
         static::assertNotNull($container);
         static::assertTrue($container->has('jose.nested_token_loader.nested_token_loader_2'));
+    }
+
+    #[Test]
+    public static function theNestedTokenLoaderFromTheConfigurationCanBeAutowired(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+        $container = $client->getContainer();
+        static::assertNotNull($container);
+
+        /** @var NestedTokenServiceConsumer $consumer */
+        $consumer = $container->get(NestedTokenServiceConsumer::class);
+
+        static::assertSame(
+            $container->get('jose.nested_token_loader.nested_token_loader_1'),
+            $consumer->getLoader()
+        );
     }
 
     #[Test]

--- a/tests/Bundle/JoseFramework/TestBundle/Resources/config/services.php
+++ b/tests/Bundle/JoseFramework/TestBundle/Resources/config/services.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Jose\Tests\Bundle\JoseFramework\TestBundle\Checker\CustomChecker;
+use Jose\Tests\Bundle\JoseFramework\TestBundle\Service\NestedTokenServiceConsumer;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -24,5 +25,9 @@ return function (ContainerConfigurator $container) {
 
     $container->set(ClockInterface::class)
         ->class(NativeClock::class)
+    ;
+
+    $container->set(NestedTokenServiceConsumer::class)
+        ->public()
     ;
 };

--- a/tests/Bundle/JoseFramework/TestBundle/Service/NestedTokenServiceConsumer.php
+++ b/tests/Bundle/JoseFramework/TestBundle/Service/NestedTokenServiceConsumer.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\TestBundle\Service;
+
+use Jose\Component\NestedToken\NestedTokenBuilder;
+use Jose\Component\NestedToken\NestedTokenLoader;
+
+/**
+ * Receives the nested token services of the configuration through the autowiring aliases registered by the bundle. The
+ * container cannot be compiled unless those aliases refer to the classes of the services.
+ */
+final readonly class NestedTokenServiceConsumer
+{
+    public function __construct(
+        private NestedTokenLoader $nestedTokenLoader1NestedTokenLoader,
+        private NestedTokenBuilder $nestedTokenBuilder1NestedTokenBuilder
+    ) {
+    }
+
+    public function getLoader(): NestedTokenLoader
+    {
+        return $this->nestedTokenLoader1NestedTokenLoader;
+    }
+
+    public function getBuilder(): NestedTokenBuilder
+    {
+        return $this->nestedTokenBuilder1NestedTokenBuilder;
+    }
+}


### PR DESCRIPTION
Fixes #660.

`NestedTokenBuilder` and `NestedTokenLoader` (the DI sources) registered their autowiring alias against `self::class` — the class of the configuration source — instead of the class of the service they create. The resulting aliases were:

```
Jose\Bundle\JoseFramework\DependencyInjection\Source\NestedToken\NestedTokenLoader $nestedTokenLoader1NestedTokenLoader
```

Nothing could ever resolve them, so autowiring a nested token loader or builder failed. They now read:

```
Jose\Component\NestedToken\NestedTokenLoader $nestedTokenLoader1NestedTokenLoader
Jose\Component\NestedToken\NestedTokenBuilder $nestedTokenBuilder1NestedTokenBuilder
```

The naming convention (`<config name>` + service kind) is unchanged, and it matches every other source (`$jwsLoader1JwsLoader`, `$builder1JweBuilder`, …).

### Are the others affected?

No. I went through all 14 `registerAliasForArgument()` call sites: the twelve others pass the class of the service, and `AbstractSource` passes `$definition->getClass()`. Only the two nested token ones were wrong.

To keep it that way, `AutowiringAliasesTest` loads the bundle extension with the functional test configuration, walks every autowiring alias it registers, and asserts the aliased service is an instance of the aliased type. That covers 22 aliases across all sources today and picks up any new one automatically. It fails on both nested token aliases without the fix.

`NestedTokenServiceConsumer` in the test bundle reproduces the report end to end: it takes both services through autowiring only, and the two new functional tests check it receives the services from the configuration.

### Not addressed here

The `$target` argument of `registerAliasForArgument()`, suggested in the issue's additional context, would let people write `#[Target('nested_token_loader_1')]` instead of the suffixed name. It landed in Symfony 7.4 and this branch supports `symfony/dependency-injection: ^7.0|^8.0`, so it can't be used unconditionally here. Worth a separate issue on a branch that can raise the requirement — it applies to every source, not just these two.

### Test run

Full suite: 777 tests, 38 failures — the same 38 that fail on an untouched `4.1.x` checkout. They are all `*ConfigurationTest` cases where `matthiasnoback/symfony-config-test` no longer matches the Symfony 8.1 config error messages, unrelated to this change. ECS and PHPStan cannot run on `4.1.x` at all (broken tool configuration, already repaired on `4.2.x` by #669).