### PR TITLE
feat(console): add a command to convert a key into PKCS#8

### DIFF
--- a/src/Bundle/Resources/config/commands.php
+++ b/src/Bundle/Resources/config/commands.php
@@ -18,6 +18,7 @@ use Jose\Component\Console\OkpKeysetGeneratorCommand;
 use Jose\Component\Console\OptimizeRsaKeyCommand;
 use Jose\Component\Console\P12CertificateLoaderCommand;
 use Jose\Component\Console\PemConverterCommand;
+use Jose\Component\Console\Pkcs8ConverterCommand;
 use Jose\Component\Console\PublicKeyCommand;
 use Jose\Component\Console\PublicKeysetCommand;
 use Jose\Component\Console\RotateKeysetCommand;
@@ -50,6 +51,7 @@ return function (ContainerConfigurator $container): void {
     $container->set(OkpKeysetGeneratorCommand::class);
     $container->set(P12CertificateLoaderCommand::class);
     $container->set(PemConverterCommand::class);
+    $container->set(Pkcs8ConverterCommand::class);
     $container->set(PublicKeyCommand::class);
     $container->set(PublicKeysetCommand::class);
     $container->set(RotateKeysetCommand::class);

--- a/src/Library/Console/Pkcs8ConverterCommand.php
+++ b/src/Library/Console/Pkcs8ConverterCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Console;
+
+use InvalidArgumentException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\Util\ECKey;
+use Jose\Component\Core\Util\JsonConverter;
+use Jose\Component\Core\Util\OKPKey;
+use Jose\Component\Core\Util\RSAKey;
+use Override;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function is_array;
+use function is_string;
+
+#[AsCommand(name: 'key:convert:pkcs8', description: 'Converts a RSA, EC or OKP key into PKCS#8 key.')]
+final class Pkcs8ConverterCommand extends ObjectOutputCommand
+{
+    #[Override]
+    protected function configure(): void
+    {
+        parent::configure();
+        $this
+            ->setHelp(
+                'This command converts a RSA, EC or OKP key into a PKCS#8 key. As PKCS#8 only covers private keys, public keys are converted into a SubjectPublicKeyInfo structure.'
+            )
+            ->addArgument('jwk', InputArgument::REQUIRED, 'The key');
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $jwk = $input->getArgument('jwk');
+        if (! is_string($jwk)) {
+            throw new InvalidArgumentException('Invalid JWK');
+        }
+        $json = JsonConverter::decode($jwk);
+        if (! is_array($json)) {
+            throw new InvalidArgumentException('Invalid JWK.');
+        }
+        $key = new JWK($json);
+
+        $pem = match ($key->get('kty')) {
+            'RSA' => RSAKey::createFromJWK($key)->toPEM(),
+            'EC' => ECKey::convertToPKCS8PEM($key),
+            'OKP' => OKPKey::convertToPKCS8PEM($key),
+            default => throw new InvalidArgumentException('Not a RSA, EC or OKP key.'),
+        };
+        $output->write($pem);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Library/Core/Util/ECKey.php
+++ b/src/Library/Core/Util/ECKey.php
@@ -7,6 +7,13 @@ namespace Jose\Component\Core\Util;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use RuntimeException;
+use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\BitString;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\ObjectIdentifier;
+use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
+use SpomkyLabs\Pki\ASN1\Type\Tagged\ExplicitlyTaggedType;
+use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use function extension_loaded;
 use function is_array;
 use function is_string;
@@ -19,6 +26,11 @@ use const STR_PAD_LEFT;
  */
 final readonly class ECKey
 {
+    /**
+     * OID of the id-ecPublicKey algorithm identifier.
+     */
+    private const EC_PUBLIC_KEY_OID = '1.2.840.10045.2.1';
+
     public static function convertToPEM(JWK $jwk): string
     {
         if ($jwk->has('d')) {
@@ -26,6 +38,49 @@ final readonly class ECKey
         }
 
         return self::convertPublicKeyToPEM($jwk);
+    }
+
+    /**
+     * Converts the key into a PKCS#8 PEM. As PKCS#8 only covers private keys, public keys are converted into a
+     * SubjectPublicKeyInfo structure, which is the format expected by the tools consuming PKCS#8 private keys.
+     */
+    public static function convertToPKCS8PEM(JWK $jwk): string
+    {
+        if ($jwk->has('d')) {
+            return self::convertPrivateKeyToPKCS8PEM($jwk);
+        }
+
+        return self::convertPublicKeyToPEM($jwk);
+    }
+
+    /**
+     * Converts the private key into a PKCS#8 (RFC 5208) PEM, i.e. a PrivateKeyInfo structure wrapping the RFC 5915
+     * ECPrivateKey. The curve is only carried by the algorithm identifier: the optional "parameters" field of the
+     * inner ECPrivateKey is left out to avoid the duplication, exactly as OpenSSL does.
+     */
+    public static function convertPrivateKeyToPKCS8PEM(JWK $jwk): string
+    {
+        $curve = $jwk->get('crv');
+        if (! is_string($curve)) {
+            throw new InvalidArgumentException('Unable to get the curve');
+        }
+        $length = (int) ceil(self::getCurveSize($curve) / 8);
+        $ecPrivateKey = Sequence::create(
+            Integer::create(1),
+            OctetString::create(self::getPrivateKeyBytes($jwk, $length)),
+            ExplicitlyTaggedType::create(1, BitString::create(self::getKey($jwk))),
+        );
+        $privateKeyInfo = Sequence::create(
+            Integer::create(0),
+            Sequence::create(
+                ObjectIdentifier::create(self::EC_PUBLIC_KEY_OID),
+                ObjectIdentifier::create(self::getCurveOid($curve)),
+            ),
+            OctetString::create($ecPrivateKey->toDER()),
+        );
+
+        return PEM::create(PEM::TYPE_PRIVATE_KEY, $privateKeyInfo->toDER())
+            ->string();
     }
 
     public static function convertPublicKeyToPEM(JWK $jwk): string
@@ -131,6 +186,24 @@ final readonly class ECKey
                 str_pad((string) $details['ec']['y'], (int) ceil($curveSize / 8), "\0", STR_PAD_LEFT)
             ),
         ];
+    }
+
+    /**
+     * Returns the OID of the named curve, as used by the AlgorithmIdentifier of the PKCS#8 and SubjectPublicKeyInfo
+     * structures.
+     */
+    private static function getCurveOid(string $curve): string
+    {
+        return match ($curve) {
+            'P-256' => '1.2.840.10045.3.1.7',
+            'secp256k1' => '1.3.132.0.10',
+            'P-384' => '1.3.132.0.34',
+            'P-521' => '1.3.132.0.35',
+            'BP-256' => '1.3.36.3.3.2.8.1.1.7',
+            'BP-384' => '1.3.36.3.3.2.8.1.1.11',
+            'BP-512' => '1.3.36.3.3.2.8.1.1.13',
+            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+        };
     }
 
     private static function getOpensslCurveName(string $curve): string
@@ -346,16 +419,25 @@ final readonly class ECKey
      */
     private static function getPrivateKeyOctets(JWK $jwk, int $length): string
     {
-        $d = $jwk->get('d');
-        if (! is_string($d)) {
-            throw new InvalidArgumentException('Unable to get the private key');
-        }
-        $data = unpack('H*', str_pad(Base64UrlSafe::decodeNoPadding($d), $length, "\0", STR_PAD_LEFT));
+        $data = unpack('H*', self::getPrivateKeyBytes($jwk, $length));
         if (! is_array($data) || ! isset($data[1]) || ! is_string($data[1])) {
             throw new InvalidArgumentException('Unable to get the private key');
         }
 
         return $data[1];
+    }
+
+    /**
+     * Returns the binary representation of the private key, left-padded to the size of the curve.
+     */
+    private static function getPrivateKeyBytes(JWK $jwk, int $length): string
+    {
+        $d = $jwk->get('d');
+        if (! is_string($d)) {
+            throw new InvalidArgumentException('Unable to get the private key');
+        }
+
+        return str_pad(Base64UrlSafe::decodeNoPadding($d), $length, "\0", STR_PAD_LEFT);
     }
 
     private static function getKey(JWK $jwk): string

--- a/src/Library/Core/Util/OKPKey.php
+++ b/src/Library/Core/Util/OKPKey.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Util;
+
+use InvalidArgumentException;
+use Jose\Component\Core\JWK;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PublicKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve25519\Ed25519PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve25519\Ed25519PublicKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve25519\X25519PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve25519\X25519PublicKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve448\Ed448PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve448\Ed448PublicKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve448\X448PrivateKey;
+use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RFC8410\Curve448\X448PublicKey;
+use function is_string;
+use function sprintf;
+
+/**
+ * Converts Octet Key Pair keys (RFC 8037) into the PEM structures defined by RFC 8410.
+ *
+ * @internal
+ */
+final readonly class OKPKey
+{
+    /**
+     * Converts the key into a PKCS#8 PEM. As PKCS#8 only covers private keys, public keys are converted into a
+     * SubjectPublicKeyInfo structure, which is the format expected by the tools consuming PKCS#8 private keys.
+     */
+    public static function convertToPKCS8PEM(JWK $jwk): string
+    {
+        if ($jwk->has('d')) {
+            return self::convertPrivateKeyToPKCS8PEM($jwk);
+        }
+
+        return self::convertPublicKeyToPEM($jwk);
+    }
+
+    /**
+     * Converts the private key into a PKCS#8 (RFC 5208) PEM. The public key is deliberately left out of the structure:
+     * the resulting OneAsymmetricKey stays at version 0, which is what RFC 8410 section 7 recommends and what the
+     * widely deployed PKCS#8 parsers expect.
+     */
+    public static function convertPrivateKeyToPKCS8PEM(JWK $jwk): string
+    {
+        $privateKey = self::createPrivateKey($jwk);
+
+        return PrivateKeyInfo::create($privateKey->algorithmIdentifier(), $privateKey->toDER())
+            ->toPEM()
+            ->string();
+    }
+
+    /**
+     * Converts the public key into a SubjectPublicKeyInfo (RFC 5280) PEM.
+     */
+    public static function convertPublicKeyToPEM(JWK $jwk): string
+    {
+        return self::createPublicKey($jwk)
+            ->publicKeyInfo()
+            ->toPEM()
+            ->string();
+    }
+
+    private static function createPrivateKey(JWK $jwk): PrivateKey
+    {
+        $curve = self::getParameter($jwk, 'crv');
+        $d = Base64UrlSafe::decodeNoPadding(self::getParameter($jwk, 'd'));
+
+        return match ($curve) {
+            'Ed25519' => Ed25519PrivateKey::create($d),
+            'Ed448' => Ed448PrivateKey::create($d),
+            'X25519' => X25519PrivateKey::create($d),
+            'X448' => X448PrivateKey::create($d),
+            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+        };
+    }
+
+    private static function createPublicKey(JWK $jwk): PublicKey
+    {
+        $curve = self::getParameter($jwk, 'crv');
+        $x = Base64UrlSafe::decodeNoPadding(self::getParameter($jwk, 'x'));
+
+        return match ($curve) {
+            'Ed25519' => Ed25519PublicKey::create($x),
+            'Ed448' => Ed448PublicKey::create($x),
+            'X25519' => X25519PublicKey::create($x),
+            'X448' => X448PublicKey::create($x),
+            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+        };
+    }
+
+    private static function getParameter(JWK $jwk, string $parameter): string
+    {
+        $value = $jwk->get($parameter);
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(sprintf('Unable to get the "%s" parameter', $parameter));
+        }
+
+        return $value;
+    }
+}

--- a/tests/Bundle/JoseFramework/Functional/Console/ConsoleTest.php
+++ b/tests/Bundle/JoseFramework/Functional/Console/ConsoleTest.php
@@ -32,6 +32,7 @@ final class ConsoleTest extends KernelTestCase
             'key:optimize',
             'key:load:p12',
             'key:convert:pkcs1',
+            'key:convert:pkcs8',
             'keyset:convert:public',
             'keyset:rotate',
             'key:generate:rsa',

--- a/tests/Component/Console/KeyConversionCommandTest.php
+++ b/tests/Component/Console/KeyConversionCommandTest.php
@@ -4,22 +4,28 @@ declare(strict_types=1);
 
 namespace Jose\Tests\Component\Console;
 
+use InvalidArgumentException;
 use Jose\Component\Console\GetThumbprintCommand;
 use Jose\Component\Console\KeyFileLoaderCommand;
 use Jose\Component\Console\OptimizeRsaKeyCommand;
 use Jose\Component\Console\P12CertificateLoaderCommand;
 use Jose\Component\Console\PemConverterCommand;
+use Jose\Component\Console\Pkcs8ConverterCommand;
 use Jose\Component\Console\PublicKeyCommand;
 use Jose\Component\Console\PublicKeysetCommand;
 use Jose\Component\Console\X509CertificateLoaderCommand;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
+use Jose\Component\KeyManagement\JWKFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use const STR_PAD_LEFT;
 
 /**
  * @internal
@@ -157,6 +163,98 @@ final class KeyConversionCommandTest extends TestCase
     }
 
     #[Test]
+    public function iCanConvertARsaKeyIntoPKCS8(): void
+    {
+        $jwk = JWKFactory::createRSAKey(2048);
+
+        $content = self::convertIntoPKCS8($jwk);
+
+        static::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $content);
+        self::assertSameKeyMaterial($jwk, JWKFactory::createFromKey($content));
+    }
+
+    #[Test]
+    #[DataProvider('ecCurves')]
+    public function iCanConvertAnEcKeyIntoPKCS8(string $curve, int $size): void
+    {
+        $jwk = JWKFactory::createECKey($curve);
+
+        $content = self::convertIntoPKCS8($jwk);
+
+        static::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $content);
+        $details = self::getKeyDetails($content);
+        static::assertSame(self::getRawParameter($jwk, 'd', $size), str_pad($details['ec']['d'], $size, "\0", STR_PAD_LEFT));
+        static::assertSame(self::getRawParameter($jwk, 'x', $size), str_pad($details['ec']['x'], $size, "\0", STR_PAD_LEFT));
+        static::assertSame(self::getRawParameter($jwk, 'y', $size), str_pad($details['ec']['y'], $size, "\0", STR_PAD_LEFT));
+    }
+
+    #[Test]
+    #[DataProvider('okpCurves')]
+    public function iCanConvertAnOkpKeyIntoPKCS8(string $curve): void
+    {
+        $jwk = JWKFactory::createOKPKey($curve);
+
+        $content = self::convertIntoPKCS8($jwk);
+
+        static::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $content);
+        self::assertSameKeyMaterial($jwk, JWKFactory::createFromKey($content));
+    }
+
+    /**
+     * PKCS#8 only covers private keys. Public keys are converted into a SubjectPublicKeyInfo structure.
+     */
+    #[Test]
+    #[DataProvider('publicKeys')]
+    public function iCanConvertAPublicKeyIntoSubjectPublicKeyInfo(JWK $jwk): void
+    {
+        $content = self::convertIntoPKCS8($jwk->toPublic());
+
+        static::assertStringStartsWith('-----BEGIN PUBLIC KEY-----', $content);
+        self::assertSameKeyMaterial($jwk->toPublic(), JWKFactory::createFromKey($content));
+    }
+
+    #[Test]
+    public function iCannotConvertAnOctKeyIntoPKCS8(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        self::convertIntoPKCS8(JWKFactory::createOctKey(256));
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function ecCurves(): iterable
+    {
+        yield 'P-256' => ['P-256', 32];
+        yield 'secp256k1' => ['secp256k1', 32];
+        yield 'P-384' => ['P-384', 48];
+        yield 'P-521' => ['P-521', 66];
+        yield 'BP-256' => ['BP-256', 32];
+        yield 'BP-384' => ['BP-384', 48];
+        yield 'BP-512' => ['BP-512', 64];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function okpCurves(): iterable
+    {
+        yield 'Ed25519' => ['Ed25519'];
+        yield 'X25519' => ['X25519'];
+    }
+
+    /**
+     * @return iterable<string, array{JWK}>
+     */
+    public static function publicKeys(): iterable
+    {
+        yield 'RSA' => [JWKFactory::createRSAKey(2048)];
+        yield 'EC' => [JWKFactory::createECKey('P-256')];
+        yield 'OKP' => [JWKFactory::createOKPKey('Ed25519')];
+    }
+
+    #[Test]
     public function iCanConvertAPrivateKeyIntoPublicKey(): void
     {
         $jwk = new JWK([
@@ -232,5 +330,54 @@ final class KeyConversionCommandTest extends TestCase
         $command->run($input, $output);
         $content = $output->fetch();
         static::assertSame('NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs', $content);
+    }
+
+    /**
+     * The order of the key parameters is irrelevant and depends on the way the key has been loaded.
+     */
+    private static function assertSameKeyMaterial(JWK $expected, JWK $actual): void
+    {
+        $expectedValues = $expected->all();
+        $actualValues = $actual->all();
+        ksort($expectedValues);
+        ksort($actualValues);
+
+        static::assertSame($expectedValues, $actualValues);
+    }
+
+    private static function convertIntoPKCS8(JWK $jwk): string
+    {
+        $input = new ArrayInput([
+            'jwk' => JsonConverter::encode($jwk),
+        ]);
+        $output = new BufferedOutput();
+        $command = new Pkcs8ConverterCommand();
+        $command->run($input, $output);
+
+        return $output->fetch();
+    }
+
+    /**
+     * @return array{ec: array{d: string, x: string, y: string}}
+     */
+    private static function getKeyDetails(string $pem): array
+    {
+        $key = openssl_pkey_get_private($pem);
+        static::assertNotFalse($key, 'The PKCS#8 key is not readable by OpenSSL');
+        $details = openssl_pkey_get_details($key);
+        static::assertIsArray($details);
+
+        return $details;
+    }
+
+    /**
+     * Returns the binary value of the given parameter, left-padded to the size of the curve.
+     */
+    private static function getRawParameter(JWK $jwk, string $parameter, int $size): string
+    {
+        $value = $jwk->get($parameter);
+        static::assertIsString($value);
+
+        return str_pad(Base64UrlSafe::decodeNoPadding($value), $size, "\0", STR_PAD_LEFT);
     }
 }


### PR DESCRIPTION
Closes #661.

## What

Adds `key:convert:pkcs8`, the counterpart of the existing `key:convert:pkcs1`, so a JWK can be handed over to libraries that only import PKCS#8 private keys — the npm `jose` package being the one mentioned in the issue.

```console
$ bin/console key:convert:pkcs8 '{"kty":"EC","crv":"P-256","d":"...","x":"...","y":"..."}'
-----BEGIN PRIVATE KEY-----
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg...
-----END PRIVATE KEY-----
```

## How

| Key type | Private key | Public key |
|---|---|---|
| `RSA` | already produced by `RSAKey::toPEM()` | SubjectPublicKeyInfo |
| `EC` | new `ECKey::convertPrivateKeyToPKCS8PEM()` | SubjectPublicKeyInfo (existing) |
| `OKP` | new `OKPKey` utility | new `OKPKey` utility |

* **EC** — the RFC 5915 `ECPrivateKey` is wrapped into a `PrivateKeyInfo`. The curve is carried by the algorithm identifier only, so the optional `parameters` field of the inner structure is left out, exactly as OpenSSL does. Every curve of the framework is supported, the Brainpool ones included.
* **OKP** — `Ed25519`, `Ed448`, `X25519` and `X448`, built on the RFC 8410 types of `spomky-labs/pki-framework`. This is the first JWK to PEM conversion available for OKP keys.
* As PKCS#8 only covers private keys, public keys are converted into a SubjectPublicKeyInfo structure, which is what the consumers of PKCS#8 private keys expect on the public side.

## Tests

`tests/Component/Console/KeyConversionCommandTest.php` covers the three key types. For EC the generated PEM is parsed back with OpenSSL and the key material is compared parameter by parameter, for the seven supported curves. For RSA, OKP and the public keys the PEM is reloaded with `JWKFactory::createFromKey()` and compared to the source JWK.

The generated DER was also checked to be byte-identical to `openssl pkey`'s canonical PKCS#8 output for P-256, BP-512, Ed25519 and X25519.

## Notes

Two pre-existing points found while working on this, both left untouched:

* For RSA keys, `key:convert:pkcs1` already emits PKCS#8 (`RSAKey::toPEM()` builds a `PrivateKeyInfo`, and the existing test asserts `-----BEGIN PRIVATE KEY-----`). So `key:convert:pkcs1` and `key:convert:pkcs8` return the same thing for RSA. Making the former emit a real PKCS#1 `RSAPrivateKey` would be a behaviour change, so it is not part of this PR.
* `KeyManagement\KeyConverter\ECKey::getSupportedCurves()` does not list `secp256k1`, so a `secp256k1` PEM cannot be loaded back into a JWK. This already affects `key:convert:pkcs1` and is why the EC test asserts through OpenSSL rather than a round trip.