### PR TITLE
fix(core): bound the compact serializers' segment split

### DIFF
--- a/src/Library/Encryption/Serializer/CompactSerializer.php
+++ b/src/Library/Encryption/Serializer/CompactSerializer.php
@@ -54,10 +54,16 @@ final readonly class CompactSerializer implements JWESerializer
         );
     }
 
+    /**
+     * The split is bounded to six segments: a valid compact JWE has exactly five, so a sixth one is enough to
+     * detect and reject any longer input. Without that bound, a delimiter-heavy string would be expanded into one
+     * array entry per delimiter before the segment count is checked, which costs about twenty-five times the size
+     * of the input in memory.
+     */
     #[Override]
     public function unserialize(string $input): JWE
     {
-        $parts = explode('.', $input);
+        $parts = explode('.', $input, 6);
         if (count($parts) !== 5) {
             throw new InvalidArgumentException('Unsupported input');
         }

--- a/src/Library/Signature/Serializer/CompactSerializer.php
+++ b/src/Library/Signature/Serializer/CompactSerializer.php
@@ -58,10 +58,16 @@ final readonly class CompactSerializer extends Serializer
         );
     }
 
+    /**
+     * The split is bounded to four segments: a valid compact JWS has exactly three, so a fourth one is enough to
+     * detect and reject any longer input. Without that bound, a delimiter-heavy string would be expanded into one
+     * array entry per delimiter before the segment count is checked, which costs about twenty-five times the size
+     * of the input in memory.
+     */
     #[Override]
     public function unserialize(string $input): JWS
     {
-        $parts = explode('.', $input);
+        $parts = explode('.', $input, 4);
         if (count($parts) !== 3) {
             throw new InvalidArgumentException('Unsupported input');
         }

--- a/tests/Component/Encryption/CompactSerializerTest.php
+++ b/tests/Component/Encryption/CompactSerializerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Encryption;
+
+use InvalidArgumentException;
+use Jose\Component\Encryption\Serializer\CompactSerializer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function memory_get_peak_usage;
+use function memory_get_usage;
+use function memory_reset_peak_usage;
+use function str_repeat;
+
+/**
+ * @internal
+ */
+final class CompactSerializerTest extends TestCase
+{
+    #[Test]
+    public function aTokenWithTooManySegmentsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported input');
+
+        (new CompactSerializer())->unserialize('eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0.....');
+    }
+
+    /**
+     * A delimiter-heavy token must be rejected without expanding it into one array entry per delimiter. The
+     * threshold is deliberately generous: the unbounded split of this input allocates roughly twenty-five times its
+     * size, while the bounded one stays proportional to it.
+     */
+    #[Test]
+    public function aDelimiterHeavyTokenIsRejectedWithoutExhaustingMemory(): void
+    {
+        $token = str_repeat('.', 2_000_000);
+        $serializer = new CompactSerializer();
+        memory_reset_peak_usage();
+        $before = memory_get_usage();
+
+        try {
+            $serializer->unserialize($token);
+            static::fail('The token should have been rejected.');
+        } catch (InvalidArgumentException $e) {
+            static::assertSame('Unsupported input', $e->getMessage());
+        }
+
+        static::assertLessThan(8_000_000, memory_get_peak_usage() - $before);
+    }
+}

--- a/tests/Component/Signature/CompactSerializerTest.php
+++ b/tests/Component/Signature/CompactSerializerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Signature;
+
+use InvalidArgumentException;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function memory_get_peak_usage;
+use function memory_get_usage;
+use function memory_reset_peak_usage;
+use function str_repeat;
+
+/**
+ * @internal
+ */
+final class CompactSerializerTest extends TestCase
+{
+    #[Test]
+    public function aTokenWithTooManySegmentsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported input');
+
+        (new CompactSerializer())->unserialize('eyJhbGciOiJub25lIn0...');
+    }
+
+    /**
+     * A delimiter-heavy token must be rejected without expanding it into one array entry per delimiter. The
+     * threshold is deliberately generous: the unbounded split of this input allocates roughly twenty-five times its
+     * size, while the bounded one stays proportional to it.
+     */
+    #[Test]
+    public function aDelimiterHeavyTokenIsRejectedWithoutExhaustingMemory(): void
+    {
+        $token = str_repeat('.', 2_000_000);
+        $serializer = new CompactSerializer();
+        memory_reset_peak_usage();
+        $before = memory_get_usage();
+
+        try {
+            $serializer->unserialize($token);
+            static::fail('The token should have been rejected.');
+        } catch (InvalidArgumentException $e) {
+            static::assertSame('Unsupported input', $e->getMessage());
+        }
+
+        static::assertLessThan(8_000_000, memory_get_peak_usage() - $before);
+    }
+}


### PR DESCRIPTION
## What

The compact JWS and JWE serializers split the whole input on every `.` before checking the segment count, so a delimiter-heavy string was first expanded into one array entry per delimiter.

```php
$parts = explode('.', $input);      // one entry per delimiter, whatever the input
if (count($parts) !== 3) {          // …only then is the shape checked
    throw new InvalidArgumentException('Unsupported input');
}
```

The split is now bounded to one segment more than a valid token has — `4` for JWS, `6` for JWE. That extra segment is enough to detect and reject any longer input, so **the accepted and rejected inputs are unchanged**: `count($parts) !== 3` (resp. `!== 5`) still rejects everything it rejected before.

## Why

Reported by Team Atlanta as a memory-exhaustion issue on `JWSLoader::loadAndVerifyWithKeySet()`.

This is hardening rather than a vulnerability, so it is being fixed in the open with no advisory. The measured amplification is about 25×, which is the ordinary overhead of a PHP packed array and nothing more:

| input | `explode` without limit | with limit |
|---|---|---|
| 2 MB of `.` | 2 000 001 entries, ~48 MB | 4 entries, ~2 MB |

Reaching a real memory limit therefore requires an application to accept multi-megabyte bearer tokens with no length cap of its own. Worth fixing because the fix is free, not because the exposure is meaningful.

The report only covered JWS; `Encryption\Serializer\CompactSerializer` had the same shape and is fixed alongside it.

## Tests

`tests/Component/{Signature,Encryption}/CompactSerializerTest.php` cover the rejection of an over-long token and assert the allocation stays bounded. Both regression tests fail without the fix (33.5 MB allocated) and pass with it.

Note for anyone touching them: the bound has to be measured with `memory_reset_peak_usage()` + `memory_get_peak_usage()`. A plain `memory_get_usage()` delta reads as zero, because the array is freed as the exception unwinds.

## Notes on the branch state

Unrelated to this change, but visible when validating it on `4.1.x`:

- The full suite has 40 pre-existing failures (Symfony bundle configuration tests, plus `ComposerJsonTest` diverging on the `brick/math` constraint). This PR adds none — checked against a stashed baseline.
- ECS does not start at all on `4.1.x`: `Undefined constant SetList::PHPUNIT`, hidden behind a crash in its own error printer. That was repaired on `4.2.x` in #669 and never backported.
- PHPStan runs and reports 42 pre-existing errors, none on the files touched here.

Reported by Team Atlanta.
