### PR TITLE
feat(signature): accept an already Base64Url encoded payload in JWSBuilder

### DIFF
--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -14,6 +14,7 @@ use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
 use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
 use LogicException;
+use RangeException;
 use RuntimeException;
 use function array_key_exists;
 use function count;
@@ -40,6 +41,14 @@ class JWSBuilder
 
     protected ?bool $isPayloadEncoded = null;
 
+    /**
+     * Indicates the payload was Base64Url encoded by the caller.
+     *
+     * This is not the "b64" header parameter, which removes the encoding altogether: here the payload is encoded as
+     * usual, the builder simply did not compute that encoding itself.
+     */
+    protected bool $isPayloadAlreadyEncoded = false;
+
     public function __construct(
         private readonly AlgorithmManager $signatureAlgorithmManager
     ) {
@@ -62,6 +71,7 @@ class JWSBuilder
         $this->isPayloadDetached = false;
         $this->signatures = [];
         $this->isPayloadEncoded = null;
+        $this->isPayloadAlreadyEncoded = false;
 
         return $this;
     }
@@ -74,6 +84,40 @@ class JWSBuilder
         $clone = clone $this;
         $clone->payload = $payload;
         $clone->isPayloadDetached = $isPayloadDetached;
+        $clone->isPayloadAlreadyEncoded = false;
+
+        return $clone;
+    }
+
+    /**
+     * Set a payload that is already Base64Url encoded. This method will return a new JWSBuilder object.
+     *
+     * Use it when the payload is only available in its encoded form, so that it is not encoded a second time. The
+     * value is decoded and must be a canonical Base64Url string without padding, the only form this library produces
+     * and accepts everywhere else.
+     *
+     * @throws InvalidArgumentException if the payload is not a canonical Base64Url string without padding
+     */
+    public function withEncodedPayload(string $payload, bool $isPayloadDetached = false): self
+    {
+        if ($this->isPayloadEncoded === false) {
+            throw new InvalidArgumentException(
+                'An encoded payload cannot be used when the protected header parameter "b64" is set to false.'
+            );
+        }
+        try {
+            $decodedPayload = Base64UrlSafe::decodeNoPadding($payload);
+        } catch (InvalidArgumentException|RangeException $throwable) {
+            throw new InvalidArgumentException(
+                'The payload must be a Base64Url encoded string without padding.',
+                0,
+                $throwable
+            );
+        }
+        $clone = clone $this;
+        $clone->payload = $decodedPayload;
+        $clone->isPayloadDetached = $isPayloadDetached;
+        $clone->isPayloadAlreadyEncoded = true;
 
         return $clone;
     }
@@ -88,6 +132,11 @@ class JWSBuilder
     {
         $this->checkB64AndCriticalHeader($protectedHeader);
         $isPayloadEncoded = $this->checkIfPayloadIsEncoded($protectedHeader);
+        if ($this->isPayloadAlreadyEncoded && $isPayloadEncoded === false) {
+            throw new InvalidArgumentException(
+                'An encoded payload cannot be used when the protected header parameter "b64" is set to false.'
+            );
+        }
         if ($this->isPayloadEncoded === null) {
             $this->isPayloadEncoded = $isPayloadEncoded;
         } elseif ($this->isPayloadEncoded !== $isPayloadEncoded) {

--- a/tests/Component/Signature/SignerTest.php
+++ b/tests/Component/Signature/SignerTest.php
@@ -10,6 +10,7 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use const JSON_THROW_ON_ERROR;
 
@@ -1015,6 +1016,169 @@ final class SignerTest extends SignatureTestCase
         static::assertTrue($jwsVerifier->verifyWithKey($loaded, new JWK([
             'kty' => 'EC',
         ]), 1));
+    }
+
+    /**
+     * A payload that is only available in its encoded form is signed as is, and not encoded a second time.
+     *
+     * @see https://github.com/web-token/jwt-framework/pull/329
+     */
+    #[Test]
+    public function jWSWithEncodedPayload(): void
+    {
+        $payload = hash('sha256', '{"user":"nemo"}', true);
+        $encodedPayload = Base64UrlSafe::encodeUnpadded($payload);
+
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+
+        $jwsBuilder = $this->getJWSBuilderFactory()
+            ->create(['HS256']);
+        $jws = $jwsBuilder
+            ->create()
+            ->withEncodedPayload($encodedPayload)
+            ->addSignature($key, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        $compact = $this->getJWSSerializerManager()
+            ->serialize('jws_compact', $jws, 0);
+        static::assertSame(
+            'eyJhbGciOiJIUzI1NiJ9.YXQplEYQHShAnWp_r3yZ84_plbxXR8LtwNNQ-LltjoM.ZBepdsr35k9RpfD5FQPTWBskZorDj1Crq5dsRlxkh6s',
+            $compact
+        );
+        static::assertSame($encodedPayload, $jws->getEncodedPayload());
+        static::assertSame($payload, $jws->getPayload());
+
+        $loaded = $this->getJWSSerializerManager()
+            ->unserialize($compact);
+        static::assertTrue(
+            $this->getJWSVerifierFactory()
+                ->create(['HS256'])
+                ->verifyWithKey($loaded, $key, 0)
+        );
+    }
+
+    /**
+     * Both ways of setting the payload describe the same JWS, whichever form the caller has at hand.
+     */
+    #[Test]
+    public function jWSWithEncodedPayloadIsTheSameAsWithTheDecodedPayload(): void
+    {
+        $payload = hash('sha256', '{"user":"nemo"}', true);
+
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+
+        $jwsBuilder = $this->getJWSBuilderFactory()
+            ->create(['HS256']);
+        $fromEncodedPayload = $jwsBuilder
+            ->create()
+            ->withEncodedPayload(Base64UrlSafe::encodeUnpadded($payload))
+            ->addSignature($key, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+        $fromPayload = $jwsBuilder
+            ->create()
+            ->withPayload($payload)
+            ->addSignature($key, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertSame(
+            $this->getJWSSerializerManager()
+                ->serialize('jws_compact', $fromPayload, 0),
+            $this->getJWSSerializerManager()
+                ->serialize('jws_compact', $fromEncodedPayload, 0)
+        );
+    }
+
+    /**
+     * Anything this library would not produce itself is rejected, as the serializers refuse to load it back.
+     */
+    #[Test]
+    #[DataProvider('invalidEncodedPayloads')]
+    public function jWSWithInvalidEncodedPayload(string $encodedPayload): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The payload must be a Base64Url encoded string without padding.');
+
+        $jwsBuilder = $this->getJWSBuilderFactory()
+            ->create(['HS256']);
+        $jwsBuilder
+            ->create()
+            ->withEncodedPayload($encodedPayload);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidEncodedPayloads(): iterable
+    {
+        yield 'not encoded at all' => ['{"iss":"me"}'];
+        yield 'Base64 instead of Base64Url' => ['eA/B'];
+        yield 'padded' => ['eA=='];
+        yield 'impossible length' => ['a'];
+        yield 'non-canonical trailing bits' => ['eB'];
+        yield 'trailing newline' => ["eA\n"];
+    }
+
+    #[Test]
+    public function jWSWithEncodedPayloadAndUnencodedPayloadHeader(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'An encoded payload cannot be used when the protected header parameter "b64" is set to false.'
+        );
+
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+
+        $jwsBuilder = $this->getJWSBuilderFactory()
+            ->create(['HS256']);
+        $jwsBuilder
+            ->create()
+            ->withEncodedPayload('YWJj')
+            ->addSignature($key, [
+                'alg' => 'HS256',
+                'b64' => false,
+                'crit' => ['b64'],
+            ])
+            ->build();
+    }
+
+    #[Test]
+    public function jWSWithUnencodedPayloadHeaderAndEncodedPayload(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'An encoded payload cannot be used when the protected header parameter "b64" is set to false.'
+        );
+
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+
+        $jwsBuilder = $this->getJWSBuilderFactory()
+            ->create(['HS256']);
+        $jwsBuilder
+            ->create()
+            ->addSignature($key, [
+                'alg' => 'HS256',
+                'b64' => false,
+                'crit' => ['b64'],
+            ])
+            ->withEncodedPayload('YWJj');
     }
 
     private function getKey1(): JWK


### PR DESCRIPTION
Target branch: 4.2.x
Resolves issue #329

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

---

This picks up @aaronpk's #329, opened in January 2022 against 2.2.x. The idea, the method name and the use case are his. The implementation is new, because the builder changed a lot since then and because the original patch had a gap I would rather not ship.

## What it does

`JWSBuilder::withEncodedPayload()` sets a payload that is already Base64Url encoded, so the builder does not encode it a second time.

```php
$jws = $jwsBuilder->create()
    ->withEncodedPayload(Base64UrlSafe::encodeUnpadded(hash('sha256', $body, true)))
    ->addSignature($key, ['alg' => 'HS256'])
    ->build();
```

The motivating case is GNAP request signing (now RFC 9635): the JWS payload is the Base64Url encoded SHA-256 hash of the request body, and that encoded string is what the caller has at hand.

## Why not the original patch

It no longer applies. `addSignature()` now reconciles the payload encoding across signatures, so setting `isPayloadEncoded = false` from the builder and then adding a signature with no `b64` header raises `Foreign payload encoding detected.` — the test shipped in #329 would fail on 4.x.

And it did not validate its input: `withEncodedPayload('{"iss":"me"}')` would have produced a JWS that no verifier can decode, silently.

## The contract

I first tried to preserve the encoded payload byte for byte, which would have allowed a JWS issued elsewhere to be signed again with a non-canonical encoding left intact. `CompactSerializer::unserialize()` uses `Base64UrlSafe::decodeNoPadding()` and rejects exactly that, so the builder would have been able to emit tokens the library itself cannot read back.

The input must therefore be canonical. It goes through `decodeNoPadding()`, and padding, the Base64 alphabet, impossible lengths and non-canonical trailing bits are all rejected. `withEncodedPayload($x)` is then equivalent in output to `withPayload(Base64UrlSafe::decodeNoPadding($x))`; what it adds is that the intent is explicit and checked, where `withPayload()` on an encoded string encodes it twice without a word.

An encoded payload contradicts `b64: false`, which removes the encoding altogether. The combination is rejected whichever order the two are set in.

## Tests

Five new test methods in `SignerTest` (ten cases with the data provider), no existing test modified: the nominal build and its round trip through the compact serializer, the equivalence with `withPayload()` on the decoded value, the six rejected inputs, and the two `b64: false` orders.

PHPUnit 868 tests green, PHPStan at level max, ECS and Rector clean.
