### PR TITLE
fix(signature): apply the payload encoding to the clone, not the receiver

### DIFF
--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -137,16 +137,16 @@ class JWSBuilder
                 'An encoded payload cannot be used when the protected header parameter "b64" is set to false.'
             );
         }
-        if ($this->isPayloadEncoded === null) {
-            $this->isPayloadEncoded = $isPayloadEncoded;
-        } elseif ($this->isPayloadEncoded !== $isPayloadEncoded) {
+        $clone = clone $this;
+        if ($clone->isPayloadEncoded === null) {
+            $clone->isPayloadEncoded = $isPayloadEncoded;
+        } elseif ($clone->isPayloadEncoded !== $isPayloadEncoded) {
             throw new InvalidArgumentException('Foreign payload encoding detected.');
         }
         $this->checkDuplicatedHeaderParameters($protectedHeader, $header);
         KeyChecker::checkKeyUsage($signatureKey, 'signature');
         $algorithm = $this->findSignatureAlgorithm($signatureKey, $protectedHeader, $header);
         KeyChecker::checkKeyAlgorithm($signatureKey, $algorithm->name());
-        $clone = clone $this;
         $clone->signatures[] = [
             'signature_algorithm' => $algorithm,
             'signature_key' => $signatureKey,

--- a/tests/Component/Signature/SignerTest.php
+++ b/tests/Component/Signature/SignerTest.php
@@ -1181,6 +1181,41 @@ final class SignerTest extends SignatureTestCase
             ->withEncodedPayload('YWJj');
     }
 
+    /**
+     * The builder is immutable: the "b64" mode is carried by the objects returned by addSignature(), never pinned on
+     * the receiver. The bundle registers the builder as a shared service, so a first build with an unencoded payload
+     * must not prevent any later, unrelated build from using the default encoding.
+     */
+    #[Test]
+    public function theBuilderInstanceIsNotPinnedToTheFirstPayloadEncoding(): void
+    {
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+
+        $jwsBuilder = $this->getJWSBuilderFactory()
+            ->create(['HS256']);
+
+        $jwsBuilder->addSignature($key, [
+            'alg' => 'HS256',
+            'b64' => false,
+            'crit' => ['b64'],
+        ]);
+
+        $jws = $jwsBuilder->withPayload('$.02')
+            ->addSignature($key, [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertSame(
+            'eyJhbGciOiJIUzI1NiJ9.JC4wMg.5mvfOroL-g7HyqJoozehmsaqmvTYGEq5jTI1gVvoEoQ',
+            $this->getJWSSerializerManager()
+                ->serialize('jws_compact', $jws, 0)
+        );
+    }
+
     private function getKey1(): JWK
     {
         return new JWK([


### PR DESCRIPTION
Fixes #679.

`JWSBuilder::addSignature()` is documented as immutable ("This method will return a new JWSBuilder object") but it wrote `isPayloadEncoded` on `$this` before cloning:

```php
if ($this->isPayloadEncoded === null) {
    $this->isPayloadEncoded = $isPayloadEncoded;   // mutates the receiver
} elseif ($this->isPayloadEncoded !== $isPayloadEncoded) {
    throw new InvalidArgumentException('Foreign payload encoding detected.');
}
```

The bundle registers the builder as a shared service, so a single `addSignature()` call on the injected instance permanently pinned the `b64` mode of that service: every later, unrelated build failed with `Foreign payload encoding detected.`.

The clone is now created before the state transition and the transition applied to it, exactly as `JWEBuilder::addRecipient()` already does with `checkAndSetContentEncryptionAlgorithm()`. The check order is unchanged, so the exceptions raised on invalid input are the same as before.

The regression test reuses one builder instance across two independent builds; it fails with `Foreign payload encoding detected.` on `4.2.x` and passes with the fix.

The wider redesign — making the builders genuinely immutable so the `create()` reset becomes unnecessary — stays tracked for 4.3.0.

### Checks

- `phpunit -c .ci-tools/phpunit.xml.dist`: 869 tests, 2541 assertions, OK (the 2 incomplete tests are pre-existing)
- ECS, PHPStan and Rector: clean