### PR TITLE
fix(encryption): allow a sender key with a static key agreement

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4491,7 +4491,7 @@ parameters:
 		-
 			rawMessage: Cannot access offset 'key_encryption_algorithm' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 2
 			path: ../src/Library/Encryption/JWEBuilder.php
 
 		-

--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -184,26 +184,17 @@ class JWEBuilder
         return $clone;
     }
 
-    // TODO: Verify if the key is compatible with the key encryption algorithm like is done to the ECDH-ES
     /**
-     * Set the sender JWK to be used instead of the internal generated JWK
+     * Set the sender JWK to be used instead of the internal generated JWK.
+     *
+     * The sender key does not add a recipient: it takes no part in the key management mode compatibility
+     * check, otherwise a static key agreement algorithm such as ECDH-SS would be rejected as a foreign key
+     * management mode. The key itself is verified by build(), where the recipients and the content
+     * encryption algorithm are known whatever the call order is.
      */
     public function withSenderKey(JWK $senderKey): self
     {
         $clone = clone $this;
-        $completeHeader = array_merge($clone->sharedHeader, $clone->sharedProtectedHeader);
-        $keyEncryptionAlgorithm = $clone->getKeyEncryptionAlgorithm($completeHeader);
-        if ($clone->keyManagementMode === null) {
-            $clone->keyManagementMode = $keyEncryptionAlgorithm->getKeyManagementMode();
-        } else {
-            if (! $clone->areKeyManagementModesCompatible(
-                $clone->keyManagementMode,
-                $keyEncryptionAlgorithm->getKeyManagementMode()
-            )) {
-                throw new InvalidArgumentException('Foreign key management mode forbidden.');
-            }
-        }
-        $clone->checkKey($keyEncryptionAlgorithm, $senderKey);
         $clone->senderKey = $senderKey;
 
         return $clone;
@@ -220,6 +211,7 @@ class JWEBuilder
         if (count($this->recipients) === 0) {
             throw new LogicException('No recipient.');
         }
+        $this->checkSenderKey();
 
         $additionalHeader = [];
         $cek = $this->determineCEK($additionalHeader);
@@ -403,6 +395,26 @@ class JWEBuilder
         return $keyEncryptionAlgorithm->wrapKey($recipientKey, $cek, $completeHeader, $additionalHeader);
     }
 
+    /**
+     * The sender key is shared by all the recipients: it is verified against the key encryption algorithm of
+     * each of them. Nothing is done when no sender key is set or when the key encryption algorithm does not
+     * use one.
+     */
+    private function checkSenderKey(): void
+    {
+        $senderKey = $this->senderKey;
+        if ($senderKey === null) {
+            return;
+        }
+        foreach ($this->recipients as $recipient) {
+            $keyEncryptionAlgorithm = $recipient['key_encryption_algorithm'];
+            if (! $keyEncryptionAlgorithm instanceof KeyEncryptionAlgorithm) {
+                throw new InvalidArgumentException('The key encryption algorithm is not valid');
+            }
+            $this->checkKey($keyEncryptionAlgorithm, $senderKey);
+        }
+    }
+
     private function checkKey(KeyEncryptionAlgorithm $keyEncryptionAlgorithm, JWK $recipientKey): void
     {
         if ($this->contentEncryptionAlgorithm === null) {
@@ -435,7 +447,7 @@ class JWEBuilder
                     );
                 }
                 $recipientKey = $this->recipients[0]['key'];
-                $senderKey = $this->recipients[0]['sender_key'] ?? null;
+                $senderKey = $this->recipients[0]['sender_key'] ?? $this->senderKey;
                 $algorithm = $this->recipients[0]['key_encryption_algorithm'];
                 if (! $algorithm instanceof KeyAgreement) {
                     throw new InvalidArgumentException('Invalid content encryption algorithm');

--- a/src/Library/Encryption/JWEDecrypter.php
+++ b/src/Library/Encryption/JWEDecrypter.php
@@ -67,12 +67,14 @@ class JWEDecrypter
      * @param JWE $jwe A JWE object to decrypt
      * @param JWK $jwk The key used to decrypt the input
      * @param int $recipient The recipient used to decrypt the token
+     * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
      */
     public function decryptUsingKey(JWE &$jwe, JWK $jwk, int $recipient, ?JWK $senderKey = null): bool
     {
         $jwkset = new JWKSet([$jwk]);
+        $successJwk = null;
 
-        return $this->decryptUsingKeySet($jwe, $jwkset, $recipient, $senderKey);
+        return $this->decryptUsingKeySet($jwe, $jwkset, $recipient, $successJwk, $senderKey);
     }
 
     /**

--- a/tests/Component/Encryption/JWEBuilderSenderKeyTest.php
+++ b/tests/Component/Encryption/JWEBuilderSenderKeyTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Encryption;
+
+use InvalidArgumentException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Encryption\JWE;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Class JWEBuilderSenderKeyTest.
+ *
+ * The static key agreement algorithms derive the agreement key from the two static keys. On the decryption
+ * side the roles are swapped: the public key of the sender is the key of the key set and the private key of
+ * the recipient is the sender key, as the "epk" header parameter is not part of the token.
+ *
+ * @internal
+ */
+final class JWEBuilderSenderKeyTest extends EncryptionTestCase
+{
+    private const PAYLOAD = 'Live long and prosper.';
+
+    #[Test]
+    public function theSenderKeyCanBeSetBeforeTheRecipient(): void
+    {
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['ECDH-SS', 'A128CBC-HS256']);
+
+        $jwe = $jweBuilder
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'ECDH-SS',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->withSenderKey($this->getSenderKey())
+            ->addRecipient($this->getRecipientKey()->toPublic())
+            ->build();
+
+        static::assertFalse($jwe->hasSharedProtectedHeaderParameter('epk'));
+        static::assertSame(self::PAYLOAD, $this->decrypt($jwe, ['ECDH-SS', 'A128CBC-HS256']));
+    }
+
+    #[Test]
+    public function theSenderKeyCanBeSetAfterTheRecipient(): void
+    {
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['ECDH-SS', 'A128CBC-HS256']);
+
+        $jwe = $jweBuilder
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'ECDH-SS',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->addRecipient($this->getRecipientKey()->toPublic())
+            ->withSenderKey($this->getSenderKey())
+            ->build();
+
+        static::assertFalse($jwe->hasSharedProtectedHeaderParameter('epk'));
+        static::assertSame(self::PAYLOAD, $this->decrypt($jwe, ['ECDH-SS', 'A128CBC-HS256']));
+    }
+
+    #[Test]
+    public function aDirectStaticKeyAgreementRequiresASenderKey(): void
+    {
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['ECDH-SS', 'A128CBC-HS256']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The sender key shall be set');
+
+        $jweBuilder
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'ECDH-SS',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->addRecipient($this->getRecipientKey()->toPublic())
+            ->build();
+    }
+
+    #[Test]
+    public function theSenderKeyIsUsedWithAStaticKeyAgreementWithKeyWrapping(): void
+    {
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['ECDH-SS+A128KW', 'A128CBC-HS256']);
+
+        $jwe = $jweBuilder
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'ECDH-SS+A128KW',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->withSenderKey($this->getSenderKey())
+            ->addRecipient($this->getRecipientKey()->toPublic())
+            ->build();
+
+        static::assertFalse($jwe->hasSharedProtectedHeaderParameter('epk'));
+        static::assertSame(self::PAYLOAD, $this->decrypt($jwe, ['ECDH-SS+A128KW', 'A128CBC-HS256']));
+    }
+
+    #[Test]
+    public function theSenderKeyReplacesTheEphemeralKeyOfAnEphemeralStaticKeyAgreement(): void
+    {
+        $senderKey = $this->getSenderKey();
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['ECDH-ES', 'A128CBC-HS256']);
+
+        $jwe = $jweBuilder
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'ECDH-ES',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->withSenderKey($senderKey)
+            ->addRecipient($this->getRecipientKey()->toPublic())
+            ->build();
+
+        static::assertSame($senderKey->toPublic()->all(), $jwe->getSharedProtectedHeaderParameter('epk'));
+
+        $jweDecrypter = $this->getJWEDecrypterFactory()
+            ->create(['ECDH-ES', 'A128CBC-HS256']);
+        $loaded = $this->getJWESerializerManager()
+            ->unserialize($this->getJWESerializerManager()->serialize('jwe_compact', $jwe, 0));
+        static::assertTrue($jweDecrypter->decryptUsingKey($loaded, $this->getRecipientKey(), 0));
+        static::assertSame(self::PAYLOAD, $loaded->getPayload());
+    }
+
+    #[Test]
+    public function theSenderKeyIsVerifiedWhenTheTokenIsBuilt(): void
+    {
+        $senderKey = new JWK($this->getSenderKey()->all() + [
+            'use' => 'sig',
+        ]);
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['ECDH-SS', 'A128CBC-HS256']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Key cannot be used to encrypt or decrypt.');
+
+        $jweBuilder
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'ECDH-SS',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->withSenderKey($senderKey)
+            ->addRecipient($this->getRecipientKey()->toPublic())
+            ->build();
+    }
+
+    /**
+     * @param array<string> $algorithms
+     */
+    private function decrypt(JWE $jwe, array $algorithms): ?string
+    {
+        $serializerManager = $this->getJWESerializerManager();
+        $loaded = $serializerManager->unserialize($serializerManager->serialize('jwe_compact', $jwe, 0));
+        $jweDecrypter = $this->getJWEDecrypterFactory()
+            ->create($algorithms);
+        static::assertTrue(
+            $jweDecrypter->decryptUsingKey($loaded, $this->getSenderKey()->toPublic(), 0, $this->getRecipientKey())
+        );
+
+        return $loaded->getPayload();
+    }
+
+    private function getSenderKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => 'OSo9FXcQCqDR6G3INwuMZn9_StSV6eLKn1KQIWufuyA',
+            'y' => 'c4v6g44omMI_949wkYtJSG_pOyhyqqqJ7zqqdv5vwGU',
+            'd' => 'xBRebaWQIa9DAxChfcOGDnfM39RMILisUxW16XHVN7c',
+        ]);
+    }
+
+    private function getRecipientKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => 'weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ',
+            'y' => 'e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck',
+            'd' => 'VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw',
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #680.

`JWEBuilder::withSenderKey()` could not be used with a direct static key agreement such as `ECDH-SS`, and
the sender key was dropped even when the mode check was passed.

### What was wrong

- `withSenderKey()` derived the key management mode from the shared headers and checked the key against it.
  Called **before** `addRecipient()` it threw `Invalid content encryption algorithm`, because `checkKey()`
  needs the content encryption algorithm and only `addRecipient()` sets it. Called **after** it threw
  `Foreign key management mode forbidden.`, because `agree` + `agree` is not a supported combination.
- `determineCEK()` read the sender key from `$this->recipients[0]['sender_key']`, an entry that is never
  written anywhere, so a direct key agreement always reached `ECDHSS::getAgreementKey()` with no sender key
  and threw `The sender key shall be set`. `processRecipient()` did not have the problem thanks to its
  `?? $this->senderKey` fallback, which is why `ECDH-SS+A128KW` and friends worked.
- `JWEDecrypter::decryptUsingKey()` passed `$senderKey` as the fourth argument of `decryptUsingKeySet()`,
  which is the `&$jwk` **output** parameter. The sender key never reached the algorithm, so a token built
  with a static key agreement could not be decrypted back through that method. Found while writing the
  round-trip test: without this one, the builder fix produces tokens nothing can read.

### What changed

- `withSenderKey()` only stores the key. The sender key does not add a recipient, so it must not go through
  the key management mode compatibility matrix.
- The key is verified by `build()` (new `checkSenderKey()`), against the key encryption algorithm of each
  recipient, where the content encryption algorithm is known whatever the call order is. This also settles
  the `TODO` that sat on top of the method.
- `determineCEK()` falls back to `$this->senderKey` like `processRecipient()` does.
- `decryptUsingKey()` passes the sender key in the right position.

### Tests

`tests/Component/Encryption/JWEBuilderSenderKeyTest.php` — `withSenderKey()` had no coverage at all and no
test exercised `ECDH-SS`. Six cases: sender key set before and after `addRecipient()` with an `ECDH-SS`
round trip, missing sender key, `ECDH-SS+A128KW`, `ECDH-ES` where the sender key replaces the ephemeral key
(the published `epk` is the given key), and the deferred key check at build time. Five of the six fail on
`4.2.x`.

Note for the reviewer: on the decryption side of a static key agreement the roles are swapped — the public
key of the sender is the key of the key set and the private key of the recipient is the sender key, since
`epk` is not part of the token. That is the existing convention of `ECDHSSAESKW` and its tests, not
something introduced here.

### Checks

Full test suite (874 tests), ECS and PHPStan are green. One PHPStan baseline entry goes from `count: 1` to
`2` (`Cannot access offset 'key_encryption_algorithm' on mixed`): `$recipients` is an untyped array and the
new loop adds one more access already covered by that rule.
