### PR TITLE
fix(core): keep every key of a set sharing the same "kid"

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4255,12 +4255,6 @@ parameters:
 			path: ../src/Library/Core/JWKSet.php
 
 		-
-			rawMessage: Possibly invalid array key type mixed.
-			identifier: offsetAccess.invalidOffset
-			count: 3
-			path: ../src/Library/Core/JWKSet.php
-
-		-
 			rawMessage: Property Jose\Component\Core\JWKSet::$keys type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Library/Core/JWKSet.php
+++ b/src/Library/Core/JWKSet.php
@@ -14,6 +14,7 @@ use function array_key_exists;
 use function count;
 use function in_array;
 use function is_array;
+use function is_int;
 use function is_string;
 use function sprintf;
 use const COUNT_NORMAL;
@@ -28,17 +29,12 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
      */
     public function __construct(array $keys)
     {
-        foreach ($keys as $k => $key) {
+        foreach ($keys as $key) {
             if (! $key instanceof JWK) {
                 throw new InvalidArgumentException('Invalid list. Should only contains JWK objects');
             }
 
-            if ($key->has('kid')) {
-                unset($keys[$k]);
-                $this->keys[$key->get('kid')] = $key;
-            } else {
-                $this->keys[] = $key;
-            }
+            $this->add($key);
         }
     }
 
@@ -56,12 +52,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
 
         $jwkset = new self([]);
         foreach ($data['keys'] as $key) {
-            $jwk = new JWK($key);
-            if ($jwk->has('kid')) {
-                $jwkset->keys[$jwk->get('kid')] = $jwk;
-            } else {
-                $jwkset->keys[] = $jwk;
-            }
+            $jwkset->add(new JWK($key));
         }
 
         return $jwkset;
@@ -91,17 +82,13 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
-     * Add key to store in the key set. This method is immutable and will return a new object.
+     * Add key to store in the key set. This method is immutable and will return a new object. A key is never replaced:
+     * adding a key that carries an already used "kid" appends it to the key set.
      */
     public function with(JWK $jwk): self
     {
         $clone = clone $this;
-
-        if ($jwk->has('kid')) {
-            $clone->keys[$jwk->get('kid')] = $jwk;
-        } else {
-            $clone->keys[] = $jwk;
-        }
+        $clone->add($jwk);
 
         return $clone;
     }
@@ -109,34 +96,39 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Remove key from the key set. This method is immutable and will return a new object.
      *
-     * @param int|string $key Key to remove from the key set
+     * @param int|string $key Key to remove from the key set. When several keys share the same "kid", only the first
+     * one is removed
      */
     public function without(int|string $key): self
     {
-        if (! $this->has($key)) {
+        $index = $this->indexOf($key);
+        if ($index === null) {
             return $this;
         }
 
         $clone = clone $this;
-        unset($clone->keys[$key]);
+        unset($clone->keys[$index]);
 
         return $clone;
     }
 
     /**
-     * Returns true if the key set contains a key with the given index.
+     * Returns true if the key set contains a key with the given index or, when a string is given, a key with that
+     * "kid".
      */
     public function has(int|string $index): bool
     {
-        return array_key_exists($index, $this->keys);
+        return $this->indexOf($index) !== null;
     }
 
     /**
-     * Returns the key with the given index. Throws an exception if the index is not present in the key store.
+     * Returns the key with the given index. When several keys share the same "kid", the first one is returned. Throws
+     * an exception if the index is not present in the key store.
      */
     public function get(int|string $index): JWK
     {
-        if (! $this->has($index)) {
+        $index = $this->indexOf($index);
+        if ($index === null) {
             throw new InvalidArgumentException('Undefined index.');
         }
 
@@ -229,6 +221,47 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->keys);
+    }
+
+    /**
+     * Stores the given key. Keys carrying a "kid" are indexed by that "kid", unless that index is already in use. As
+     * stated by the RFC7517 section 4.5, several keys of a key set may share the same "kid": such keys are appended to
+     * the key set instead of replacing the ones already stored.
+     */
+    private function add(JWK $jwk): void
+    {
+        if ($jwk->has('kid')) {
+            $kid = $jwk->get('kid');
+            if ((is_string($kid) || is_int($kid)) && ! array_key_exists($kid, $this->keys)) {
+                $this->keys[$kid] = $jwk;
+
+                return;
+            }
+        }
+
+        $this->keys[] = $jwk;
+    }
+
+    /**
+     * Resolves the given index into an internal key of the key store, or null when the key set has no such key. A
+     * string index that is not used as an index is compared against the "kid" of every key, so that keys sharing a
+     * "kid" with an already indexed key remain reachable.
+     */
+    private function indexOf(int|string $index): int|string|null
+    {
+        if (array_key_exists($index, $this->keys)) {
+            return $index;
+        }
+        if (is_int($index)) {
+            return null;
+        }
+        foreach ($this->all() as $key => $jwk) {
+            if ($jwk->has('kid') && $jwk->get('kid') === $index) {
+                return $key;
+            }
+        }
+
+        return null;
     }
 
     private function canKeyBeUsedFor(string $type, JWK $key): bool|int

--- a/tests/Component/Core/JWKSetTest.php
+++ b/tests/Component/Core/JWKSetTest.php
@@ -196,6 +196,128 @@ final class JWKSetTest extends TestCase
     }
 
     #[Test]
+    public function keysSharingTheSameKidAreAllKept(): void
+    {
+        $jwkset = new JWKSet([
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'k1',
+                'k' => 'AAAA',
+            ]),
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'k1',
+                'k' => 'BBBB',
+            ]),
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'k2',
+                'k' => 'CCCC',
+            ]),
+        ]);
+
+        static::assertCount(3, $jwkset);
+        static::assertSame(
+            '{"keys":[{"kty":"oct","kid":"k1","k":"AAAA"},{"kty":"oct","kid":"k1","k":"BBBB"},{"kty":"oct","kid":"k2","k":"CCCC"}]}',
+            json_encode($jwkset, JSON_THROW_ON_ERROR)
+        );
+        static::assertTrue($jwkset->has('k1'));
+        static::assertSame('AAAA', $jwkset->get('k1')->get('k'));
+    }
+
+    #[Test]
+    public function keysSharingTheSameKidAreAllKeptWhenCreatedFromKeyData(): void
+    {
+        $jwkset = JWKSet::createFromKeyData([
+            'keys' => [
+                [
+                    'kty' => 'oct',
+                    'kid' => 'k1',
+                    'k' => 'AAAA',
+                ],
+                [
+                    'kty' => 'oct',
+                    'kid' => 'k1',
+                    'k' => 'BBBB',
+                ],
+            ],
+        ]);
+
+        static::assertCount(2, $jwkset);
+        static::assertSame('AAAA', $jwkset->get('k1')->get('k'));
+    }
+
+    #[Test]
+    public function keysSharingTheSameKidAreAllKeptWhenAddedOneByOne(): void
+    {
+        $jwkset = new JWKSet([]);
+        $jwkset = $jwkset->with(new JWK([
+            'kty' => 'oct',
+            'kid' => 'k1',
+            'k' => 'AAAA',
+        ]));
+        $jwkset = $jwkset->with(new JWK([
+            'kty' => 'oct',
+            'kid' => 'k1',
+            'k' => 'BBBB',
+        ]));
+
+        static::assertCount(2, $jwkset);
+        static::assertSame('AAAA', $jwkset->get('k1')->get('k'));
+    }
+
+    #[Test]
+    public function keysSharingTheSameKidAreRemovedOneByOne(): void
+    {
+        $jwkset = new JWKSet([
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'k1',
+                'k' => 'AAAA',
+            ]),
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'k1',
+                'k' => 'BBBB',
+            ]),
+        ]);
+
+        $jwkset = $jwkset->without('k1');
+        static::assertCount(1, $jwkset);
+        static::assertTrue($jwkset->has('k1'));
+        static::assertSame('BBBB', $jwkset->get('k1')->get('k'));
+
+        $jwkset = $jwkset->without('k1');
+        static::assertCount(0, $jwkset);
+        static::assertFalse($jwkset->has('k1'));
+    }
+
+    #[Test]
+    public function aKeySharingTheKidOfAnUnusableKeyCanStillBeSelected(): void
+    {
+        $jwkset = new JWKSet([
+            new JWK([
+                'kty' => 'BAR',
+                'kid' => 'k1',
+                'use' => 'sig',
+            ]),
+            new JWK([
+                'kty' => 'FOO',
+                'kid' => 'k1',
+                'alg' => 'foo',
+                'use' => 'sig',
+            ]),
+        ]);
+
+        $jwk = $jwkset->selectKey('sig', new FooAlgorithm(), [
+            'kid' => 'k1',
+        ]);
+
+        static::assertInstanceOf(JWK::class, $jwk);
+        static::assertSame('FOO', $jwk->get('kty'));
+    }
+
+    #[Test]
     public function keySet2(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
Fixes #682.

## Problem

`JWKSet` indexes its keys by `kid`, so two keys carrying the same one overwrite each other and the second silently wins. RFC 7517 §4.5 explicitly allows a key set to hold several keys with the same `kid` — typically an RSA key and an EC key considered as equivalent alternatives by the application. A JWKS served that way loses one of the two on load, and `selectKey()` can then fail to find any usable key.

## Why not the list-based indexing suggested in the issue

The issue proposed storing the keys in a plain list and resolving `kid` lookups on demand, with the caveat that it had to be validated against the test suite first. It does not survive it: `has(0)` currently returns `false` on a set whose keys all carry a `kid`, because no integer index exists in the internal array. A plain list makes that index valid. Three tests assert the current behaviour:

- `tests/Component/Core/JWKSetTest.php:141`
- `tests/Component/KeyManagement/JWKSetTest.php:103`
- `tests/Component/KeyManagement/JWKTest.php:120`

That is a BC break, so the list refactoring stays out of a patch release and remains a candidate for 5.0.0.

The alternative the issue mentioned for 4.2.x — shipping only a warning — leaves the keys being dropped. This PR takes a third route that fixes the bug without breaking anything: **indexing by `kid` is kept, but a key whose `kid` is already taken is appended under a numeric index instead of replacing the stored one.** PHP preserves insertion order, so serialization keeps the original order of the key set.

## Changes

In `src/Library/Core/JWKSet.php`:

- `add()` centralises the indexing logic that was duplicated — and could drift — across the constructor, `createFromKeyData()` and `with()`;
- `indexOf()` resolves a string index that is not used as an array key by scanning the keys' `kid`, so the extra keys stay reachable through `get()`, `has()` and `without()`. `without('k1')` removes the first one; calling it again removes the next;
- the `is_string`/`is_int` guard on the `kid` brings a related fix: a key without a `kid` can no longer be overwritten by a key whose numeric `kid` matches its auto-assigned index.

## Behaviour changes, inherent to the fix

- `with()` on an already used `kid` now appends instead of replacing.
- `get('kid')` returns the **first** matching key; it used to return the last one, the first being lost.
- `keyset:merge` therefore no longer implicitly deduplicates by `kid`. No test covered that behaviour.

## Verification

- PHPUnit: 873 tests, 2555 assertions, green (the 2 incomplete ones are pre-existing). The three `has(0) === false` assertions still pass.
- ECS: green.
- PHPStan: green. One now-obsolete `offsetAccess.invalidOffset` baseline entry (count 3) was dropped, and no new one was added — `indexOf()` iterates over `all()`, which is typed `JWK[]`.
- The issue's reproduction snippet now prints `3` and keeps all three keys.

Six regression tests were added to `tests/Component/Core/JWKSetTest.php`, covering the constructor, `createFromKeyData()`, `with()`, `without()`, and the real-world case of `selectKey()` picking the second key when the first one sharing the `kid` is unusable for the requested algorithm.