### PR TITLE
fix(encryption): read the recipient header from the builder state

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4473,7 +4473,7 @@ parameters:
 		-
 			rawMessage: Cannot access offset 'header' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 3
 			path: ../src/Library/Encryption/JWEBuilder.php
 
 		-
@@ -4492,12 +4492,6 @@ parameters:
 			rawMessage: Cannot access offset 'sender_key' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: ../src/Library/Encryption/JWEBuilder.php
-
-		-
-			rawMessage: 'Cannot call method getHeader() on mixed.'
-			identifier: method.nonObject
-			count: 2
 			path: ../src/Library/Encryption/JWEBuilder.php
 
 		-

--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -125,7 +125,7 @@ class JWEBuilder
     {
         $this->checkDuplicatedHeaderParameters($sharedProtectedHeader, $this->sharedHeader);
         foreach ($this->recipients as $recipient) {
-            $this->checkDuplicatedHeaderParameters($sharedProtectedHeader, $recipient->getHeader());
+            $this->checkDuplicatedHeaderParameters($sharedProtectedHeader, $recipient['header']);
         }
         $clone = clone $this;
         $clone->sharedProtectedHeader = $sharedProtectedHeader;
@@ -142,7 +142,7 @@ class JWEBuilder
     {
         $this->checkDuplicatedHeaderParameters($this->sharedProtectedHeader, $sharedHeader);
         foreach ($this->recipients as $recipient) {
-            $this->checkDuplicatedHeaderParameters($sharedHeader, $recipient->getHeader());
+            $this->checkDuplicatedHeaderParameters($sharedHeader, $recipient['header']);
         }
         $clone = clone $this;
         $clone->sharedHeader = $sharedHeader;

--- a/tests/Component/Encryption/EncrypterTest.php
+++ b/tests/Component/Encryption/EncrypterTest.php
@@ -71,6 +71,87 @@ final class EncrypterTest extends EncryptionTestCase
     }
 
     #[Test]
+    public function sharedHeaderCanBeSetAfterTheRecipientHasBeenAdded(): void
+    {
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['RSA-OAEP-256', 'A256CBC-HS512']);
+        $jweDecrypter = $this->getJWEDecrypterFactory()
+            ->create(['RSA-OAEP-256', 'A256CBC-HS512']);
+
+        $jwe = $jweBuilder
+            ->create()
+            ->withPayload('FOO')
+            ->withSharedProtectedHeader([
+                'enc' => 'A256CBC-HS512',
+                'alg' => 'RSA-OAEP-256',
+            ])
+            ->addRecipient($this->getRSARecipientKey())
+            ->withSharedHeader([
+                'cty' => 'text/plain',
+            ])
+            ->build();
+
+        $token = $this->getJWESerializerManager()
+            ->serialize('jwe_json_flattened', $jwe, 0);
+        $loaded = $this->getJWESerializerManager()
+            ->unserialize($token);
+
+        static::assertSame('text/plain', $loaded->getSharedHeaderParameter('cty'));
+        static::assertTrue($jweDecrypter->decryptUsingKeySet($loaded, $this->getPrivateKeySet(), 0));
+        static::assertSame('FOO', $loaded->getPayload());
+    }
+
+    #[Test]
+    public function duplicatedHeaderWhenTheSharedHeaderIsSetAfterTheRecipient(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The header contains duplicated entries: cty.');
+
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['RSA-OAEP-256', 'A256CBC-HS512']);
+
+        $jweBuilder
+            ->create()
+            ->withPayload('FOO')
+            ->withSharedProtectedHeader([
+                'enc' => 'A256CBC-HS512',
+                'alg' => 'RSA-OAEP-256',
+            ])
+            ->addRecipient($this->getRSARecipientKey(), [
+                'cty' => 'text/plain',
+            ])
+            ->withSharedHeader([
+                'cty' => 'application/json',
+            ]);
+    }
+
+    #[Test]
+    public function duplicatedHeaderWhenTheSharedProtectedHeaderIsSetAfterTheRecipient(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The header contains duplicated entries: cty.');
+
+        $jweBuilder = $this->getJWEBuilderFactory()
+            ->create(['RSA-OAEP-256', 'A256CBC-HS512']);
+
+        $jweBuilder
+            ->create()
+            ->withPayload('FOO')
+            ->withSharedProtectedHeader([
+                'enc' => 'A256CBC-HS512',
+                'alg' => 'RSA-OAEP-256',
+            ])
+            ->addRecipient($this->getRSARecipientKey(), [
+                'cty' => 'text/plain',
+            ])
+            ->withSharedProtectedHeader([
+                'enc' => 'A256CBC-HS512',
+                'alg' => 'RSA-OAEP-256',
+                'cty' => 'application/json',
+            ]);
+    }
+
+    #[Test]
     public function createCompactJWEUsingFactory(): void
     {
         $jweBuilder = $this->getJWEBuilderFactory()


### PR DESCRIPTION
Fixes #678.

`JWEBuilder::withSharedProtectedHeader()` and `JWEBuilder::withSharedHeader()` iterated over the already
registered recipients and called `$recipient->getHeader()`, but `addRecipient()` stores plain arrays
(`['key' => ..., 'header' => ..., 'key_encryption_algorithm' => ...]`).

Setting a shared header after a recipient therefore raised a fatal
`Error: Call to a member function getHeader() on array` instead of performing the
duplicated-header-parameter check. As a consequence that check only ever ran when the recipient was
added last.

Both loops now read `$recipient['header']`.

## Tests

Three regression tests in `EncrypterTest`, all failing before the fix:

- `sharedHeaderCanBeSetAfterTheRecipientHasBeenAdded` — builds, serializes to `jwe_json_flattened` and
  decrypts a JWE whose shared (unprotected) header is set after `addRecipient()`
- `duplicatedHeaderWhenTheSharedHeaderIsSetAfterTheRecipient`
- `duplicatedHeaderWhenTheSharedProtectedHeaderIsSetAfterTheRecipient`

The PHPStan baseline is updated accordingly: the `method.nonObject` entry for `getHeader()` is gone and
the `offsetAccess.nonOffsetAccessible` count for `'header'` goes from 1 to 3.

Replacing those array entries by readonly value objects remains part of the builder redesign planned for
4.3/5.0, as does the order sensitivity of `addRecipient()` mentioned at the end of the issue.