### PR TITLE
fix(core): keep the cause of a load or verification failure

### DIFF
--- a/src/Library/Encryption/JWEDecrypter.php
+++ b/src/Library/Encryption/JWEDecrypter.php
@@ -19,6 +19,8 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyWrapping;
 use Jose\Component\Encryption\Algorithm\KeyEncryptionAlgorithm;
 use Throwable;
 use function count;
+use function func_num_args;
+use function is_callable;
 use function is_string;
 use function sprintf;
 use function strlen;
@@ -80,6 +82,12 @@ class JWEDecrypter
     /**
      * This method will try to decrypt the given JWE and recipient using a JWKSet.
      *
+     * A key that cannot be used, or that does not decrypt the recipient, does not abort the decryption: the next key of
+     * the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
+     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of the
+     * signature yet (it will be in 5.0.0) and is read with func_num_args()/func_get_arg(5), so that classes extending
+     * this one remain compatible.
+     *
      * @param JWE $jwe A JWE object to decrypt
      * @param JWKSet $jwkset The key set used to decrypt the input
      * @param JWK $jwk The key used to decrypt the token in case of success
@@ -92,6 +100,10 @@ class JWEDecrypter
         ?JWK &$jwk = null,
         ?JWK $senderKey = null
     ): bool {
+        $onError = func_num_args() >= 6 ? func_get_arg(5) : null;
+        if (! is_callable($onError)) {
+            $onError = null;
+        }
         if ($jwkset->count() === 0) {
             throw new InvalidArgumentException('No key in the key set.');
         }
@@ -102,7 +114,7 @@ class JWEDecrypter
             throw new InvalidArgumentException('The JWE does not contain any recipient.');
         }
 
-        $plaintext = $this->decryptRecipientKey($jwe, $jwkset, $recipient, $jwk, $senderKey);
+        $plaintext = $this->decryptRecipientKey($jwe, $jwkset, $recipient, $jwk, $senderKey, $onError);
         if ($plaintext !== null) {
             $jwe = $jwe->withPayload($plaintext);
 
@@ -120,13 +132,16 @@ class JWEDecrypter
      *
      * The shared unprotected header is never a valid source for "alg" and "enc": it is not covered by the
      * AAD and, unlike the per-recipient header, nothing requires those parameters to be located there.
+     *
+     * @param callable(Throwable): void|null $onError
      */
     private function decryptRecipientKey(
         JWE $jwe,
         JWKSet $jwkset,
         int $i,
         ?JWK &$successJwk = null,
-        ?JWK $senderKey = null
+        ?JWK $senderKey = null,
+        ?callable $onError = null
     ): ?string {
         $recipient = $jwe->getRecipient($i);
         $sharedProtectedHeader = $jwe->getSharedProtectedHeader();
@@ -167,8 +182,11 @@ class JWEDecrypter
                 $successJwk = $recipientKey;
 
                 return $payload;
-            } catch (Throwable) {
-                // We do nothing, we continue with other keys
+            } catch (Throwable $throwable) {
+                if ($onError !== null) {
+                    $onError($throwable);
+                }
+
                 continue;
             }
         }

--- a/src/Library/Encryption/JWELoader.php
+++ b/src/Library/Encryption/JWELoader.php
@@ -61,35 +61,52 @@ class JWELoader
     /**
      * This method will try to load and decrypt the given token using a JWKSet. If succeeded, the methods will populate
      * the $recipient variable and returns the JWE.
+     *
+     * The failure semantics are unchanged, but the last error met along the way - a serialization failure, a rejected
+     * header or a key that could not decrypt the recipient - is chained as the previous exception, so that the reason
+     * of the failure remains available to the caller.
      */
     public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
     {
+        $lastError = null;
         try {
             $jwe = $this->serializerManager->unserialize($token);
             $nbRecipients = $jwe->countRecipients();
             for ($i = 0; $i < $nbRecipients; ++$i) {
-                if ($this->processRecipient($jwe, $keyset, $i)) {
+                if ($this->processRecipient($jwe, $keyset, $i, $lastError)) {
                     $recipient = $i;
 
                     return $jwe;
                 }
             }
-        } catch (Throwable) {
-            // Nothing to do. Exception thrown just after
+        } catch (Throwable $throwable) {
+            $lastError = $throwable;
         }
 
-        throw new RuntimeException('Unable to load and decrypt the token.');
+        throw new RuntimeException('Unable to load and decrypt the token.', 0, $lastError);
     }
 
-    private function processRecipient(JWE &$jwe, JWKSet $keyset, int $recipient): bool
+    private function processRecipient(JWE &$jwe, JWKSet $keyset, int $recipient, ?Throwable &$lastError): bool
     {
         try {
             if ($this->headerCheckerManager !== null) {
                 $this->headerCheckerManager->check($jwe, $recipient);
             }
+            $jwk = null;
 
-            return $this->jweDecrypter->decryptUsingKeySet($jwe, $keyset, $recipient);
-        } catch (Throwable) {
+            return $this->jweDecrypter->decryptUsingKeySet(
+                $jwe,
+                $keyset,
+                $recipient,
+                $jwk,
+                null,
+                static function (Throwable $throwable) use (&$lastError): void {
+                    $lastError = $throwable;
+                }
+            );
+        } catch (Throwable $throwable) {
+            $lastError = $throwable;
+
             return false;
         }
     }

--- a/src/Library/Encryption/Serializer/JWESerializerManager.php
+++ b/src/Library/Encryption/Serializer/JWESerializerManager.php
@@ -50,23 +50,29 @@ final class JWESerializerManager
     /**
      * Loads data and return a JWE object. Throws an exception if none of the serializer was able to convert the input.
      *
+     * When no serializer is able to convert the input, the exception thrown by the last one is chained as the previous
+     * exception, so that the actual reason of the failure remains available to the caller.
+     *
      * @param string $input A string that represents a JWE
      * @param string|null $name the name of the serializer if the input is unserialized
      */
     public function unserialize(string $input, ?string &$name = null): JWE
     {
+        $lastError = null;
         foreach ($this->serializers as $serializer) {
             try {
                 $jws = $serializer->unserialize($input);
                 $name = $serializer->name();
 
                 return $jws;
-            } catch (InvalidArgumentException) {
+            } catch (InvalidArgumentException $invalidArgumentException) {
+                $lastError = $invalidArgumentException;
+
                 continue;
             }
         }
 
-        throw new InvalidArgumentException('Unsupported input.');
+        throw new InvalidArgumentException('Unsupported input.', 0, $lastError);
     }
 
     /**

--- a/src/Library/Signature/JWSLoader.php
+++ b/src/Library/Signature/JWSLoader.php
@@ -61,6 +61,10 @@ class JWSLoader
     /**
      * This method will try to load and verify the token using the given key set. It returns a JWS and will populate the
      * $signature variable in case of success, otherwise an exception is thrown.
+     *
+     * The failure semantics are unchanged, but the last error met along the way - a serialization failure, a rejected
+     * header or a key that could not verify the signature - is chained as the previous exception, so that the reason of
+     * the failure remains available to the caller.
      */
     public function loadAndVerifyWithKeySet(
         string $token,
@@ -68,32 +72,50 @@ class JWSLoader
         ?int &$signature,
         ?string $payload = null
     ): JWS {
+        $lastError = null;
         try {
             $jws = $this->serializerManager->unserialize($token);
             $nbSignatures = $jws->countSignatures();
             for ($i = 0; $i < $nbSignatures; ++$i) {
-                if ($this->processSignature($jws, $keyset, $i, $payload)) {
+                if ($this->processSignature($jws, $keyset, $i, $payload, $lastError)) {
                     $signature = $i;
 
                     return $jws;
                 }
             }
-        } catch (Throwable) {
-            // Nothing to do. Exception thrown just after
+        } catch (Throwable $throwable) {
+            $lastError = $throwable;
         }
 
-        throw new Exception('Unable to load and verify the token.');
+        throw new Exception('Unable to load and verify the token.', 0, $lastError);
     }
 
-    private function processSignature(JWS $jws, JWKSet $keyset, int $signature, ?string $payload): bool
-    {
+    private function processSignature(
+        JWS $jws,
+        JWKSet $keyset,
+        int $signature,
+        ?string $payload,
+        ?Throwable &$lastError
+    ): bool {
         try {
             if ($this->headerCheckerManager !== null) {
                 $this->headerCheckerManager->check($jws, $signature);
             }
+            $jwk = null;
 
-            return $this->jwsVerifier->verifyWithKeySet($jws, $keyset, $signature, $payload);
-        } catch (Throwable) {
+            return $this->jwsVerifier->verifyWithKeySet(
+                $jws,
+                $keyset,
+                $signature,
+                $payload,
+                $jwk,
+                static function (Throwable $throwable) use (&$lastError): void {
+                    $lastError = $throwable;
+                }
+            );
+        } catch (Throwable $throwable) {
+            $lastError = $throwable;
+
             return false;
         }
     }

--- a/src/Library/Signature/JWSVerifier.php
+++ b/src/Library/Signature/JWSVerifier.php
@@ -14,6 +14,8 @@ use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
 use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
 use Throwable;
+use function func_num_args;
+use function is_callable;
 use function sprintf;
 
 class JWSVerifier
@@ -48,6 +50,12 @@ class JWSVerifier
      * This method will try to verify the JWS object using the given key set and for the given signature. It returns
      * true if the signature is verified, otherwise false.
      *
+     * A key that cannot be used, or that does not verify the signature, does not abort the verification: the next key
+     * of the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
+     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of the
+     * signature yet (it will be in 5.0.0) and is read with func_num_args()/func_get_arg(5), so that classes extending
+     * this one remain compatible.
+     *
      * @param JWS $jws A JWS object
      * @param JWKSet $jwkset The signature will be verified using keys in the key set
      * @param JWK $jwk The key used to verify the signature in case of success
@@ -62,6 +70,10 @@ class JWSVerifier
         ?string $detachedPayload = null,
         ?JWK &$jwk = null
     ): bool {
+        $onError = func_num_args() >= 6 ? func_get_arg(5) : null;
+        if (! is_callable($onError)) {
+            $onError = null;
+        }
         if ($jwkset->count() === 0) {
             throw new InvalidArgumentException('There is no key in the key set.');
         }
@@ -71,15 +83,19 @@ class JWSVerifier
         $this->checkPayload($jws, $detachedPayload);
         $signature = $jws->getSignature($signatureIndex);
 
-        return $this->verifySignature($jws, $jwkset, $signature, $detachedPayload, $jwk);
+        return $this->verifySignature($jws, $jwkset, $signature, $detachedPayload, $jwk, $onError);
     }
 
+    /**
+     * @param callable(Throwable): void|null $onError
+     */
     private function verifySignature(
         JWS $jws,
         JWKSet $jwkset,
         Signature $signature,
         ?string $detachedPayload = null,
-        ?JWK &$successJwk = null
+        ?JWK &$successJwk = null,
+        ?callable $onError = null
     ): bool {
         $input = $this->getInputToVerify($jws, $signature, $detachedPayload);
         $algorithm = $this->getAlgorithm($signature);
@@ -92,8 +108,11 @@ class JWSVerifier
 
                     return true;
                 }
-            } catch (Throwable) {
-                // We do nothing, we continue with other keys
+            } catch (Throwable $throwable) {
+                if ($onError !== null) {
+                    $onError($throwable);
+                }
+
                 continue;
             }
         }

--- a/src/Library/Signature/Serializer/JWSSerializerManager.php
+++ b/src/Library/Signature/Serializer/JWSSerializerManager.php
@@ -48,23 +48,29 @@ final class JWSSerializerManager
     /**
      * Loads data and return a JWS object.
      *
+     * When no serializer is able to convert the input, the exception thrown by the last one is chained as the previous
+     * exception, so that the actual reason of the failure remains available to the caller.
+     *
      * @param string $input A string that represents a JWS
      * @param string|null $name the name of the serializer if the input is unserialized
      */
     public function unserialize(string $input, ?string &$name = null): JWS
     {
+        $lastError = null;
         foreach ($this->serializers as $serializer) {
             try {
                 $jws = $serializer->unserialize($input);
                 $name = $serializer->name();
 
                 return $jws;
-            } catch (InvalidArgumentException) {
+            } catch (InvalidArgumentException $invalidArgumentException) {
+                $lastError = $invalidArgumentException;
+
                 continue;
             }
         }
 
-        throw new InvalidArgumentException('Unsupported input.');
+        throw new InvalidArgumentException('Unsupported input.', 0, $lastError);
     }
 
     private function add(JWSSerializer $serializer): void

--- a/tests/Component/Encryption/JWELoaderTest.php
+++ b/tests/Component/Encryption/JWELoaderTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Jose\Tests\Component\Encryption;
 
 use Exception;
+use InvalidArgumentException;
+use Jose\Component\Checker\AlgorithmChecker;
+use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\InvalidHeaderException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Encryption\JWELoader;
+use Jose\Component\Encryption\JWETokenSupport;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
@@ -79,6 +84,96 @@ final class JWELoaderTest extends EncryptionTestCase
     }
 
     #[Test]
+    public function theSerializationFailureIsChainedAsPreviousException(): void
+    {
+        $token = 'This is not a token';
+        $key = new JWK([
+            'kty' => 'EC',
+            'kid' => 'peregrin.took@tuckborough.example',
+            'use' => 'enc',
+            'crv' => 'P-384',
+            'x' => 'YU4rRUzdmVqmRtWOs2OpDE_T5fsNIodcG8G5FWPrTPMyxpzsSOGaQLpe2FpxBmu2',
+            'y' => 'A8-yxCHxkfBz3hKZfI1jUYMjUhsEveZ9THuwFjH2sCNdtksRJU7D5-SkgaFL1ETP',
+        ]);
+
+        $exception = $this->loadAndCatch($this->getJWELoader(), $token, $key);
+
+        static::assertSame('Unable to load and decrypt the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidArgumentException::class, $previous);
+        static::assertSame('Unsupported input.', $previous->getMessage());
+        static::assertInstanceOf(InvalidArgumentException::class, $previous->getPrevious());
+    }
+
+    #[Test]
+    public function theUnsupportedAlgorithmIsChainedAsPreviousException(): void
+    {
+        $token = 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6InBlcmVncmluLnRvb2tAdHVja2Jvcm91Z2guZXhhbXBsZSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwieCI6InVCbzRrSFB3Nmtiang1bDB4b3dyZF9vWXpCbWF6LUdLRlp1NHhBRkZrYllpV2d1dEVLNml1RURzUTZ3TmROZzMiLCJ5Ijoic3AzcDVTR2haVkMyZmFYdW1JLWU5SlUyTW84S3BvWXJGRHI1eVBOVnRXNFBnRXdaT3lRVEEtSmRhWTh0YjdFMCJ9LCJlbmMiOiJBMTI4R0NNIn0.0DJjBXri_kBcC46IkU5_Jk9BqaQeHdv2.mH-G2zVqgztUtnW_.tkZuOO9h95OgHJmkkrfLBisku8rGf6nzVxhRM3sVOhXgz5NJ76oID7lpnAi_cPWJRCjSpAaUZ5dOR3Spy7QuEkmKx8-3RCMhSYMzsXaEwDdXta9Mn5B7cCBoJKB0IgEnj_qfo1hIi-uEkUpOZ8aLTZGHfpl05jMwbKkTe2yK3mjF6SBAsgicQDVCkcY9BLluzx1RmC3ORXaM0JaHPB93YcdSDGgpgBWMVrNU1ErkjcMqMoT_wtCex3w03XdLkjXIuEr2hWgeP-nkUZTPU9EoGSPj6fAS-bSz87RCPrxZdj_iVyC6QWcqAu07WNhjzJEPc4jVntRJ6K53NgPQ5p99l3Z408OUqj4ioYezbS6vTPlQ.WuGzxmcreYjpHGJoa17EBg';
+        $key = new JWK([
+            'kty' => 'EC',
+            'kid' => 'peregrin.took@tuckborough.example',
+            'use' => 'enc',
+            'crv' => 'P-384',
+            'x' => 'YU4rRUzdmVqmRtWOs2OpDE_T5fsNIodcG8G5FWPrTPMyxpzsSOGaQLpe2FpxBmu2',
+            'y' => 'A8-yxCHxkfBz3hKZfI1jUYMjUhsEveZ9THuwFjH2sCNdtksRJU7D5-SkgaFL1ETP',
+        ]);
+
+        $exception = $this->loadAndCatch($this->getJWELoader(), $token, $key);
+
+        static::assertSame('Unable to load and decrypt the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidArgumentException::class, $previous);
+        static::assertSame('The algorithm "ECDH-ES+A128KW" is not supported.', $previous->getMessage());
+    }
+
+    #[Test]
+    public function theKeyRejectionIsChainedAsPreviousException(): void
+    {
+        $token = 'eyJhbGciOiJBMTI4S1ciLCJraWQiOiI4MWIyMDk2NS04MzMyLTQzZDktYTQ2OC04MjE2MGFkOTFhYzgiLCJlbmMiOiJBMTI4R0NNIn0.CBI6oDw8MydIx1IBntf_lQcw2MmJKIQx.Qx0pmsDa8KnJc9Jo.AwliP-KmWgsZ37BvzCefNen6VTbRK3QMA4TkvRkH0tP1bTdhtFJgJxeVmJkLD61A1hnWGetdg11c9ADsnWgL56NyxwSYjU1ZEHcGkd3EkU0vjHi9gTlb90qSYFfeF0LwkcTtjbYKCsiNJQkcIp1yeM03OmuiYSoYJVSpf7ej6zaYcMv3WwdxDFl8REwOhNImk2Xld2JXq6BR53TSFkyT7PwVLuq-1GwtGHlQeg7gDT6xW0JqHDPn_H-puQsmthc9Zg0ojmJfqqFvETUxLAF-KjcBTS5dNy6egwkYtOt8EIHK-oEsKYtZRaa8Z7MOZ7UGxGIMvEmxrGCPeJa14slv2-gaqK0kEThkaSqdYw0FkQZF.ER7MWJZ1FBI_NKvn7Zb1Lw';
+        $key = new JWK([
+            'kty' => 'EC',
+            'kid' => 'peregrin.took@tuckborough.example',
+            'use' => 'enc',
+            'crv' => 'P-384',
+            'x' => 'YU4rRUzdmVqmRtWOs2OpDE_T5fsNIodcG8G5FWPrTPMyxpzsSOGaQLpe2FpxBmu2',
+            'y' => 'A8-yxCHxkfBz3hKZfI1jUYMjUhsEveZ9THuwFjH2sCNdtksRJU7D5-SkgaFL1ETP',
+        ]);
+
+        $exception = $this->loadAndCatch($this->getJWELoader(), $token, $key);
+
+        static::assertSame('Unable to load and decrypt the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidArgumentException::class, $previous);
+        static::assertSame('Wrong key type.', $previous->getMessage());
+    }
+
+    #[Test]
+    public function theHeaderCheckerFailureIsChainedAsPreviousException(): void
+    {
+        $token = 'eyJhbGciOiJBMTI4S1ciLCJraWQiOiI4MWIyMDk2NS04MzMyLTQzZDktYTQ2OC04MjE2MGFkOTFhYzgiLCJlbmMiOiJBMTI4R0NNIn0.CBI6oDw8MydIx1IBntf_lQcw2MmJKIQx.Qx0pmsDa8KnJc9Jo.AwliP-KmWgsZ37BvzCefNen6VTbRK3QMA4TkvRkH0tP1bTdhtFJgJxeVmJkLD61A1hnWGetdg11c9ADsnWgL56NyxwSYjU1ZEHcGkd3EkU0vjHi9gTlb90qSYFfeF0LwkcTtjbYKCsiNJQkcIp1yeM03OmuiYSoYJVSpf7ej6zaYcMv3WwdxDFl8REwOhNImk2Xld2JXq6BR53TSFkyT7PwVLuq-1GwtGHlQeg7gDT6xW0JqHDPn_H-puQsmthc9Zg0ojmJfqqFvETUxLAF-KjcBTS5dNy6egwkYtOt8EIHK-oEsKYtZRaa8Z7MOZ7UGxGIMvEmxrGCPeJa14slv2-gaqK0kEThkaSqdYw0FkQZF.ER7MWJZ1FBI_NKvn7Zb1Lw';
+        $key = new JWK([
+            'kty' => 'oct',
+            'kid' => '81b20965-8332-43d9-a468-82160ad91ac8',
+            'use' => 'enc',
+            'alg' => 'A128KW',
+            'k' => 'GZy6sIZ6wl9NJOKB-jnmVQ',
+        ]);
+        $jweLoader = new JWELoader(
+            $this->getJWESerializerManager(),
+            $this->getJWEDecrypterFactory()
+                ->create(['A128KW', 'A128GCM']),
+            new HeaderCheckerManager([new AlgorithmChecker(['A256KW'])], [new JWETokenSupport()])
+        );
+
+        $exception = $this->loadAndCatch($jweLoader, $token, $key);
+
+        static::assertSame('Unable to load and decrypt the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidHeaderException::class, $previous);
+        static::assertSame('Unsupported algorithm.', $previous->getMessage());
+    }
+
+    #[Test]
     public function theJweLoaderCanLoadAndDecryptAToken(): void
     {
         $token = 'eyJhbGciOiJBMTI4S1ciLCJraWQiOiI4MWIyMDk2NS04MzMyLTQzZDktYTQ2OC04MjE2MGFkOTFhYzgiLCJlbmMiOiJBMTI4R0NNIn0.CBI6oDw8MydIx1IBntf_lQcw2MmJKIQx.Qx0pmsDa8KnJc9Jo.AwliP-KmWgsZ37BvzCefNen6VTbRK3QMA4TkvRkH0tP1bTdhtFJgJxeVmJkLD61A1hnWGetdg11c9ADsnWgL56NyxwSYjU1ZEHcGkd3EkU0vjHi9gTlb90qSYFfeF0LwkcTtjbYKCsiNJQkcIp1yeM03OmuiYSoYJVSpf7ej6zaYcMv3WwdxDFl8REwOhNImk2Xld2JXq6BR53TSFkyT7PwVLuq-1GwtGHlQeg7gDT6xW0JqHDPn_H-puQsmthc9Zg0ojmJfqqFvETUxLAF-KjcBTS5dNy6egwkYtOt8EIHK-oEsKYtZRaa8Z7MOZ7UGxGIMvEmxrGCPeJa14slv2-gaqK0kEThkaSqdYw0FkQZF.ER7MWJZ1FBI_NKvn7Zb1Lw';
@@ -95,6 +190,17 @@ final class JWELoaderTest extends EncryptionTestCase
 
         static::assertSame(file_get_contents(__DIR__ . '/message.txt'), $jwe->getPayload());
         static::assertSame(0, $recipient);
+    }
+
+    private function loadAndCatch(JWELoader $jweLoader, string $token, JWK $key): Exception
+    {
+        try {
+            $jweLoader->loadAndDecryptWithKey($token, $key, $recipient);
+        } catch (Exception $exception) {
+            return $exception;
+        }
+
+        static::fail('The token should not be loaded.');
     }
 
     private function getJWELoader(): JWELoader

--- a/tests/Component/Signature/JWSLoaderTest.php
+++ b/tests/Component/Signature/JWSLoaderTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Jose\Tests\Component\Signature;
 
 use Exception;
+use InvalidArgumentException;
+use Jose\Component\Checker\AlgorithmChecker;
+use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\InvalidHeaderException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSTokenSupport;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
@@ -74,6 +79,91 @@ final class JWSLoaderTest extends SignatureTestCase
     }
 
     #[Test]
+    public function theSerializationFailureIsChainedAsPreviousException(): void
+    {
+        $token = 'This is not a token';
+        $key = new JWK([
+            'kty' => 'oct',
+            'kid' => '018c0ae5-4d9b-471b-bfd6-eef314bc7037',
+            'use' => 'sig',
+            'alg' => 'HS256',
+            'k' => 'hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG-Onbc6mxCcYg',
+        ]);
+
+        $exception = $this->loadAndCatch($this->getJWSLoader(), $token, $key);
+
+        static::assertSame('Unable to load and verify the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidArgumentException::class, $previous);
+        static::assertSame('Unsupported input.', $previous->getMessage());
+        static::assertInstanceOf(InvalidArgumentException::class, $previous->getPrevious());
+    }
+
+    #[Test]
+    public function theUnsupportedAlgorithmIsChainedAsPreviousException(): void
+    {
+        $token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6ImJpbGJvLmJhZ2dpbnNAaG9iYml0b24uZXhhbXBsZSJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4.MRjdkly7_-oTPTS3AXP41iQIGKa80A0ZmTuV5MEaHoxnW2e5CZ5NlKtainoFmKZopdHM1O2U4mwzJdQx996ivp83xuglII7PNDi84wnB-BDkoBwA78185hX-Es4JIwmDLJK3lfWRa-XtL0RnltuYv746iYTh_qHRD68BNt1uSNCrUCTJDt5aAE6x8wW1Kt9eRo4QPocSadnHXFxnt8Is9UzpERV0ePPQdLuW3IS_de3xyIrDaLGdjluPxUAhb6L2aXic1U12podGU0KLUQSE_oI-ZnmKJ3F4uOZDnd6QZWJushZ41Axf_fcIe8u9ipH84ogoree7vjbU5y18kDquDg';
+        $key = new JWK([
+            'kty' => 'RSA',
+            'kid' => 'bilbo.baggins@hobbiton.example',
+            'use' => 'sig',
+            'n' => 'n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw',
+            'e' => 'AQAB',
+        ]);
+        $exception = $this->loadAndCatch($this->getJWSLoader(), $token, $key);
+
+        static::assertSame('Unable to load and verify the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidArgumentException::class, $previous);
+        static::assertSame('The algorithm "RS256" is not supported.', $previous->getMessage());
+    }
+
+    #[Test]
+    public function theKeyRejectionIsChainedAsPreviousException(): void
+    {
+        $token = 'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4.s0h6KThzkfBBBkLspW1h84VsJZFTsPPqMDA7g1Md7p0';
+        $key = new JWK([
+            'kty' => 'RSA',
+            'kid' => 'bilbo.baggins@hobbiton.example',
+            'use' => 'sig',
+            'n' => 'n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw',
+            'e' => 'AQAB',
+        ]);
+        $exception = $this->loadAndCatch($this->getJWSLoader(), $token, $key);
+
+        static::assertSame('Unable to load and verify the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidArgumentException::class, $previous);
+        static::assertSame('Wrong key type.', $previous->getMessage());
+    }
+
+    #[Test]
+    public function theHeaderCheckerFailureIsChainedAsPreviousException(): void
+    {
+        $token = 'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4.s0h6KThzkfBBBkLspW1h84VsJZFTsPPqMDA7g1Md7p0';
+        $key = new JWK([
+            'kty' => 'oct',
+            'kid' => '018c0ae5-4d9b-471b-bfd6-eef314bc7037',
+            'use' => 'sig',
+            'alg' => 'HS256',
+            'k' => 'hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG-Onbc6mxCcYg',
+        ]);
+        $jwsLoader = new JWSLoader(
+            $this->getJWSSerializerManager(),
+            $this->getJWSVerifierFactory()
+                ->create(['HS256']),
+            new HeaderCheckerManager([new AlgorithmChecker(['RS256'])], [new JWSTokenSupport()])
+        );
+
+        $exception = $this->loadAndCatch($jwsLoader, $token, $key);
+
+        static::assertSame('Unable to load and verify the token.', $exception->getMessage());
+        $previous = $exception->getPrevious();
+        static::assertInstanceOf(InvalidHeaderException::class, $previous);
+        static::assertSame('Unsupported algorithm.', $previous->getMessage());
+    }
+
+    #[Test]
     public function theTokenCanBeVerified(): void
     {
         $token = 'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4.s0h6KThzkfBBBkLspW1h84VsJZFTsPPqMDA7g1Md7p0';
@@ -92,6 +182,17 @@ final class JWSLoaderTest extends SignatureTestCase
             $jws->getPayload()
         );
         static::assertSame(0, $signature);
+    }
+
+    private function loadAndCatch(JWSLoader $jwsLoader, string $token, JWK $key): Exception
+    {
+        try {
+            $jwsLoader->loadAndVerifyWithKey($token, $key, $signature);
+        } catch (Exception $exception) {
+            return $exception;
+        }
+
+        static::fail('The token should not be loaded.');
     }
 
     private function getJWSLoader(): JWSLoader


### PR DESCRIPTION
Closes #681.

When loading a token failed, every layer swallowed the exception explaining why, and the caller ended up with a bare `Unable to load and verify the token.` and no `previous`. Whatever the real reason was — malformed token, unsupported `alg`, rejected header, unusable key — the message was the same.

The last error met along the way is now chained as the previous exception. No BC break: the exception classes and the messages are unchanged, only `getPrevious()` is populated.

## Changes

| File | Change |
| --- | --- |
| `JWSSerializerManager`, `JWESerializerManager` | `Unsupported input.` now chains the last `InvalidArgumentException` thrown by a serializer |
| `JWSLoader`, `JWELoader` | the last error — serialization, header checker or key — is passed as `$previous` |
| `JWSVerifier`, `JWEDecrypter` | the per-key `Throwable`s that are discarded to try the next key are reported to the caller |

`JWSVerifier::verifyWithKeySet()` and `JWEDecrypter::decryptUsingKeySet()` return a `bool` and cannot throw without changing their semantics, and adding a parameter would break classes extending them. The callable that observes those failures is therefore passed as an **undeclared** additional argument and read with `func_num_args()`/`func_get_arg(5)` — the same pattern already used by `JWEDecrypter::decryptCEK()`. It will become part of the signature in 5.0.0. A subclass that overrides the method simply ignores it and behaves exactly as today.

## Result

```
Exception - Unable to load and verify the token.
  -> InvalidArgumentException - The algorithm "RS256" is not supported.
  -> InvalidArgumentException - Wrong key type.
  -> InvalidHeaderException - Unsupported algorithm.
  -> InvalidArgumentException - Unsupported input. -> InvalidArgumentException - Unsupported input
```

One case still has no `previous`, by design: right `kty`, right `alg`, signature that does not match. No `Throwable` is thrown there — `verify()` simply returns `false`.

The dedicated exception hierarchy (so that `catch (JoseException)` becomes possible) remains the separate 4.3.0 issue.

## Checks

- 876 tests pass, including 8 new ones covering serialization failure, unsupported algorithm, rejected key and header checker failure, for both JWS and JWE
- PHPStan, ECS and Rector are green