### PR TITLE
ci: run the whole release sequence in a single job

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -1,5 +1,11 @@
 name: "Automatic Releases"
 
+# The five commands must stay steps of a single job: "release" runs
+# `git checkout <release branch>`, which is what makes that branch available
+# locally, and the following commands require it. Splitting them into separate
+# jobs gives each one a fresh checkout of the default branch, so every release
+# made from an older branch fails with "not a valid object name".
+
 on:
   milestone:
     types:
@@ -27,18 +33,6 @@ jobs:
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
-  merge-up:
-    name: "Create Merge-Up Pull Request"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "release"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-
       - name: "Create Merge-Up Pull Request"
         uses: "laminas/automatic-releases@1.25.0"
         with:
@@ -49,18 +43,6 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-  switch:
-    name: "Create and/or Switch to new Release Branch"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "merge-up"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
 
       - name: "Create and/or Switch to new Release Branch"
         uses: "laminas/automatic-releases@1.25.0"
@@ -73,18 +55,6 @@ jobs:
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
-  bump:
-    name: "Bump Changelog Version On Originating Release Branch"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "switch"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-
       - name: "Bump Changelog Version On Originating Release Branch"
         uses: "laminas/automatic-releases@1.25.0"
         with:
@@ -95,18 +65,6 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-  milestones:
-    name: "Create new milestones"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "bump"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
 
       - name: "Create new milestones"
         uses: "laminas/automatic-releases@1.25.0"


### PR DESCRIPTION
Same fix as bd025c82, which landed on `4.2.x` only. This branch carries it to `4.3.x`.

The `release` command runs `git checkout <release branch>`, which is what makes that branch available locally; `create-merge-up-pull-request` then runs `git branch <tmp> <release branch>` and needs it. With one job per command, each got a fresh checkout of the **default** branch, so every release cut from an older branch failed with `fatal: not a valid object name`.

`4.3.x` is the default branch, so this is the copy GitHub actually runs for `milestone: closed` events — the fix is inert until it lands here.

Pinned action versions and per-command tokens are unchanged.