### PR TITLE
refactor: remove the code duplicated by the managers, factories and JWE components

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4404,17 +4404,7 @@ parameters:
 			count: 1
 			path: ../src/Library/Checker/HeaderCheckerManager.php
 
-		-
-			rawMessage: 'Method Jose\Component\Checker\HeaderCheckerManager::checkDuplicatedHeaderParameters() has parameter $header1 with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Checker/HeaderCheckerManager.php
 
-		-
-			rawMessage: 'Method Jose\Component\Checker\HeaderCheckerManager::checkDuplicatedHeaderParameters() has parameter $header2 with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Checker/HeaderCheckerManager.php
 
 		-
 			rawMessage: 'Method Jose\Component\Checker\HeaderCheckerManager::checkHeaders() has parameter $header with no value type specified in iterable type array.'
@@ -4560,23 +4550,8 @@ parameters:
 			count: 1
 			path: ../src/Library/Console/RsaKeysetGeneratorCommand.php
 
-		-
-			rawMessage: 'Method Jose\Component\Core\AlgorithmManagerFactory::all() should return array<Jose\Component\Core\Algorithm> but returns array.'
-			identifier: return.type
-			count: 1
-			path: ../src/Library/Core/AlgorithmManagerFactory.php
 
-		-
-			rawMessage: 'Parameter #1 $algorithms of class Jose\Component\Core\AlgorithmManager constructor expects iterable<Jose\Component\Core\Algorithm>, list<mixed> given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Core/AlgorithmManagerFactory.php
 
-		-
-			rawMessage: Property Jose\Component\Core\AlgorithmManagerFactory::$algorithms type has no value type specified in iterable type array.
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Core/AlgorithmManagerFactory.php
 
 		-
 			rawMessage: 'Method Jose\Component\Core\JWK::__construct() has parameter $values with no value type specified in iterable type array.'
@@ -4914,17 +4889,7 @@ parameters:
 			count: 1
 			path: ../src/Library/Encryption/JWEDecrypter.php
 
-		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypter::checkDuplicatedHeaderParameters() has parameter $header1 with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Encryption/JWEDecrypter.php
 
-		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypter::checkDuplicatedHeaderParameters() has parameter $header2 with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Encryption/JWEDecrypter.php
 
 		-
 			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypter::decryptCEK() has parameter $completeHeader with no value type specified in iterable type array.'

--- a/src/Bundle/Serializer/JWEEncoder.php
+++ b/src/Bundle/Serializer/JWEEncoder.php
@@ -28,7 +28,7 @@ final readonly class JWEEncoder implements EncoderInterface, DecoderInterface, N
         ?JWESerializerManager $serializerManager = null
     ) {
         if ($serializerManager === null) {
-            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->names());
+            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->aliases());
         }
         $this->serializerManager = $serializerManager;
     }

--- a/src/Bundle/Serializer/JWESerializer.php
+++ b/src/Bundle/Serializer/JWESerializer.php
@@ -21,7 +21,7 @@ final readonly class JWESerializer implements DenormalizerInterface
         ?JWESerializerManager $serializerManager = null
     ) {
         if ($serializerManager === null) {
-            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->names());
+            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->aliases());
         }
         $this->serializerManager = $serializerManager;
     }

--- a/src/Bundle/Serializer/JWSEncoder.php
+++ b/src/Bundle/Serializer/JWSEncoder.php
@@ -27,7 +27,7 @@ final readonly class JWSEncoder implements EncoderInterface, DecoderInterface, N
         ?JWSSerializerManager $serializerManager = null
     ) {
         if ($serializerManager === null) {
-            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->names());
+            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->aliases());
         }
         $this->serializerManager = $serializerManager;
     }

--- a/src/Bundle/Serializer/JWSSerializer.php
+++ b/src/Bundle/Serializer/JWSSerializer.php
@@ -21,7 +21,7 @@ final readonly class JWSSerializer implements DenormalizerInterface
         ?JWSSerializerManager $serializerManager = null
     ) {
         if ($serializerManager === null) {
-            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->names());
+            $serializerManager = $serializerManagerFactory->create($serializerManagerFactory->aliases());
         }
         $this->serializerManager = $serializerManager;
     }

--- a/src/Bundle/Services/ClaimCheckerManagerFactory.php
+++ b/src/Bundle/Services/ClaimCheckerManagerFactory.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\Services;
 
-use InvalidArgumentException;
 use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Core\Util\AliasedRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use function sprintf;
 
 final class ClaimCheckerManagerFactory
 {
     /**
-     * @var ClaimChecker[]
+     * @use AliasedRegistry<ClaimChecker>
      */
-    private array $checkers = [];
+    use AliasedRegistry;
 
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher
@@ -29,18 +28,7 @@ final class ClaimCheckerManagerFactory
      */
     public function create(array $aliases): ClaimCheckerManager
     {
-        $checkers = [];
-        foreach ($aliases as $alias) {
-            if (! isset($this->checkers[$alias])) {
-                throw new InvalidArgumentException(sprintf(
-                    'The claim checker with the alias "%s" is not supported.',
-                    $alias
-                ));
-            }
-            $checkers[] = $this->checkers[$alias];
-        }
-
-        return new ClaimCheckerManager($checkers, $this->eventDispatcher);
+        return new ClaimCheckerManager($this->select($aliases, 'claim checker'), $this->eventDispatcher);
     }
 
     /**
@@ -48,26 +36,6 @@ final class ClaimCheckerManagerFactory
      */
     public function add(string $alias, ClaimChecker $checker): void
     {
-        $this->checkers[$alias] = $checker;
-    }
-
-    /**
-     * Returns all claim checker aliases supported by this factory.
-     *
-     * @return string[]
-     */
-    public function aliases(): array
-    {
-        return array_keys($this->checkers);
-    }
-
-    /**
-     * Returns all claim checkers supported by this factory.
-     *
-     * @return ClaimChecker[]
-     */
-    public function all(): array
-    {
-        return $this->checkers;
+        $this->register($alias, $checker);
     }
 }

--- a/src/Bundle/Services/HeaderCheckerManagerFactory.php
+++ b/src/Bundle/Services/HeaderCheckerManagerFactory.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace Jose\Bundle\JoseFramework\Services;
 
-use InvalidArgumentException;
 use Jose\Component\Checker\HeaderChecker;
 use Jose\Component\Checker\TokenTypeSupport;
+use Jose\Component\Core\Util\AliasedRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use function sprintf;
 
 final class HeaderCheckerManagerFactory
 {
     /**
-     * @var HeaderChecker[]
+     * @use AliasedRegistry<HeaderChecker>
      */
-    private array $checkers = [];
+    use AliasedRegistry;
 
     /**
      * @var TokenTypeSupport[]
@@ -35,18 +34,11 @@ final class HeaderCheckerManagerFactory
      */
     public function create(array $aliases): HeaderCheckerManager
     {
-        $checkers = [];
-        foreach ($aliases as $alias) {
-            if (! isset($this->checkers[$alias])) {
-                throw new InvalidArgumentException(sprintf(
-                    'The header checker with the alias "%s" is not supported.',
-                    $alias
-                ));
-            }
-            $checkers[] = $this->checkers[$alias];
-        }
-
-        return new HeaderCheckerManager($checkers, $this->tokenTypes, $this->eventDispatcher);
+        return new HeaderCheckerManager(
+            $this->select($aliases, 'header checker'),
+            $this->tokenTypes,
+            $this->eventDispatcher
+        );
     }
 
     /**
@@ -55,7 +47,7 @@ final class HeaderCheckerManagerFactory
      */
     public function add(string $alias, HeaderChecker $checker): void
     {
-        $this->checkers[$alias] = $checker;
+        $this->register($alias, $checker);
     }
 
     /**
@@ -64,25 +56,5 @@ final class HeaderCheckerManagerFactory
     public function addTokenTypeSupport(TokenTypeSupport $tokenType): void
     {
         $this->tokenTypes[] = $tokenType;
-    }
-
-    /**
-     * Returns all header parameter checker aliases supported by this factory.
-     *
-     * @return string[]
-     */
-    public function aliases(): array
-    {
-        return array_keys($this->checkers);
-    }
-
-    /**
-     * Returns all header parameter checkers supported by this factory.
-     *
-     * @return HeaderChecker[]
-     */
-    public function all(): array
-    {
-        return $this->checkers;
     }
 }

--- a/src/Library/Checker/ClaimCheckerManagerFactory.php
+++ b/src/Library/Checker/ClaimCheckerManagerFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use Jose\Component\Core\Exception\InvalidArgumentException;
-use function sprintf;
+use Jose\Component\Core\Util\AliasedRegistry;
 
 /**
  * This class is responsible for creating and managing claim checkers.
@@ -14,9 +13,9 @@ use function sprintf;
 class ClaimCheckerManagerFactory
 {
     /**
-     * @var ClaimChecker[]
+     * @use AliasedRegistry<ClaimChecker>
      */
-    private array $checkers = [];
+    use AliasedRegistry;
 
     /**
      * This method creates a Claim Checker Manager and populate it with the claim checkers found based on the alias. If
@@ -26,18 +25,7 @@ class ClaimCheckerManagerFactory
      */
     public function create(array $aliases): ClaimCheckerManager
     {
-        $checkers = [];
-        foreach ($aliases as $alias) {
-            if (! isset($this->checkers[$alias])) {
-                throw new InvalidArgumentException(sprintf(
-                    'The claim checker with the alias "%s" is not supported.',
-                    $alias
-                ));
-            }
-            $checkers[] = $this->checkers[$alias];
-        }
-
-        return new ClaimCheckerManager($checkers);
+        return new ClaimCheckerManager($this->select($aliases, 'claim checker'));
     }
 
     /**
@@ -45,26 +33,6 @@ class ClaimCheckerManagerFactory
      */
     public function add(string $alias, ClaimChecker $checker): void
     {
-        $this->checkers[$alias] = $checker;
-    }
-
-    /**
-     * Returns all claim checker aliases supported by this factory.
-     *
-     * @return string[]
-     */
-    public function aliases(): array
-    {
-        return array_keys($this->checkers);
-    }
-
-    /**
-     * Returns all claim checkers supported by this factory.
-     *
-     * @return ClaimChecker[]
-     */
-    public function all(): array
-    {
-        return $this->checkers;
+        $this->register($alias, $checker);
     }
 }

--- a/src/Library/Checker/HeaderCheckerManager.php
+++ b/src/Library/Checker/HeaderCheckerManager.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jose\Component\Checker;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use Jose\Component\Core\JWT;
+use Jose\Component\Core\Util\HeaderParameterChecker;
 use Jose\Component\Core\Util\InheritanceChecker;
 use function array_key_exists;
 use function count;
@@ -81,7 +81,7 @@ class HeaderCheckerManager implements HeaderCheckerManagerInterface
                 $protected = [];
                 $unprotected = [];
                 $tokenType->retrieveTokenHeaders($jwt, $index, $protected, $unprotected);
-                $this->checkDuplicatedHeaderParameters($protected, $unprotected);
+                HeaderParameterChecker::checkDuplicates($protected, $unprotected);
                 $this->checkMandatoryHeaderParameters($mandatoryHeaderParameters, $protected, $unprotected);
                 $this->checkHeaders($protected, $unprotected);
 
@@ -90,17 +90,6 @@ class HeaderCheckerManager implements HeaderCheckerManagerInterface
         }
 
         throw new InvalidArgumentException('Unsupported token type.');
-    }
-
-    private function checkDuplicatedHeaderParameters(array $header1, array $header2): void
-    {
-        $inter = array_intersect_key($header1, $header2);
-        if (count($inter) !== 0) {
-            throw new InvalidHeaderParameterException(sprintf(
-                'The header contains duplicated entries: %s.',
-                implode(', ', array_keys($inter))
-            ));
-        }
     }
 
     /**

--- a/src/Library/Checker/HeaderCheckerManagerFactory.php
+++ b/src/Library/Checker/HeaderCheckerManagerFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use Jose\Component\Core\Exception\InvalidArgumentException;
-use function sprintf;
+use Jose\Component\Core\Util\AliasedRegistry;
 
 /**
  * This class is a factory to create Header Checker Managers. It allows to add header parameter checkers and token type
@@ -16,9 +15,9 @@ use function sprintf;
 class HeaderCheckerManagerFactory
 {
     /**
-     * @var HeaderChecker[]
+     * @use AliasedRegistry<HeaderChecker>
      */
-    private array $checkers = [];
+    use AliasedRegistry;
 
     /**
      * @var TokenTypeSupport[]
@@ -33,18 +32,7 @@ class HeaderCheckerManagerFactory
      */
     public function create(array $aliases): HeaderCheckerManager
     {
-        $checkers = [];
-        foreach ($aliases as $alias) {
-            if (! isset($this->checkers[$alias])) {
-                throw new InvalidArgumentException(sprintf(
-                    'The header checker with the alias "%s" is not supported.',
-                    $alias
-                ));
-            }
-            $checkers[] = $this->checkers[$alias];
-        }
-
-        return new HeaderCheckerManager($checkers, $this->tokenTypes);
+        return new HeaderCheckerManager($this->select($aliases, 'header checker'), $this->tokenTypes);
     }
 
     /**
@@ -53,7 +41,7 @@ class HeaderCheckerManagerFactory
      */
     public function add(string $alias, HeaderChecker $checker): void
     {
-        $this->checkers[$alias] = $checker;
+        $this->register($alias, $checker);
     }
 
     /**
@@ -62,25 +50,5 @@ class HeaderCheckerManagerFactory
     public function addTokenTypeSupport(TokenTypeSupport $tokenType): void
     {
         $this->tokenTypes[] = $tokenType;
-    }
-
-    /**
-     * Returns all header parameter checker aliases supported by this factory.
-     *
-     * @return string[]
-     */
-    public function aliases(): array
-    {
-        return array_keys($this->checkers);
-    }
-
-    /**
-     * Returns all header parameter checkers supported by this factory.
-     *
-     * @return HeaderChecker[]
-     */
-    public function all(): array
-    {
-        return $this->checkers;
     }
 }

--- a/src/Library/Core/AlgorithmManagerFactory.php
+++ b/src/Library/Core/AlgorithmManagerFactory.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core;
 
-use Jose\Component\Core\Exception\InvalidArgumentException;
-use function is_string;
-use function sprintf;
+use Jose\Component\Core\Util\AliasedRegistry;
 
 /**
  * @see \Jose\Tests\Component\Core\AlgorithmManagerFactoryTest
  */
 final class AlgorithmManagerFactory
 {
-    private array $algorithms = [];
+    /**
+     * @use AliasedRegistry<Algorithm>
+     */
+    use AliasedRegistry;
 
     /**
      * @param Algorithm[] $algorithms
@@ -33,28 +34,7 @@ final class AlgorithmManagerFactory
      */
     public function add(string $alias, Algorithm $algorithm): void
     {
-        $this->algorithms[$alias] = $algorithm;
-    }
-
-    /**
-     * Returns the list of aliases.
-     *
-     * @return string[]
-     */
-    public function aliases(): array
-    {
-        return array_keys($this->algorithms);
-    }
-
-    /**
-     * Returns all algorithms supported by this factory. This is an associative array. Keys are the aliases of the
-     * algorithms.
-     *
-     * @return Algorithm[]
-     */
-    public function all(): array
-    {
-        return $this->algorithms;
+        $this->register($alias, $algorithm);
     }
 
     /**
@@ -64,20 +44,6 @@ final class AlgorithmManagerFactory
      */
     public function create(array $aliases): AlgorithmManager
     {
-        $algorithms = [];
-        foreach ($aliases as $alias) {
-            if (! is_string($alias)) {
-                throw new InvalidArgumentException('Invalid alias');
-            }
-            if (! isset($this->algorithms[$alias])) {
-                throw new InvalidArgumentException(sprintf(
-                    'The algorithm with the alias "%s" is not supported.',
-                    $alias
-                ));
-            }
-            $algorithms[] = $this->algorithms[$alias];
-        }
-
-        return new AlgorithmManager($algorithms);
+        return new AlgorithmManager($this->select($aliases, 'algorithm'));
     }
 }

--- a/src/Library/Core/Util/AliasedRegistry.php
+++ b/src/Library/Core/Util/AliasedRegistry.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Util;
+
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use function is_string;
+use function sprintf;
+
+/**
+ * Common implementation of the "alias => object" registry every factory of this library is built on: the algorithm
+ * manager factory, the header and claim checker manager factories and the JWS/JWE serializer manager factories.
+ *
+ * Those factories keep their own public API: this trait only holds the registered objects and provides the lookup they
+ * all need, so that an unknown alias is reported the same way everywhere.
+ *
+ * @internal
+ *
+ * @template T of object
+ */
+trait AliasedRegistry
+{
+    /**
+     * @var array<string, T>
+     */
+    private array $items = [];
+
+    /**
+     * Returns the list of aliases supported by this factory.
+     *
+     * @return string[]
+     */
+    public function aliases(): array
+    {
+        return array_keys($this->items);
+    }
+
+    /**
+     * Returns all the objects supported by this factory. This is an associative array whose keys are the aliases.
+     *
+     * @return array<string, T>
+     */
+    public function all(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * Registers an object under the given alias. The same object may be registered twice (or more) under distinct
+     * aliases, which is helpful when it has several configuration options.
+     *
+     * @param T $item
+     */
+    private function register(string $alias, object $item): void
+    {
+        $this->items[$alias] = $item;
+    }
+
+    /**
+     * Returns the objects registered under the given aliases, in that order.
+     *
+     * The label is the human readable name of what the registry holds ("algorithm", "claim checker"...). It is only
+     * used to build the error message. The exception class is the one the factory reported before the registry was
+     * shared.
+     *
+     * @param string[] $aliases
+     * @param class-string<InvalidArgumentException> $exceptionClass
+     *
+     * @return list<T>
+     */
+    private function select(
+        array $aliases,
+        string $label,
+        string $exceptionClass = InvalidArgumentException::class
+    ): array {
+        $items = [];
+        foreach ($aliases as $alias) {
+            if (! is_string($alias)) {
+                throw new $exceptionClass(sprintf('Invalid %s alias.', $label));
+            }
+            if (! isset($this->items[$alias])) {
+                throw new $exceptionClass(sprintf(
+                    'The %s with the alias "%s" is not supported.',
+                    $label,
+                    $alias
+                ));
+            }
+            $items[] = $this->items[$alias];
+        }
+
+        return $items;
+    }
+}

--- a/src/Library/Core/Util/HeaderParameterChecker.php
+++ b/src/Library/Core/Util/HeaderParameterChecker.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Util;
+
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use function count;
+use function implode;
+use function sprintf;
+
+/**
+ * Checks the header parameters of a token against each other.
+ *
+ * @internal
+ */
+final class HeaderParameterChecker
+{
+    /**
+     * Ensures the two given headers do not share any parameter.
+     *
+     * The protected, unprotected and per-recipient headers of a token are merged into a single JOSE header, hence a
+     * parameter set in more than one of them is rejected: see RFC 7515 section 7.2.1 and RFC 7516 section 7.2.1.
+     *
+     * @param array<array-key, mixed> $header1
+     * @param array<array-key, mixed> $header2
+     */
+    public static function checkDuplicates(array $header1, array $header2): void
+    {
+        $inter = array_intersect_key($header1, $header2);
+        if (count($inter) !== 0) {
+            throw new InvalidHeaderParameterException(sprintf(
+                'The header contains duplicated entries: %s.',
+                implode(', ', array_keys($inter))
+            ));
+        }
+    }
+}

--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -13,6 +13,7 @@ use Jose\Component\Core\Exception\RuntimeException;
 use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\HeaderParameterChecker;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Core\Util\KeyChecker;
@@ -23,6 +24,7 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyAgreementWithKeyWrappin
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyEncryption;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyWrapping;
 use Jose\Component\Encryption\Algorithm\KeyEncryptionAlgorithm;
+use Jose\Component\Encryption\Util\EncryptionAlgorithmManagers;
 use function array_key_exists;
 use function count;
 use function intdiv;
@@ -73,18 +75,9 @@ class JWEBuilder implements JWEBuilderInterface
     public function __construct(AlgorithmManager $algorithmManager)
     {
         InheritanceChecker::warnIfExtended(static::class, self::class, JWEBuilderInterface::class);
-        $keyEncryptionAlgorithms = [];
-        $contentEncryptionAlgorithms = [];
-        foreach ($algorithmManager->all() as $algorithm) {
-            if ($algorithm instanceof KeyEncryptionAlgorithm) {
-                $keyEncryptionAlgorithms[] = $algorithm;
-            }
-            if ($algorithm instanceof ContentEncryptionAlgorithm) {
-                $contentEncryptionAlgorithms[] = $algorithm;
-            }
-        }
-        $this->keyEncryptionAlgorithmManager = new AlgorithmManager($keyEncryptionAlgorithms);
-        $this->contentEncryptionAlgorithmManager = new AlgorithmManager($contentEncryptionAlgorithms);
+        $managers = EncryptionAlgorithmManagers::split($algorithmManager, static::class);
+        $this->keyEncryptionAlgorithmManager = $managers->keyEncryption;
+        $this->contentEncryptionAlgorithmManager = $managers->contentEncryption;
     }
 
     /**
@@ -321,10 +314,10 @@ class JWEBuilder implements JWEBuilderInterface
      */
     private function checkDuplicatedHeaderParametersOfAllRecipients(): void
     {
-        $this->checkDuplicatedHeaderParameters($this->sharedProtectedHeader, $this->sharedHeader);
+        HeaderParameterChecker::checkDuplicates($this->sharedProtectedHeader, $this->sharedHeader);
         foreach ($this->recipients as $recipient) {
-            $this->checkDuplicatedHeaderParameters($this->sharedProtectedHeader, $recipient->header);
-            $this->checkDuplicatedHeaderParameters($this->sharedHeader, $recipient->header);
+            HeaderParameterChecker::checkDuplicates($this->sharedProtectedHeader, $recipient->header);
+            HeaderParameterChecker::checkDuplicates($this->sharedHeader, $recipient->header);
         }
     }
 
@@ -736,20 +729,5 @@ class JWEBuilder implements JWEBuilderInterface
         }
 
         return $contentEncryptionAlgorithm;
-    }
-
-    /**
-     * @param array<string, mixed> $header1
-     * @param array<string, mixed> $header2
-     */
-    private function checkDuplicatedHeaderParameters(array $header1, array $header2): void
-    {
-        $inter = array_intersect_key($header1, $header2);
-        if (count($inter) !== 0) {
-            throw new InvalidHeaderParameterException(sprintf(
-                'The header contains duplicated entries: %s.',
-                implode(', ', array_keys($inter))
-            ));
-        }
     }
 }

--- a/src/Library/Encryption/JWEDecrypter.php
+++ b/src/Library/Encryption/JWEDecrypter.php
@@ -12,6 +12,7 @@ use Jose\Component\Core\Exception\InvalidKeySetException;
 use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\HeaderParameterChecker;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
@@ -21,8 +22,8 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyAgreementWithKeyWrappin
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyEncryption;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyWrapping;
 use Jose\Component\Encryption\Algorithm\KeyEncryptionAlgorithm;
+use Jose\Component\Encryption\Util\EncryptionAlgorithmManagers;
 use Throwable;
-use function count;
 use function func_num_args;
 use function is_callable;
 use function is_string;
@@ -42,18 +43,9 @@ class JWEDecrypter implements JWEDecrypterInterface
     public function __construct(AlgorithmManager $algorithmManager)
     {
         InheritanceChecker::warnIfExtended(static::class, self::class, JWEDecrypterInterface::class);
-        $keyEncryptionAlgorithms = [];
-        $contentEncryptionAlgorithms = [];
-        foreach ($algorithmManager->all() as $key => $algorithm) {
-            if ($algorithm instanceof KeyEncryptionAlgorithm) {
-                $keyEncryptionAlgorithms[$key] = $algorithm;
-            }
-            if ($algorithm instanceof ContentEncryptionAlgorithm) {
-                $contentEncryptionAlgorithms[$key] = $algorithm;
-            }
-        }
-        $this->keyEncryptionAlgorithmManager = new AlgorithmManager($keyEncryptionAlgorithms);
-        $this->contentEncryptionAlgorithmManager = new AlgorithmManager($contentEncryptionAlgorithms);
+        $managers = EncryptionAlgorithmManagers::split($algorithmManager, static::class);
+        $this->keyEncryptionAlgorithmManager = $managers->keyEncryption;
+        $this->contentEncryptionAlgorithmManager = $managers->contentEncryption;
     }
 
     /**
@@ -157,9 +149,9 @@ class JWEDecrypter implements JWEDecrypterInterface
         $sharedHeader = $jwe->getSharedHeader();
         $recipientHeader = $recipient->getHeader();
 
-        $this->checkDuplicatedHeaderParameters($sharedProtectedHeader, $sharedHeader);
-        $this->checkDuplicatedHeaderParameters($sharedProtectedHeader, $recipientHeader);
-        $this->checkDuplicatedHeaderParameters($sharedHeader, $recipientHeader);
+        HeaderParameterChecker::checkDuplicates($sharedProtectedHeader, $sharedHeader);
+        HeaderParameterChecker::checkDuplicates($sharedProtectedHeader, $recipientHeader);
+        HeaderParameterChecker::checkDuplicates($sharedHeader, $recipientHeader);
 
         $completeHeader = array_merge($sharedHeader, $recipientHeader, $sharedProtectedHeader);
         $this->checkCompleteHeader($completeHeader);
@@ -340,16 +332,5 @@ class JWEDecrypter implements JWEDecrypterInterface
         }
 
         return $content_encryption_algorithm;
-    }
-
-    private function checkDuplicatedHeaderParameters(array $header1, array $header2): void
-    {
-        $inter = array_intersect_key($header1, $header2);
-        if (count($inter) !== 0) {
-            throw new InvalidHeaderParameterException(sprintf(
-                'The header contains duplicated entries: %s.',
-                implode(', ', array_keys($inter))
-            ));
-        }
     }
 }

--- a/src/Library/Encryption/Serializer/JWESerializerManagerFactory.php
+++ b/src/Library/Encryption/Serializer/JWESerializerManagerFactory.php
@@ -5,58 +5,52 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption\Serializer;
 
 use Jose\Component\Core\Exception\UnsupportedSerializerException;
-use function sprintf;
+use Jose\Component\Core\Util\AliasedRegistry;
+use function trigger_deprecation;
 
 final class JWESerializerManagerFactory
 {
     /**
-     * @var JWESerializer[]
+     * @use AliasedRegistry<JWESerializer>
      */
-    private array $serializers = [];
+    use AliasedRegistry;
 
     /**
-     * Creates a serializer manager factory using the given serializers.
+     * Creates a serializer manager using the given serializer names.
      *
      * @param string[] $names
      */
     public function create(array $names): JWESerializerManager
     {
-        $serializers = [];
-        foreach ($names as $name) {
-            if (! isset($this->serializers[$name])) {
-                throw new UnsupportedSerializerException(sprintf('Unsupported serializer "%s".', $name));
-            }
-            $serializers[] = $this->serializers[$name];
-        }
-
-        return new JWESerializerManager($serializers);
+        return new JWESerializerManager(
+            $this->select($names, 'JWE serializer', UnsupportedSerializerException::class)
+        );
     }
 
     /**
-     * Return the serializer names supported by the manager.
+     * Returns the serializer names supported by this factory.
+     *
+     * @deprecated since 4.3.0, will be removed in 5.0.0. Please use "aliases()" instead.
      *
      * @return string[]
      */
     public function names(): array
     {
-        return array_keys($this->serializers);
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::names()" is deprecated and will be removed in 5.0.0. Please use "aliases()" instead.',
+            self::class
+        );
+
+        return $this->aliases();
     }
 
     /**
-     * Returns all serializers supported by this factory.
-     *
-     * @return JWESerializer[]
-     */
-    public function all(): array
-    {
-        return $this->serializers;
-    }
-
-    /**
-     * Adds a serializer to the manager.
+     * Adds a serializer to this factory. The serializer is registered under its own name.
      */
     public function add(JWESerializer $serializer): void
     {
-        $this->serializers[$serializer->name()] = $serializer;
+        $this->register($serializer->name(), $serializer);
     }
 }

--- a/src/Library/Encryption/Util/EncryptionAlgorithmManagers.php
+++ b/src/Library/Encryption/Util/EncryptionAlgorithmManagers.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption\Util;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
+use Jose\Component\Encryption\Algorithm\KeyEncryptionAlgorithm;
+use function count;
+use function implode;
+use function trigger_deprecation;
+
+/**
+ * The two algorithm managers the JWE builder and the JWE decrypter work with, extracted from the single manager they
+ * receive: the one with the key encryption algorithms and the one with the content encryption algorithms.
+ *
+ * @internal
+ */
+final readonly class EncryptionAlgorithmManagers
+{
+    private function __construct(
+        public AlgorithmManager $keyEncryption,
+        public AlgorithmManager $contentEncryption
+    ) {
+    }
+
+    /**
+     * Splits the given manager. The caller is the class the manager was given to; it is only used to report the
+     * algorithms that are neither key encryption nor content encryption algorithms.
+     *
+     * Those algorithms are dropped, which turns a misconfiguration into an "algorithm not supported" error much later.
+     * Dropping them is deprecated since 4.3.0: in 5.0.0 the builder and the decrypter will be given the two managers
+     * directly and will not have to guess anything.
+     */
+    public static function split(AlgorithmManager $algorithmManager, string $caller): self
+    {
+        $keyEncryptionAlgorithms = [];
+        $contentEncryptionAlgorithms = [];
+        $ignored = [];
+        foreach ($algorithmManager->all() as $name => $algorithm) {
+            $supported = false;
+            if ($algorithm instanceof KeyEncryptionAlgorithm) {
+                $keyEncryptionAlgorithms[$name] = $algorithm;
+                $supported = true;
+            }
+            if ($algorithm instanceof ContentEncryptionAlgorithm) {
+                $contentEncryptionAlgorithms[$name] = $algorithm;
+                $supported = true;
+            }
+            if (! $supported) {
+                $ignored[] = $name;
+            }
+        }
+        if (count($ignored) !== 0) {
+            trigger_deprecation(
+                'web-token/jwt-framework',
+                '4.3.0',
+                'Passing algorithms that are neither key encryption nor content encryption algorithms to "%s" is deprecated. The following algorithms are currently ignored and will be rejected in 5.0.0: %s.',
+                $caller,
+                implode(', ', $ignored)
+            );
+        }
+
+        return new self(new AlgorithmManager($keyEncryptionAlgorithms), new AlgorithmManager(
+            $contentEncryptionAlgorithms
+        ));
+    }
+}

--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -15,6 +15,7 @@ use Jose\Component\Core\Exception\RuntimeException;
 use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\HeaderParameterChecker;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Core\Util\KeyChecker;
@@ -157,7 +158,7 @@ class JWSBuilder implements JWSBuilderInterface
     public function addSignature(JWK $signatureKey, array $protectedHeader, array $header = []): self
     {
         $this->checkB64AndCriticalHeader($protectedHeader);
-        $this->checkDuplicatedHeaderParameters($protectedHeader, $header);
+        HeaderParameterChecker::checkDuplicates($protectedHeader, $header);
         KeyChecker::checkKeyUsage($signatureKey, 'signature');
         $algorithm = $this->findSignatureAlgorithm($signatureKey, $protectedHeader, $header);
         KeyChecker::checkKeyAlgorithm($signatureKey, $algorithm->name());
@@ -314,20 +315,5 @@ class JWSBuilder implements JWSBuilderInterface
         }
 
         return $algorithm;
-    }
-
-    /**
-     * @param array<string, mixed> $header1
-     * @param array<string, mixed> $header2
-     */
-    private function checkDuplicatedHeaderParameters(array $header1, array $header2): void
-    {
-        $inter = array_intersect_key($header1, $header2);
-        if (count($inter) !== 0) {
-            throw new InvalidHeaderParameterException(sprintf(
-                'The header contains duplicated entries: %s.',
-                implode(', ', array_keys($inter))
-            ));
-        }
     }
 }

--- a/src/Library/Signature/Serializer/JWSSerializerManagerFactory.php
+++ b/src/Library/Signature/Serializer/JWSSerializerManagerFactory.php
@@ -5,49 +5,52 @@ declare(strict_types=1);
 namespace Jose\Component\Signature\Serializer;
 
 use Jose\Component\Core\Exception\UnsupportedSerializerException;
-use function sprintf;
+use Jose\Component\Core\Util\AliasedRegistry;
+use function trigger_deprecation;
 
 final class JWSSerializerManagerFactory
 {
     /**
-     * @var JWSSerializer[]
+     * @use AliasedRegistry<JWSSerializer>
      */
-    private array $serializers = [];
+    use AliasedRegistry;
 
     /**
+     * Creates a serializer manager using the given serializer names.
+     *
      * @param string[] $names
      */
     public function create(array $names): JWSSerializerManager
     {
-        $serializers = [];
-        foreach ($names as $name) {
-            if (! isset($this->serializers[$name])) {
-                throw new UnsupportedSerializerException(sprintf('Unsupported serializer "%s".', $name));
-            }
-            $serializers[] = $this->serializers[$name];
-        }
-
-        return new JWSSerializerManager($serializers);
+        return new JWSSerializerManager(
+            $this->select($names, 'JWS serializer', UnsupportedSerializerException::class)
+        );
     }
 
     /**
+     * Returns the serializer names supported by this factory.
+     *
+     * @deprecated since 4.3.0, will be removed in 5.0.0. Please use "aliases()" instead.
+     *
      * @return string[]
      */
     public function names(): array
     {
-        return array_keys($this->serializers);
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::names()" is deprecated and will be removed in 5.0.0. Please use "aliases()" instead.',
+            self::class
+        );
+
+        return $this->aliases();
     }
 
     /**
-     * @return JWSSerializer[]
+     * Adds a serializer to this factory. The serializer is registered under its own name.
      */
-    public function all(): array
-    {
-        return $this->serializers;
-    }
-
     public function add(JWSSerializer $serializer): void
     {
-        $this->serializers[$serializer->name()] = $serializer;
+        $this->register($serializer->name(), $serializer);
     }
 }

--- a/tests/Component/Core/AliasedRegistryTest.php
+++ b/tests/Component/Core/AliasedRegistryTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Core;
+
+use Jose\Component\Checker\AlgorithmChecker;
+use Jose\Component\Checker\AudienceChecker;
+use Jose\Component\Checker\ClaimCheckerManagerFactory;
+use Jose\Component\Checker\HeaderCheckerManagerFactory;
+use Jose\Component\Core\AlgorithmManagerFactory;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\UnsupportedSerializerException;
+use Jose\Component\Encryption\Serializer\CompactSerializer as JWECompactSerializer;
+use Jose\Component\Encryption\Serializer\JWESerializerManagerFactory;
+use Jose\Component\Signature\Serializer\CompactSerializer as JWSCompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManagerFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function sprintf;
+use const E_USER_DEPRECATED;
+
+/**
+ * The factories of the library share the same "alias => object" registry: they list their aliases the same way and they
+ * reject an unknown alias the same way.
+ *
+ * @internal
+ */
+final class AliasedRegistryTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('factories')]
+    public function theRegisteredAliasesAreListed(
+        object $factory,
+        string $alias,
+        string $label,
+        string $exceptionClass
+    ): void {
+        static::assertSame([$alias], $factory->aliases());
+        static::assertSame([$alias], array_keys($factory->all()));
+    }
+
+    #[Test]
+    #[DataProvider('factories')]
+    public function anUnknownAliasIsRejected(
+        object $factory,
+        string $alias,
+        string $label,
+        string $exceptionClass
+    ): void {
+        $this->expectException($exceptionClass);
+        $this->expectExceptionMessage(sprintf('The %s with the alias "unknown" is not supported.', $label));
+
+        $factory->create(['unknown']);
+    }
+
+    #[Test]
+    #[DataProvider('factories')]
+    public function theRegisteredObjectsAreSelected(
+        object $factory,
+        string $alias,
+        string $label,
+        string $exceptionClass
+    ): void {
+        $manager = $factory->create([$alias]);
+
+        static::assertNotNull($manager);
+    }
+
+    #[Test]
+    public function theJwsSerializerFactoryStillSupportsTheDeprecatedNamesMethod(): void
+    {
+        $factory = new JWSSerializerManagerFactory();
+        $factory->add(new JWSCompactSerializer());
+
+        $names = null;
+        $deprecations = $this->collectDeprecations(static function () use ($factory, &$names): void {
+            $names = $factory->names();
+        });
+
+        static::assertSame($factory->aliases(), $names);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            'The method "Jose\Component\Signature\Serializer\JWSSerializerManagerFactory::names()" is deprecated',
+            $deprecations[0]
+        );
+    }
+
+    #[Test]
+    public function theJweSerializerFactoryStillSupportsTheDeprecatedNamesMethod(): void
+    {
+        $factory = new JWESerializerManagerFactory();
+        $factory->add(new JWECompactSerializer());
+
+        $names = null;
+        $deprecations = $this->collectDeprecations(static function () use ($factory, &$names): void {
+            $names = $factory->names();
+        });
+
+        static::assertSame($factory->aliases(), $names);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            'The method "Jose\Component\Encryption\Serializer\JWESerializerManagerFactory::names()" is deprecated',
+            $deprecations[0]
+        );
+    }
+
+    /**
+     * @return iterable<string, array{object, string, string, class-string<InvalidArgumentException>}>
+     */
+    public static function factories(): iterable
+    {
+        $algorithms = new AlgorithmManagerFactory([new FooAlgorithm()]);
+
+        yield 'algorithm' => [$algorithms, 'foo', 'algorithm', InvalidArgumentException::class];
+
+        $headerCheckers = new HeaderCheckerManagerFactory();
+        $headerCheckers->add('foo', new AlgorithmChecker(['HS256']));
+
+        yield 'header checker' => [$headerCheckers, 'foo', 'header checker', InvalidArgumentException::class];
+
+        $claimCheckers = new ClaimCheckerManagerFactory();
+        $claimCheckers->add('foo', new AudienceChecker('bar'));
+
+        yield 'claim checker' => [$claimCheckers, 'foo', 'claim checker', InvalidArgumentException::class];
+
+        $jwsSerializers = new JWSSerializerManagerFactory();
+        $jwsSerializer = new JWSCompactSerializer();
+        $jwsSerializers->add($jwsSerializer);
+
+        yield 'JWS serializer' => [
+            $jwsSerializers,
+            $jwsSerializer->name(),
+            'JWS serializer',
+            UnsupportedSerializerException::class,
+        ];
+
+        $jweSerializers = new JWESerializerManagerFactory();
+        $jweSerializer = new JWECompactSerializer();
+        $jweSerializers->add($jweSerializer);
+
+        yield 'JWE serializer' => [
+            $jweSerializers,
+            $jweSerializer->name(),
+            'JWE serializer',
+            UnsupportedSerializerException::class,
+        ];
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}

--- a/tests/Component/Encryption/EncryptionAlgorithmManagerSplitTest.php
+++ b/tests/Component/Encryption/EncryptionAlgorithmManagerSplitTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Encryption;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128GCM;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\A128KW;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Signature\Algorithm\HS256;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use const E_USER_DEPRECATED;
+
+/**
+ * The JWE builder and the JWE decrypter receive a single algorithm manager they split in two: the key encryption
+ * algorithms and the content encryption algorithms. An algorithm that is neither is dropped, which is deprecated.
+ *
+ * @internal
+ */
+final class EncryptionAlgorithmManagerSplitTest extends TestCase
+{
+    #[Test]
+    public function theBuilderSplitsTheAlgorithmManager(): void
+    {
+        $builder = new JWEBuilder(new AlgorithmManager([new A128KW(), new A128GCM()]));
+
+        static::assertSame(['A128KW'], $builder->getKeyEncryptionAlgorithmManager()->list());
+        static::assertSame(['A128GCM'], $builder->getContentEncryptionAlgorithmManager()->list());
+    }
+
+    #[Test]
+    public function theDecrypterSplitsTheAlgorithmManager(): void
+    {
+        $decrypter = new JWEDecrypter(new AlgorithmManager([new A128KW(), new A128GCM()]));
+
+        static::assertSame(['A128KW'], $decrypter->getKeyEncryptionAlgorithmManager()->list());
+        static::assertSame(['A128GCM'], $decrypter->getContentEncryptionAlgorithmManager()->list());
+    }
+
+    #[Test]
+    public function noDeprecationIsTriggeredWhenAllTheAlgorithmsAreEncryptionAlgorithms(): void
+    {
+        $algorithmManager = new AlgorithmManager([new A128KW(), new A128GCM()]);
+
+        $deprecations = $this->collectDeprecations(static function () use ($algorithmManager): void {
+            new JWEBuilder($algorithmManager);
+            new JWEDecrypter($algorithmManager);
+        });
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function theBuilderDeprecatesTheAlgorithmsItDrops(): void
+    {
+        $algorithmManager = new AlgorithmManager([new A128KW(), new A128GCM(), new HS256()]);
+
+        $builder = null;
+        $deprecations = $this->collectDeprecations(static function () use ($algorithmManager, &$builder): void {
+            $builder = new JWEBuilder($algorithmManager);
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(JWEBuilder::class, $deprecations[0]);
+        static::assertStringContainsString('HS256', $deprecations[0]);
+        static::assertSame(['A128KW'], $builder->getKeyEncryptionAlgorithmManager()->list());
+        static::assertSame(['A128GCM'], $builder->getContentEncryptionAlgorithmManager()->list());
+    }
+
+    #[Test]
+    public function theDecrypterDeprecatesTheAlgorithmsItDrops(): void
+    {
+        $algorithmManager = new AlgorithmManager([new A128KW(), new A128GCM(), new HS256()]);
+
+        $decrypter = null;
+        $deprecations = $this->collectDeprecations(static function () use ($algorithmManager, &$decrypter): void {
+            $decrypter = new JWEDecrypter($algorithmManager);
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(JWEDecrypter::class, $deprecations[0]);
+        static::assertStringContainsString('HS256', $deprecations[0]);
+        static::assertSame(['A128KW'], $decrypter->getKeyEncryptionAlgorithmManager()->list());
+        static::assertSame(['A128GCM'], $decrypter->getContentEncryptionAlgorithmManager()->list());
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}


### PR DESCRIPTION
Closes #689.

Three pieces of copy-pasted logic are extracted into `@internal` helpers. No BC break: every public method is kept, with the same signature.

## 1. The alias registries

`AlgorithmManagerFactory`, `HeaderCheckerManagerFactory`, `ClaimCheckerManagerFactory`, `JWSSerializerManagerFactory` and `JWESerializerManagerFactory` each implemented their own `alias => object` map. They now share `Jose\Component\Core\Util\AliasedRegistry`, a generic `@internal` trait holding the map, `aliases()`, `all()`, the registration and the lookup. The two bundle factories (`Jose\Bundle\JoseFramework\Services\{Claim,Header}CheckerManagerFactory`) are rebased on it too.

The five error messages become one template, `The <what> with the alias "<alias>" is not supported.`. Each factory keeps the exception class it threw before, passed to the shared lookup:

| factory | exception | message before | after |
| --- | --- | --- | --- |
| `AlgorithmManagerFactory` | `InvalidArgumentException` | `The algorithm with the alias "foo" is not supported.` | unchanged |
| `HeaderCheckerManagerFactory` | `InvalidArgumentException` | `The header checker with the alias "foo" is not supported.` | unchanged |
| `ClaimCheckerManagerFactory` | `InvalidArgumentException` | `The claim checker with the alias "foo" is not supported.` | unchanged |
| `JWSSerializerManagerFactory` | `UnsupportedSerializerException` | `Unsupported serializer "foo".` | `The JWS serializer with the alias "foo" is not supported.` |
| `JWESerializerManagerFactory` | `UnsupportedSerializerException` | `Unsupported serializer "foo".` | `The JWE serializer with the alias "foo" is not supported.` |

The two serializer factories gain `aliases()` and their `names()` is **deprecated** (it still works and returns the same thing). The four bundle classes that called it use `aliases()` now.

## 2. `checkDuplicatedHeaderParameters()`

Duplicated verbatim in `JWSBuilder`, `JWEBuilder`, `JWEDecrypter` and `HeaderCheckerManager`. It moves to `Jose\Component\Core\Util\HeaderParameterChecker::checkDuplicates()`. The `InvalidHeaderParameterException` and its message are unchanged.

## 3. Splitting the algorithm manager in the JWE components

`JWEBuilder::__construct()` and `JWEDecrypter::__construct()` both split the manager they receive by `instanceof`. That moves to `Jose\Component\Encryption\Util\EncryptionAlgorithmManagers::split()`.

That constructor also silently dropped any algorithm that is neither a key encryption nor a content encryption algorithm, so a misconfiguration only surfaced much later as an `algorithm not supported` error. Dropping them is now **deprecated** and the ignored algorithms are named:

> Passing algorithms that are neither key encryption nor content encryption algorithms to "Jose\Component\Encryption\JWEBuilder" is deprecated. The following algorithms are currently ignored and will be rejected in 5.0.0: HS256.

The behaviour itself is unchanged; only the deprecation is new.

## Left for 5.0.0

- Remove `names()` from both serializer factories.
- Have `JWEBuilder` and `JWEDecrypter` accept two explicit managers instead of one they have to split.

## Tests

- `tests/Component/Core/AliasedRegistryTest.php` — the five factories list their aliases and reject an unknown alias with the same message and the expected exception class; `names()` still works and deprecates.
- `tests/Component/Encryption/EncryptionAlgorithmManagerSplitTest.php` — the split, and the deprecation of the dropped algorithms, for both the builder and the decrypter.

Rebased on 4.3.x after #703, #706, #707 and #709. Local run: PHPUnit 1010 tests green, PHPStan (level max) 0 errors, ECS, Rector and Deptrac green. 7 now-obsolete entries were removed from the PHPStan baseline.