### PR TITLE
feat(signature): unify MAC and signature algorithms behind sign()

### DIFF
--- a/src/Bundle/DataCollector/AlgorithmCollector.php
+++ b/src/Bundle/DataCollector/AlgorithmCollector.php
@@ -70,15 +70,15 @@ final readonly class AlgorithmCollector implements Collector
         int &$contentEncryptionAlgorithms
     ): string {
         switch (true) {
-            case $algorithm instanceof SignatureAlgorithm:
-                $signatureAlgorithms++;
-
-                return 'Signature';
-
             case $algorithm instanceof MacAlgorithm:
                 $macAlgorithms++;
 
                 return 'MAC';
+
+            case $algorithm instanceof SignatureAlgorithm:
+                $signatureAlgorithms++;
+
+                return 'Signature';
 
             case $algorithm instanceof KeyEncryptionAlgorithm:
                 $keyEncryptionAlgorithms++;

--- a/src/Experimental/Signature/Blake2b.php
+++ b/src/Experimental/Signature/Blake2b.php
@@ -8,17 +8,19 @@ use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
+use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
 use Override;
 use RuntimeException;
 use function extension_loaded;
 use function in_array;
 use function is_string;
 use function strlen;
+use function trigger_deprecation;
 
 /**
  * @see \Jose\Tests\Component\Signature\Algorithm\Blake2bTest
  */
-final readonly class Blake2b implements MacAlgorithm
+final readonly class Blake2b implements MacAlgorithm, SignatureAlgorithm
 {
     private const MINIMUM_KEY_LENGTH = 32;
 
@@ -44,15 +46,32 @@ final readonly class Blake2b implements MacAlgorithm
     #[Override]
     public function verify(JWK $key, string $input, string $signature): bool
     {
-        return hash_equals($this->hash($key, $input), $signature);
+        return hash_equals($this->sign($key, $input), $signature);
     }
 
     #[Override]
-    public function hash(JWK $key, string $input): string
+    public function sign(JWK $key, string $input): string
     {
         $k = $this->getKey($key);
 
         return sodium_crypto_generichash($input, $k);
+    }
+
+    /**
+     * @deprecated since 4.3.0, use sign() instead. Will be removed in 5.0.0.
+     */
+    #[Override]
+    public function hash(JWK $key, string $input): string
+    {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::hash()" is deprecated and will be removed in 5.0.0. Use "%s::sign()" instead.',
+            self::class,
+            self::class
+        );
+
+        return $this->sign($key, $input);
     }
 
     private function getKey(JWK $key): string

--- a/src/Experimental/Signature/HS256_64.php
+++ b/src/Experimental/Signature/HS256_64.php
@@ -11,6 +11,15 @@ use Override;
 final readonly class HS256_64 extends HMAC
 {
     #[Override]
+    public function sign(JWK $key, string $input): string
+    {
+        return substr($this->computeMac($key, $input), 0, 8);
+    }
+
+    /**
+     * @deprecated since 4.3.0, use sign() instead. Will be removed in 5.0.0.
+     */
+    #[Override]
     public function hash(JWK $key, string $input): string
     {
         $signature = parent::hash($key, $input);

--- a/src/Experimental/composer.json
+++ b/src/Experimental/composer.json
@@ -40,6 +40,7 @@
     "require": {
         "php": ">=8.2",
         "ext-openssl": "*",
+        "symfony/deprecation-contracts": "^2.5|^3.0",
         "web-token/jwt-library": "^4.0"
     }
 }

--- a/src/Library/Signature/Algorithm/HMAC.php
+++ b/src/Library/Signature/Algorithm/HMAC.php
@@ -8,10 +8,12 @@ use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
+use ReflectionMethod;
 use function in_array;
 use function is_string;
+use function trigger_deprecation;
 
-abstract readonly class HMAC implements MacAlgorithm
+abstract readonly class HMAC implements MacAlgorithm, SignatureAlgorithm
 {
     #[Override]
     public function allowedKeyTypes(): array
@@ -22,11 +24,38 @@ abstract readonly class HMAC implements MacAlgorithm
     #[Override]
     public function verify(JWK $key, string $input, string $signature): bool
     {
-        return hash_equals($this->hash($key, $input), $signature);
+        return hash_equals($this->sign($key, $input), $signature);
     }
 
     #[Override]
+    public function sign(JWK $key, string $input): string
+    {
+        if ($this->overridesHash()) {
+            // @phpstan-ignore method.deprecated (the override of a subclass is honoured until 5.0.0)
+            return $this->hash($key, $input);
+        }
+
+        return $this->computeMac($key, $input);
+    }
+
+    /**
+     * @deprecated since 4.3.0, use sign() instead. Will be removed in 5.0.0.
+     */
+    #[Override]
     public function hash(JWK $key, string $input): string
+    {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::hash()" is deprecated and will be removed in 5.0.0. Use "%s::sign()" instead.',
+            static::class,
+            static::class
+        );
+
+        return $this->computeMac($key, $input);
+    }
+
+    protected function computeMac(JWK $key, string $input): string
     {
         $k = $this->getKey($key);
 
@@ -50,4 +79,17 @@ abstract readonly class HMAC implements MacAlgorithm
     }
 
     abstract protected function getHashAlgorithm(): string;
+
+    /**
+     * Tells whether the concrete algorithm alters the signature by overriding the deprecated hash() method, as
+     * subclasses had to do before sign() existed. Their override is honoured until 5.0.0, when hash() is removed.
+     */
+    private function overridesHash(): bool
+    {
+        /** @var array<class-string, bool> $overrides */
+        static $overrides = [];
+
+        return $overrides[static::class] ??= (new ReflectionMethod(static::class, 'hash'))->getDeclaringClass()
+            ->getName() !== self::class;
+    }
 }

--- a/src/Library/Signature/Algorithm/MacAlgorithm.php
+++ b/src/Library/Signature/Algorithm/MacAlgorithm.php
@@ -7,10 +7,20 @@ namespace Jose\Component\Signature\Algorithm;
 use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\JWK;
 
+/**
+ * A MAC algorithm is a signature algorithm: it produces a signature from a key and an input, and verifies it.
+ *
+ * The interface only exists to tell symmetric algorithms apart from the asymmetric ones, for key selection or policy
+ * decisions. Since 4.3.0 every MAC algorithm shipped by the library also implements SignatureAlgorithm, and sign() is
+ * the method to call. Implement both interfaces to be ready for 5.0.0, where MacAlgorithm will extend
+ * SignatureAlgorithm and hash() will be removed.
+ */
 interface MacAlgorithm extends Algorithm
 {
     /**
      * Sign the input.
+     *
+     * @deprecated since 4.3.0, use SignatureAlgorithm::sign() instead. Will be removed in 5.0.0.
      *
      * @param JWK $key The private key used to hash the data
      * @param string $input The input

--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -22,6 +22,7 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function sprintf;
+use function trigger_deprecation;
 
 class JWSBuilder
 {
@@ -193,15 +194,39 @@ class JWSBuilder
                 JsonConverter::encode($protectedHeader)
             );
             $input = sprintf('%s.%s', $encodedProtectedHeader, $encodedPayload);
-            if ($algorithm instanceof SignatureAlgorithm) {
-                $s = $algorithm->sign($signatureKey, $input);
-            } else {
-                $s = $algorithm->hash($signatureKey, $input);
-            }
+            $s = $this->computeSignature($algorithm, $signatureKey, $input);
             $jws = $jws->addSignature($s, $protectedHeader, $encodedProtectedHeader, $header);
         }
 
         return $jws;
+    }
+
+    /**
+     * Computes the signature of the input.
+     *
+     * Algorithms that only implement MacAlgorithm are signed through hash(); that fallback goes away in 5.0.0, when
+     * MacAlgorithm will extend SignatureAlgorithm.
+     *
+     * @param MacAlgorithm|SignatureAlgorithm $algorithm
+     */
+    private function computeSignature(Algorithm $algorithm, JWK $key, string $input): string
+    {
+        if ($algorithm instanceof SignatureAlgorithm) {
+            return $algorithm->sign($key, $input);
+        }
+
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The class "%s" implements "%s" only. Relying on "%s::hash()" is deprecated since 4.3.0 and will not be supported in 5.0.0: implement "%s" and its sign() method instead.',
+            $algorithm::class,
+            MacAlgorithm::class,
+            MacAlgorithm::class,
+            SignatureAlgorithm::class
+        );
+
+        // @phpstan-ignore method.deprecated (the deprecated method is still supported until 5.0.0)
+        return $algorithm->hash($key, $input);
     }
 
     /**

--- a/tests/Component/Signature/LegacyMacAlgorithmTest.php
+++ b/tests/Component/Signature/LegacyMacAlgorithmTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Signature;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Tests\Component\Signature\Stub\LegacyMacAlgorithm;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class LegacyMacAlgorithmTest extends TestCase
+{
+    private const PAYLOAD = 'Live long and Prosper.';
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function anAlgorithmThatOnlyImplementsMacAlgorithmStillProducesAValidToken(): void
+    {
+        $algorithm = new LegacyMacAlgorithm();
+        $key = $this->getKey();
+        $algorithmManager = new AlgorithmManager([$algorithm]);
+        $serializer = new CompactSerializer();
+
+        $jws = (new JWSBuilder($algorithmManager))
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->addSignature($key, [
+                'alg' => 'LEGACY-HS256',
+            ])
+            ->build();
+        $token = $serializer->serialize($jws, 0);
+
+        $loaded = $serializer->unserialize($token);
+
+        static::assertSame(self::PAYLOAD, $loaded->getPayload());
+        static::assertTrue((new JWSVerifier($algorithmManager))->verifyWithKey($loaded, $key, 0));
+    }
+
+    #[Test]
+    public function signingWithAnAlgorithmThatOnlyImplementsMacAlgorithmIsDeprecated(): void
+    {
+        $this->expectUserDeprecationMessage(
+            'Since web-token/jwt-framework 4.3.0: The class "Jose\Tests\Component\Signature\Stub\LegacyMacAlgorithm" implements "Jose\Component\Signature\Algorithm\MacAlgorithm" only. Relying on "Jose\Component\Signature\Algorithm\MacAlgorithm::hash()" is deprecated since 4.3.0 and will not be supported in 5.0.0: implement "Jose\Component\Signature\Algorithm\SignatureAlgorithm" and its sign() method instead.'
+        );
+
+        $jws = (new JWSBuilder(new AlgorithmManager([new LegacyMacAlgorithm()])))
+            ->create()
+            ->withPayload(self::PAYLOAD)
+            ->addSignature($this->getKey(), [
+                'alg' => 'LEGACY-HS256',
+            ])
+            ->build();
+
+        static::assertSame(1, $jws->countSignatures());
+    }
+
+    private function getKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => Base64UrlSafe::encodeUnpadded('foofoofoofoofoofoofoofoofoofoofo'),
+        ]);
+    }
+}

--- a/tests/Component/Signature/Stub/LegacyMacAlgorithm.php
+++ b/tests/Component/Signature/Stub/LegacyMacAlgorithm.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Signature\Stub;
+
+use InvalidArgumentException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Signature\Algorithm\MacAlgorithm;
+use Override;
+use function in_array;
+use function is_string;
+
+/**
+ * A MAC algorithm that only implements MacAlgorithm, the way third-party algorithms did before 4.3.0 introduced
+ * SignatureAlgorithm::sign() as the method to use.
+ */
+final readonly class LegacyMacAlgorithm implements MacAlgorithm
+{
+    #[Override]
+    public function name(): string
+    {
+        return 'LEGACY-HS256';
+    }
+
+    #[Override]
+    public function allowedKeyTypes(): array
+    {
+        return ['oct'];
+    }
+
+    #[Override]
+    public function hash(JWK $key, string $input): string
+    {
+        return hash_hmac('sha256', $input, $this->getKey($key), true);
+    }
+
+    #[Override]
+    public function verify(JWK $key, string $input, string $signature): bool
+    {
+        return hash_equals($this->hash($key, $input), $signature);
+    }
+
+    private function getKey(JWK $key): string
+    {
+        if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
+            throw new InvalidArgumentException('Wrong key type.');
+        }
+        $k = $key->get('k');
+        if (! is_string($k)) {
+            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+        }
+
+        return Base64UrlSafe::decodeNoPadding($k);
+    }
+}

--- a/tests/SignatureAlgorithm/Experimental/Blake2bTest.php
+++ b/tests/SignatureAlgorithm/Experimental/Blake2bTest.php
@@ -7,8 +7,10 @@ namespace Jose\Tests\SignatureAlgorithm\Experimental;
 use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
 use Jose\Experimental\Signature\Blake2b;
 use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -60,7 +62,7 @@ final class Blake2bTest extends TestCase
     {
         $algorithm = new Blake2b();
 
-        static::assertTrue(hash_equals($this->expectedHashWithKeyOne, $algorithm->hash($this->keyOne, self::CONTENTS)));
+        static::assertTrue(hash_equals($this->expectedHashWithKeyOne, $algorithm->sign($this->keyOne, self::CONTENTS)));
         static::assertTrue($algorithm->verify($this->keyOne, self::CONTENTS, $this->expectedHashWithKeyOne));
     }
 
@@ -76,7 +78,7 @@ final class Blake2bTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Key provided is shorter than 256 bits.');
 
-        $algorithm->hash($key, self::CONTENTS);
+        $algorithm->sign($key, self::CONTENTS);
     }
 
     #[Test]
@@ -85,8 +87,26 @@ final class Blake2bTest extends TestCase
         $algorithm = new Blake2b();
 
         static::assertFalse(
-            hash_equals($this->expectedHashWithKeyOne, $algorithm->hash($this->keyTwo, self::CONTENTS))
+            hash_equals($this->expectedHashWithKeyOne, $algorithm->sign($this->keyTwo, self::CONTENTS))
         );
         static::assertFalse($algorithm->verify($this->keyTwo, self::CONTENTS, $this->expectedHashWithKeyOne));
+    }
+
+    #[Test]
+    public function theAlgorithmIsASignatureAlgorithm(): void
+    {
+        static::assertInstanceOf(SignatureAlgorithm::class, new Blake2b());
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function theDeprecatedHashMethodReturnsTheSignature(): void
+    {
+        $algorithm = new Blake2b();
+
+        static::assertSame(
+            $algorithm->sign($this->keyOne, self::CONTENTS),
+            $algorithm->hash($this->keyOne, self::CONTENTS)
+        );
     }
 }

--- a/tests/SignatureAlgorithm/Experimental/ExperimentalHMACSignatureTest.php
+++ b/tests/SignatureAlgorithm/Experimental/ExperimentalHMACSignatureTest.php
@@ -7,6 +7,7 @@ namespace Jose\Tests\SignatureAlgorithm\Experimental;
 use Jose\Component\Core\JWK;
 use Jose\Experimental\Signature\HS1;
 use Jose\Experimental\Signature\HS256_64;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -24,7 +25,7 @@ final class ExperimentalHMACSignatureTest extends TestCase
 
         static::assertSame('HS1', $hmac->name());
 
-        $signature = $hmac->hash($key, $data);
+        $signature = $hmac->sign($key, $data);
 
         static::assertTrue($hmac->verify($key, $data, $signature));
     }
@@ -38,10 +39,21 @@ final class ExperimentalHMACSignatureTest extends TestCase
 
         static::assertSame('HS256/64', $hmac->name());
 
-        $signature = $hmac->hash($key, $data);
+        $signature = $hmac->sign($key, $data);
 
         static::assertSame(hex2bin('89f750759cb8ad93'), $signature);
         static::assertTrue($hmac->verify($key, $data, $signature));
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function theDeprecatedHashMethodOfATruncatedAlgorithmIsTruncatedToo(): void
+    {
+        $key = $this->getKey();
+        $hmac = new HS256_64();
+        $data = 'Live long and Prosper.';
+
+        static::assertSame(hex2bin('89f750759cb8ad93'), $hmac->hash($key, $data));
     }
 
     private function getKey(): JWK

--- a/tests/SignatureAlgorithm/HMAC/HMACSignatureTest.php
+++ b/tests/SignatureAlgorithm/HMAC/HMACSignatureTest.php
@@ -10,6 +10,10 @@ use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Signature\Algorithm\HS256;
 use Jose\Component\Signature\Algorithm\HS384;
 use Jose\Component\Signature\Algorithm\HS512;
+use Jose\Component\Signature\Algorithm\MacAlgorithm;
+use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
+use Jose\Tests\SignatureAlgorithm\HMAC\Stub\LegacyTruncatedHMAC;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -30,7 +34,7 @@ final class HMACSignatureTest extends TestCase
         $hmac = new HS256();
         $data = 'Live long and Prosper.';
 
-        $hmac->hash($key, $data);
+        $hmac->sign($key, $data);
     }
 
     #[Test]
@@ -60,7 +64,7 @@ final class HMACSignatureTest extends TestCase
         $hmac = new HS256();
         $data = 'Live long and Prosper.';
 
-        $signature = $hmac->hash($key, $data);
+        $signature = $hmac->sign($key, $data);
 
         static::assertTrue($hmac->verify($key, $data, $signature));
     }
@@ -77,7 +81,7 @@ final class HMACSignatureTest extends TestCase
         $hmac = new HS384();
         $data = 'Live long and Prosper.';
 
-        $signature = $hmac->hash($key, $data);
+        $signature = $hmac->sign($key, $data);
 
         static::assertTrue($hmac->verify($key, $data, $signature));
     }
@@ -92,11 +96,56 @@ final class HMACSignatureTest extends TestCase
         $hmac = new HS512();
         $data = 'Live long and Prosper.';
 
-        $signature = $hmac->hash($key, $data);
+        $signature = $hmac->sign($key, $data);
 
         static::assertSame(hex2bin(
             'e8b36712b6c6dc422eec77f31ce372ccac769450413238158bd702069630456a148d0c10dd3a661a774217fb90b0d5f94fa6c3c985438bade92ff975b9e4dc04'
         ), $signature);
+        static::assertTrue($hmac->verify($key, $data, $signature));
+    }
+
+    #[Test]
+    public function hmacAlgorithmsAreSignatureAlgorithms(): void
+    {
+        $hmac = new HS256();
+
+        static::assertInstanceOf(SignatureAlgorithm::class, $hmac);
+        static::assertInstanceOf(MacAlgorithm::class, $hmac);
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function theDeprecatedHashMethodReturnsTheSignature(): void
+    {
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => Base64UrlSafe::encodeUnpadded(
+                'foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo'
+            ),
+        ]);
+        $hmac = new HS256();
+        $data = 'Live long and Prosper.';
+
+        static::assertSame($hmac->sign($key, $data), $hmac->hash($key, $data));
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function anAlgorithmThatOverridesTheDeprecatedHashMethodIsStillHonoured(): void
+    {
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => Base64UrlSafe::encodeUnpadded(
+                'foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo'
+            ),
+        ]);
+        $hmac = new LegacyTruncatedHMAC();
+        $data = 'Live long and Prosper.';
+
+        $signature = $hmac->sign($key, $data);
+
+        static::assertSame($hmac->hash($key, $data), $signature);
+        static::assertSame(8, mb_strlen($signature, '8bit'));
         static::assertTrue($hmac->verify($key, $data, $signature));
     }
 }

--- a/tests/SignatureAlgorithm/HMAC/Stub/LegacyTruncatedHMAC.php
+++ b/tests/SignatureAlgorithm/HMAC/Stub/LegacyTruncatedHMAC.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\SignatureAlgorithm\HMAC\Stub;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\HMAC;
+use Override;
+
+/**
+ * An algorithm that alters the signature by overriding hash(), the only way to do so before 4.3.0 introduced sign().
+ */
+final readonly class LegacyTruncatedHMAC extends HMAC
+{
+    #[Override]
+    public function hash(JWK $key, string $input): string
+    {
+        return substr(parent::hash($key, $input), 0, 8);
+    }
+
+    #[Override]
+    public function name(): string
+    {
+        return 'LEGACY-HS256/64';
+    }
+
+    #[Override]
+    protected function getHashAlgorithm(): string
+    {
+        return 'sha256';
+    }
+}


### PR DESCRIPTION
Closes #687.

`MacAlgorithm` and `SignatureAlgorithm` describe the same operation under two names, which forced an `instanceof` dance at every call site and left methods typed `Algorithm` with a `@return MacAlgorithm|SignatureAlgorithm` docblock.

## What changes

- `HMAC` and `Blake2b` now implement `SignatureAlgorithm` in addition to `MacAlgorithm`. `sign()` carries the implementation, `verify()` uses it, and `hash()` is a deprecated alias.
- `MacAlgorithm::hash()` is deprecated in favour of `SignatureAlgorithm::sign()`.
- `JWSBuilder::build()` calls `sign()`; the `instanceof` branch moved to a single private helper that only serves algorithms which do not implement `SignatureAlgorithm`.
- `AlgorithmCollector` now tests `MacAlgorithm` before `SignatureAlgorithm`, so HMAC algorithms keep being reported as *MAC* in the profiler.
- `web-token/jwt-experimental` declares `symfony/deprecation-contracts`, which `Blake2b` now uses.

## Why `MacAlgorithm` does not extend `SignatureAlgorithm` yet

The 4.3.0 plan in #687 has `MacAlgorithm extends SignatureAlgorithm`, but that adds `sign()` to a public interface: every third-party class implementing `MacAlgorithm` would stop loading. The interface is therefore left untouched and the unification is done on the implementation side, which gets the same result for callers without breaking anyone. The interface change stays scheduled for 5.0.0, where `hash()` goes away and `MacAlgorithm` becomes a pure marker.

## Backward compatibility

Two legacy shapes keep working, each with a deprecation notice pointing at `sign()`:

- an algorithm implementing `MacAlgorithm` only — `JWSBuilder` signs it through `hash()`;
- a subclass of `HMAC` that alters the signature by overriding `hash()`, the way `HS256/64` did — `HMAC::sign()` detects the override and calls it, so such an algorithm does not silently start producing untruncated signatures.

The one visible behaviour change is that HMAC algorithms are now `instanceof SignatureAlgorithm`. Code that used that check to *exclude* symmetric algorithms must test `MacAlgorithm` first, as `AlgorithmCollector` now does.

## Tests

- `LegacyMacAlgorithmTest` signs and verifies a token with an algorithm implementing `MacAlgorithm` only, and asserts the deprecation message.
- `HMACSignatureTest` covers the unified interface, the `hash()` alias, and a subclass overriding `hash()` (`LegacyTruncatedHMAC`).
- `Blake2bTest` and `ExperimentalHMACSignatureTest` cover the same for the experimental algorithms, including `HS256/64` truncation through both `sign()` and `hash()`.

PHPUnit (899 tests), PHPStan, ECS, Rector and Deptrac are green.