### PR TITLE
feat(core): introduce a JOSE exception hierarchy

### DIFF
--- a/src/Experimental/ContentEncryption/AESCCM.php
+++ b/src/Experimental/ContentEncryption/AESCCM.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Jose\Experimental\ContentEncryption;
 
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
 use Override;
-use RuntimeException;
 use const OPENSSL_RAW_DATA;
 
 abstract readonly class AESCCM implements ContentEncryptionAlgorithm
@@ -42,7 +43,7 @@ abstract readonly class AESCCM implements ContentEncryptionAlgorithm
             $this->getTagLength()
         );
         if ($result === false) {
-            throw new RuntimeException('Unable to encrypt the content');
+            throw new EncryptionFailedException('Unable to encrypt the content');
         }
 
         return $result;
@@ -64,7 +65,7 @@ abstract readonly class AESCCM implements ContentEncryptionAlgorithm
 
         $result = openssl_decrypt($data, $this->getMode(), $cek, OPENSSL_RAW_DATA, $iv, $tag, $calculated_aad);
         if ($result === false) {
-            throw new RuntimeException('Unable to decrypt the content');
+            throw new DecryptionFailedException('Unable to decrypt the content');
         }
 
         return $result;

--- a/src/Experimental/KeyEncryption/AESCTR.php
+++ b/src/Experimental/KeyEncryption/AESCTR.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Jose\Experimental\KeyEncryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyEncryption;
 use Override;
-use RuntimeException;
 use function in_array;
 use function is_string;
 use const OPENSSL_RAW_DATA;
@@ -37,7 +39,7 @@ abstract readonly class AESCTR implements KeyEncryption
 
         $result = openssl_encrypt($cek, $this->getMode(), $k, OPENSSL_RAW_DATA, $iv);
         if ($result === false) {
-            throw new RuntimeException('Unable to encrypt the CEK');
+            throw new EncryptionFailedException('Unable to encrypt the CEK');
         }
 
         return $result;
@@ -50,13 +52,13 @@ abstract readonly class AESCTR implements KeyEncryption
     public function decryptKey(JWK $key, string $encrypted_cek, array $header): string
     {
         $k = $this->getKey($key);
-        isset($header['iv']) || throw new InvalidArgumentException('The header parameter "iv" is missing.');
-        is_string($header['iv']) || throw new InvalidArgumentException('The header parameter "iv" is not valid.');
+        isset($header['iv']) || throw new InvalidHeaderParameterException('The header parameter "iv" is missing.');
+        is_string($header['iv']) || throw new InvalidHeaderParameterException('The header parameter "iv" is not valid.');
         $iv = Base64UrlSafe::decodeNoPadding($header['iv']);
 
         $result = openssl_decrypt($encrypted_cek, $this->getMode(), $k, OPENSSL_RAW_DATA, $iv);
         if ($result === false) {
-            throw new RuntimeException('Unable to decrypt the CEK');
+            throw new DecryptionFailedException('Unable to decrypt the CEK');
         }
 
         return $result;
@@ -73,14 +75,14 @@ abstract readonly class AESCTR implements KeyEncryption
     private function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);

--- a/src/Experimental/KeyEncryption/Chacha20Poly1305.php
+++ b/src/Experimental/KeyEncryption/Chacha20Poly1305.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Jose\Experimental\KeyEncryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\LogicException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyEncryption;
-use LogicException;
 use Override;
-use RuntimeException;
 use function in_array;
 use function is_string;
 use function strlen;
@@ -50,7 +52,7 @@ final readonly class Chacha20Poly1305 implements KeyEncryption
         $tag = null;
         $result = openssl_encrypt($cek, 'chacha20-poly1305', $k, OPENSSL_RAW_DATA, $nonce, $tag);
         if ($result === false || ! is_string($tag) || strlen($tag) !== 16) {
-            throw new RuntimeException('Unable to encrypt the CEK');
+            throw new EncryptionFailedException('Unable to encrypt the CEK');
         }
 
         $additionalHeader['nonce'] = Base64UrlSafe::encodeUnpadded($nonce);
@@ -66,22 +68,22 @@ final readonly class Chacha20Poly1305 implements KeyEncryption
     public function decryptKey(JWK $key, string $encrypted_cek, array $header): string
     {
         $k = $this->getKey($key);
-        isset($header['nonce']) || throw new InvalidArgumentException('The header parameter "nonce" is missing.');
-        is_string($header['nonce']) || throw new InvalidArgumentException('The header parameter "nonce" is not valid.');
+        isset($header['nonce']) || throw new InvalidHeaderParameterException('The header parameter "nonce" is missing.');
+        is_string($header['nonce']) || throw new InvalidHeaderParameterException('The header parameter "nonce" is not valid.');
         $nonce = Base64UrlSafe::decodeNoPadding($header['nonce']);
         if (strlen($nonce) !== 12) {
-            throw new InvalidArgumentException('The header parameter "nonce" is not valid.');
+            throw new InvalidHeaderParameterException('The header parameter "nonce" is not valid.');
         }
-        isset($header['tag']) || throw new InvalidArgumentException('The header parameter "tag" is missing.');
-        is_string($header['tag']) || throw new InvalidArgumentException('The header parameter "tag" is not valid.');
+        isset($header['tag']) || throw new InvalidHeaderParameterException('The header parameter "tag" is missing.');
+        is_string($header['tag']) || throw new InvalidHeaderParameterException('The header parameter "tag" is not valid.');
         $tag = Base64UrlSafe::decodeNoPadding($header['tag']);
         if (strlen($tag) !== 16) {
-            throw new InvalidArgumentException('The header parameter "tag" is not valid.');
+            throw new InvalidHeaderParameterException('The header parameter "tag" is not valid.');
         }
 
         $result = openssl_decrypt($encrypted_cek, 'chacha20-poly1305', $k, OPENSSL_RAW_DATA, $nonce, $tag);
         if ($result === false) {
-            throw new RuntimeException('Unable to decrypt the CEK');
+            throw new DecryptionFailedException('Unable to decrypt the CEK');
         }
 
         return $result;
@@ -96,14 +98,14 @@ final readonly class Chacha20Poly1305 implements KeyEncryption
     private function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);

--- a/src/Experimental/Signature/Blake2b.php
+++ b/src/Experimental/Signature/Blake2b.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Experimental\Signature;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
 use Override;
-use RuntimeException;
 use function extension_loaded;
 use function in_array;
 use function is_string;
@@ -25,7 +25,7 @@ final readonly class Blake2b implements MacAlgorithm
     public function __construct()
     {
         if (! extension_loaded('sodium')) {
-            throw new RuntimeException('Please install the Sodium extension');
+            throw new MissingDependencyException('Please install the Sodium extension');
         }
     }
 
@@ -58,18 +58,18 @@ final readonly class Blake2b implements MacAlgorithm
     private function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
         $key = Base64UrlSafe::decodeNoPadding($k);
         if (strlen($key) < self::MINIMUM_KEY_LENGTH) {
-            throw new InvalidArgumentException('Key provided is shorter than 256 bits.');
+            throw new InvalidKeyException('Key provided is shorter than 256 bits.');
         }
 
         return $key;

--- a/src/Library/Checker/CallableChecker.php
+++ b/src/Library/Checker/CallableChecker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Override;
 use function call_user_func;
 use function is_callable;

--- a/src/Library/Checker/ClaimCheckerManagerFactory.php
+++ b/src/Library/Checker/ClaimCheckerManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use function sprintf;
 
 /**

--- a/src/Library/Checker/ClaimExceptionInterface.php
+++ b/src/Library/Checker/ClaimExceptionInterface.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use Throwable;
+use Jose\Component\Core\Exception\JoseException;
 
 /**
  * Represents an interface for claim exceptions.
  *
- * This interface extends from the Throwable interface, allowing
- * the claim exceptions to be thrown and caught like any other exception.
+ * This interface extends from the JoseException interface, allowing
+ * the claim exceptions to be caught with any other exception of this library.
  */
-interface ClaimExceptionInterface extends Throwable
+interface ClaimExceptionInterface extends JoseException
 {
 }

--- a/src/Library/Checker/HeaderCheckerManager.php
+++ b/src/Library/Checker/HeaderCheckerManager.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use Jose\Component\Core\JWT;
 use Jose\Component\Core\Util\InheritanceChecker;
 use function array_key_exists;
@@ -98,7 +99,7 @@ class HeaderCheckerManager implements HeaderCheckerManagerInterface
     {
         $inter = array_intersect_key($header1, $header2);
         if (count($inter) !== 0) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidHeaderParameterException(sprintf(
                 'The header contains duplicated entries: %s.',
                 implode(', ', array_keys($inter))
             ));

--- a/src/Library/Checker/HeaderCheckerManagerFactory.php
+++ b/src/Library/Checker/HeaderCheckerManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use function sprintf;
 
 /**

--- a/src/Library/Checker/InvalidHeaderException.php
+++ b/src/Library/Checker/InvalidHeaderException.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Jose\Component\Checker;
 
 use Exception;
+use Jose\Component\Core\Exception\JoseException;
 
 /**
  * This exception is thrown by header checkers when a header check failed.
  */
-class InvalidHeaderException extends Exception
+class InvalidHeaderException extends Exception implements JoseException
 {
     public function __construct(
         string $message,

--- a/src/Library/Checker/MissingMandatoryHeaderParameterException.php
+++ b/src/Library/Checker/MissingMandatoryHeaderParameterException.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Jose\Component\Checker;
 
 use Exception;
+use Jose\Component\Core\Exception\JoseException;
 
-class MissingMandatoryHeaderParameterException extends Exception
+class MissingMandatoryHeaderParameterException extends Exception implements JoseException
 {
     /**
      * @param string[] $parameters

--- a/src/Library/Console/AddKeyIntoKeysetCommand.php
+++ b/src/Library/Console/AddKeyIntoKeysetCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
@@ -44,11 +45,11 @@ final class AddKeyIntoKeysetCommand extends ObjectOutputCommand
     {
         $jwkset = $input->getArgument('jwkset');
         if (! is_string($jwkset)) {
-            throw new InvalidArgumentException('The argument must be a valid JWKSet.');
+            throw new InvalidKeySetException('The argument must be a valid JWKSet.');
         }
         $json = JsonConverter::decode($jwkset);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('The argument must be a valid JWKSet.');
+            throw new InvalidKeySetException('The argument must be a valid JWKSet.');
         }
 
         return JWKSet::createFromKeyData($json);
@@ -58,11 +59,11 @@ final class AddKeyIntoKeysetCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('The argument must be a valid JWK.');
+            throw new InvalidKeyException('The argument must be a valid JWK.');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('The argument must be a valid JWK.');
+            throw new InvalidKeyException('The argument must be a valid JWK.');
         }
 
         return new JWK($json);

--- a/src/Library/Console/EcKeyGeneratorCommand.php
+++ b/src/Library/Console/EcKeyGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/EcKeysetGeneratorCommand.php
+++ b/src/Library/Console/EcKeysetGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;

--- a/src/Library/Console/GeneratorCommand.php
+++ b/src/Library/Console/GeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;

--- a/src/Library/Console/GetThumbprintCommand.php
+++ b/src/Library/Console/GetThumbprintCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
 use Override;
@@ -32,7 +33,7 @@ final class GetThumbprintCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $hash = $input->getOption('hash');
         if (! is_string($hash)) {

--- a/src/Library/Console/JKULoaderCommand.php
+++ b/src/Library/Console/JKULoaderCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JKUFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/KeyAnalyzerCommand.php
+++ b/src/Library/Console/KeyAnalyzerCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\Analyzer\KeyAnalyzerManager;
@@ -68,11 +68,11 @@ final class KeyAnalyzerCommand extends Command
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWK.');
+            throw new InvalidKeyException('Invalid JWK.');
         }
 
         return new JWK($json);

--- a/src/Library/Console/KeyFileLoaderCommand.php
+++ b/src/Library/Console/KeyFileLoaderCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/KeysetAnalyzerCommand.php
+++ b/src/Library/Console/KeysetAnalyzerCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\Analyzer\KeyAnalyzerManager;
@@ -83,11 +83,11 @@ final class KeysetAnalyzerCommand extends Command
     {
         $jwkset = $input->getArgument('jwkset');
         if (! is_string($jwkset)) {
-            throw new InvalidArgumentException('Invalid JWKSet');
+            throw new InvalidKeySetException('Invalid JWKSet');
         }
         $json = JsonConverter::decode($jwkset);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWKSet');
+            throw new InvalidKeySetException('Invalid JWKSet');
         }
 
         return JWKSet::createFromKeyData($json);

--- a/src/Library/Console/MergeKeysetCommand.php
+++ b/src/Library/Console/MergeKeysetCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
 use Override;
@@ -37,7 +37,7 @@ final class MergeKeysetCommand extends ObjectOutputCommand
         foreach ($keySets as $keySet) {
             $json = JsonConverter::decode($keySet);
             if (! is_array($json)) {
-                throw new InvalidArgumentException('The argument must be a valid JWKSet.');
+                throw new InvalidKeySetException('The argument must be a valid JWKSet.');
             }
             $jwkset = JWKSet::createFromKeyData($json);
             foreach ($jwkset->all() as $jwk) {

--- a/src/Library/Console/OctKeyGeneratorCommand.php
+++ b/src/Library/Console/OctKeyGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/OctKeysetGeneratorCommand.php
+++ b/src/Library/Console/OctKeysetGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;

--- a/src/Library/Console/OkpKeyGeneratorCommand.php
+++ b/src/Library/Console/OkpKeyGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/OkpKeysetGeneratorCommand.php
+++ b/src/Library/Console/OkpKeysetGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;

--- a/src/Library/Console/OptimizeRsaKeyCommand.php
+++ b/src/Library/Console/OptimizeRsaKeyCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\KeyConverter\RSAKey;
@@ -31,11 +31,11 @@ final class OptimizeRsaKeyCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $key = RSAKey::createFromJWK(new JWK($json));
         $key->optimize();

--- a/src/Library/Console/P12CertificateLoaderCommand.php
+++ b/src/Library/Console/P12CertificateLoaderCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/PemConverterCommand.php
+++ b/src/Library/Console/PemConverterCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Core\Util\JsonConverter;
@@ -32,18 +32,18 @@ final class PemConverterCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWK.');
+            throw new InvalidKeyException('Invalid JWK.');
         }
         $key = new JWK($json);
 
         $pem = match ($key->get('kty')) {
             'RSA' => RSAKey::createFromJWK($key)->toPEM(),
             'EC' => ECKey::convertToPEM($key),
-            default => throw new InvalidArgumentException('Not a RSA or EC key.'),
+            default => throw new InvalidKeyException('Not a RSA or EC key.'),
         };
         $output->write($pem);
 

--- a/src/Library/Console/Pkcs8ConverterCommand.php
+++ b/src/Library/Console/Pkcs8ConverterCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Core\Util\JsonConverter;
@@ -37,11 +37,11 @@ final class Pkcs8ConverterCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWK.');
+            throw new InvalidKeyException('Invalid JWK.');
         }
         $key = new JWK($json);
 
@@ -49,7 +49,7 @@ final class Pkcs8ConverterCommand extends ObjectOutputCommand
             'RSA' => RSAKey::createFromJWK($key)->toPEM(),
             'EC' => ECKey::convertToPKCS8PEM($key),
             'OKP' => OKPKey::convertToPKCS8PEM($key),
-            default => throw new InvalidArgumentException('Not a RSA, EC or OKP key.'),
+            default => throw new InvalidKeyException('Not a RSA, EC or OKP key.'),
         };
         $output->write($pem);
 

--- a/src/Library/Console/PublicKeyCommand.php
+++ b/src/Library/Console/PublicKeyCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\JsonConverter;
 use Override;
@@ -45,11 +45,11 @@ final class PublicKeyCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
 
         return new JWK($json);

--- a/src/Library/Console/PublicKeysetCommand.php
+++ b/src/Library/Console/PublicKeysetCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
 use Override;
@@ -48,11 +48,11 @@ final class PublicKeysetCommand extends ObjectOutputCommand
     {
         $jwkset = $input->getArgument('jwkset');
         if (! is_string($jwkset)) {
-            throw new InvalidArgumentException('Invalid JWKSet');
+            throw new InvalidKeySetException('Invalid JWKSet');
         }
         $json = JsonConverter::decode($jwkset);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWKSet');
+            throw new InvalidKeySetException('Invalid JWKSet');
         }
 
         return JWKSet::createFromKeyData($json);

--- a/src/Library/Console/RotateKeysetCommand.php
+++ b/src/Library/Console/RotateKeysetCommand.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
@@ -51,11 +52,11 @@ final class RotateKeysetCommand extends ObjectOutputCommand
     {
         $jwkset = $input->getArgument('jwkset');
         if (! is_string($jwkset)) {
-            throw new InvalidArgumentException('Invalid JWKSet');
+            throw new InvalidKeySetException('Invalid JWKSet');
         }
         $json = JsonConverter::decode($jwkset);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWKSet');
+            throw new InvalidKeySetException('Invalid JWKSet');
         }
 
         return JWKSet::createFromKeyData($json);
@@ -65,11 +66,11 @@ final class RotateKeysetCommand extends ObjectOutputCommand
     {
         $jwk = $input->getArgument('jwk');
         if (! is_string($jwk)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
         $json = JsonConverter::decode($jwk);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid JWK');
+            throw new InvalidKeyException('Invalid JWK');
         }
 
         return new JWK($json);

--- a/src/Library/Console/RsaKeyGeneratorCommand.php
+++ b/src/Library/Console/RsaKeyGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/RsaKeysetGeneratorCommand.php
+++ b/src/Library/Console/RsaKeysetGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;

--- a/src/Library/Console/SecretKeyGeneratorCommand.php
+++ b/src/Library/Console/SecretKeyGeneratorCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/X509CertificateLoaderCommand.php
+++ b/src/Library/Console/X509CertificateLoaderCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Console/X5ULoaderCommand.php
+++ b/src/Library/Console/X5ULoaderCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\KeyManagement\X5UFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Library/Core/AlgorithmManager.php
+++ b/src/Library/Core/AlgorithmManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use function array_key_exists;
 use function sprintf;
 
@@ -61,7 +61,7 @@ final class AlgorithmManager
     public function get(string $algorithm): Algorithm
     {
         if (! $this->has($algorithm)) {
-            throw new InvalidArgumentException(sprintf('The algorithm "%s" is not supported.', $algorithm));
+            throw new UnsupportedAlgorithmException(sprintf('The algorithm "%s" is not supported.', $algorithm));
         }
 
         return $this->algorithms[$algorithm];

--- a/src/Library/Core/AlgorithmManagerFactory.php
+++ b/src/Library/Core/AlgorithmManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use function is_string;
 use function sprintf;
 

--- a/src/Library/Core/Exception/DecryptionFailedException.php
+++ b/src/Library/Core/Exception/DecryptionFailedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when the decryption of a content or of a content encryption key failed.
+ */
+class DecryptionFailedException extends RuntimeException
+{
+}

--- a/src/Library/Core/Exception/EncryptionFailedException.php
+++ b/src/Library/Core/Exception/EncryptionFailedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when the encryption of a content or of a content encryption key failed.
+ */
+class EncryptionFailedException extends RuntimeException
+{
+}

--- a/src/Library/Core/Exception/InvalidArgumentException.php
+++ b/src/Library/Core/Exception/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+use InvalidArgumentException as SplInvalidArgumentException;
+
+/**
+ * Base class for the invalid arguments reported by this library.
+ *
+ * It extends the SPL class so that the catch blocks written for previous versions keep matching.
+ */
+class InvalidArgumentException extends SplInvalidArgumentException implements JoseException
+{
+}

--- a/src/Library/Core/Exception/InvalidHeaderParameterException.php
+++ b/src/Library/Core/Exception/InvalidHeaderParameterException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when a JOSE header parameter needed to process a token is missing or has an unexpected value.
+ *
+ * Header checkers report their own failures with Jose\Component\Checker\InvalidHeaderException.
+ */
+class InvalidHeaderParameterException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/InvalidKeyException.php
+++ b/src/Library/Core/Exception/InvalidKeyException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when a key is missing, malformed, of an unexpected type or cannot be used for the requested
+ * operation.
+ */
+class InvalidKeyException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/InvalidKeySetException.php
+++ b/src/Library/Core/Exception/InvalidKeySetException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when a key set is malformed, empty or does not contain any suitable key.
+ */
+class InvalidKeySetException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/InvalidPayloadException.php
+++ b/src/Library/Core/Exception/InvalidPayloadException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when a payload is missing, is not encoded as expected or is inconsistent with the header
+ * parameters of the token.
+ */
+class InvalidPayloadException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/InvalidSerializationException.php
+++ b/src/Library/Core/Exception/InvalidSerializationException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown by the serializers when the input is not a valid representation of the expected serialization.
+ */
+class InvalidSerializationException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/InvalidTokenException.php
+++ b/src/Library/Core/Exception/InvalidTokenException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown by the loaders when a token cannot be loaded, verified or decrypted.
+ *
+ * The failure of the last attempt is available through the previous exception.
+ */
+class InvalidTokenException extends RuntimeException
+{
+}

--- a/src/Library/Core/Exception/JoseException.php
+++ b/src/Library/Core/Exception/JoseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+use Throwable;
+
+/**
+ * Marker interface implemented by every exception thrown by this library.
+ *
+ * It allows a single catch block to handle any failure reported by the framework:
+ *
+ *     try {
+ *         $jws = $jwsLoader->loadAndVerifyWithKeySet($token, $jwkset, $signature);
+ *     } catch (JoseException $e) {
+ *         // the original cause, when there is one, is available through $e->getPrevious()
+ *     }
+ *
+ * Every implementation extends the SPL exception that was thrown before version 4.3.0, hence the catch
+ * blocks written for previous versions keep matching.
+ */
+interface JoseException extends Throwable
+{
+}

--- a/src/Library/Core/Exception/LogicException.php
+++ b/src/Library/Core/Exception/LogicException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+use LogicException as SplLogicException;
+
+/**
+ * Base class for the API misuses reported by this library.
+ *
+ * It extends the SPL class so that the catch blocks written for previous versions keep matching.
+ */
+class LogicException extends SplLogicException implements JoseException
+{
+}

--- a/src/Library/Core/Exception/MissingDependencyException.php
+++ b/src/Library/Core/Exception/MissingDependencyException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when a PHP extension or a Composer package required by an algorithm is not installed.
+ */
+class MissingDependencyException extends RuntimeException
+{
+}

--- a/src/Library/Core/Exception/MissingPayloadException.php
+++ b/src/Library/Core/Exception/MissingPayloadException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Implemented by the exceptions thrown when a builder is asked to build a token without a payload.
+ *
+ * Before version 4.3.0 the JWS builder reported that failure with a RuntimeException and the JWE builder
+ * with a LogicException. Those two SPL parents cannot be merged without breaking the existing catch
+ * blocks, hence the two implementations MissingPayloadRuntimeException and MissingPayloadLogicException.
+ * Catching this interface handles both. They are merged into a single class in version 5.0.0.
+ */
+interface MissingPayloadException extends JoseException
+{
+}

--- a/src/Library/Core/Exception/MissingPayloadLogicException.php
+++ b/src/Library/Core/Exception/MissingPayloadLogicException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown by the JWE builder when no payload was set.
+ *
+ * It extends LogicException, the SPL class thrown by that builder before version 4.3.0. Catch
+ * MissingPayloadException to handle the JWS builder the same way.
+ */
+final class MissingPayloadLogicException extends LogicException implements MissingPayloadException
+{
+}

--- a/src/Library/Core/Exception/MissingPayloadRuntimeException.php
+++ b/src/Library/Core/Exception/MissingPayloadRuntimeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown by the JWS builder when no payload was set.
+ *
+ * It extends RuntimeException, the SPL class thrown by that builder before version 4.3.0. Catch
+ * MissingPayloadException to handle the JWE builder the same way.
+ */
+final class MissingPayloadRuntimeException extends RuntimeException implements MissingPayloadException
+{
+}

--- a/src/Library/Core/Exception/RangeException.php
+++ b/src/Library/Core/Exception/RangeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+use RangeException as SplRangeException;
+
+/**
+ * Base class for the out of range values reported by this library.
+ *
+ * It extends the SPL class so that the catch blocks written for previous versions keep matching.
+ */
+class RangeException extends SplRangeException implements JoseException
+{
+}

--- a/src/Library/Core/Exception/RuntimeException.php
+++ b/src/Library/Core/Exception/RuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+use RuntimeException as SplRuntimeException;
+
+/**
+ * Base class for the runtime failures reported by this library.
+ *
+ * It extends the SPL class so that the catch blocks written for previous versions keep matching.
+ */
+class RuntimeException extends SplRuntimeException implements JoseException
+{
+}

--- a/src/Library/Core/Exception/UnsupportedAlgorithmException.php
+++ b/src/Library/Core/Exception/UnsupportedAlgorithmException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when an algorithm is not supported by this library or is not registered in the algorithm manager
+ * in use.
+ */
+class UnsupportedAlgorithmException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/UnsupportedCurveException.php
+++ b/src/Library/Core/Exception/UnsupportedCurveException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when an elliptic curve is not supported by this library or by the current platform.
+ */
+class UnsupportedCurveException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/Exception/UnsupportedSerializerException.php
+++ b/src/Library/Core/Exception/UnsupportedSerializerException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Exception;
+
+/**
+ * Thrown when a serializer is requested by a name that is not registered in the serializer manager in use.
+ */
+class UnsupportedSerializerException extends InvalidArgumentException
+{
+}

--- a/src/Library/Core/JWK.php
+++ b/src/Library/Core/JWK.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use JsonSerializable;
 use Override;
@@ -29,7 +31,7 @@ class JWK implements JsonSerializable
     public function __construct(array $values)
     {
         if (! isset($values['kty'])) {
-            throw new InvalidArgumentException('The parameter "kty" is mandatory.');
+            throw new InvalidKeyException('The parameter "kty" is mandatory.');
         }
         $this->values = $values;
     }
@@ -66,7 +68,7 @@ class JWK implements JsonSerializable
     public function get(string $key)
     {
         if (! $this->has($key)) {
-            throw new InvalidArgumentException(sprintf('The value identified by "%s" does not exist.', $key));
+            throw new InvalidKeyException(sprintf('The value identified by "%s" does not exist.', $key));
         }
 
         return $this->values[$key];
@@ -100,13 +102,13 @@ class JWK implements JsonSerializable
     public function thumbprint(string $hash_algorithm): string
     {
         if (! in_array($hash_algorithm, hash_algos(), true)) {
-            throw new InvalidArgumentException(sprintf('The hash algorithm "%s" is not supported.', $hash_algorithm));
+            throw new UnsupportedAlgorithmException(sprintf('The hash algorithm "%s" is not supported.', $hash_algorithm));
         }
         $values = array_intersect_key($this->values, array_flip(['kty', 'n', 'e', 'crv', 'x', 'y', 'k']));
         ksort($values);
         $input = json_encode($values, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         if ($input === false) {
-            throw new InvalidArgumentException('Unable to compute the key thumbprint');
+            throw new InvalidKeyException('Unable to compute the key thumbprint');
         }
 
         return Base64UrlSafe::encodeUnpadded(hash($hash_algorithm, $input, true));

--- a/src/Library/Core/JWKSet.php
+++ b/src/Library/Core/JWKSet.php
@@ -6,8 +6,10 @@ namespace Jose\Component\Core;
 
 use ArrayIterator;
 use Countable;
-use InvalidArgumentException;
 use IteratorAggregate;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
 use JsonSerializable;
 use Traversable;
 use function array_key_exists;
@@ -31,7 +33,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     {
         foreach ($keys as $key) {
             if (! $key instanceof JWK) {
-                throw new InvalidArgumentException('Invalid list. Should only contains JWK objects');
+                throw new InvalidKeySetException('Invalid list. Should only contains JWK objects');
             }
 
             $this->add($key);
@@ -44,10 +46,10 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     public static function createFromKeyData(array $data): self
     {
         if (! isset($data['keys'])) {
-            throw new InvalidArgumentException('Invalid data.');
+            throw new InvalidKeySetException('Invalid data.');
         }
         if (! is_array($data['keys'])) {
-            throw new InvalidArgumentException('Invalid data.');
+            throw new InvalidKeySetException('Invalid data.');
         }
 
         $jwkset = new self([]);
@@ -65,7 +67,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     {
         $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
         if (! is_array($data)) {
-            throw new InvalidArgumentException('Invalid argument.');
+            throw new InvalidKeySetException('Invalid argument.');
         }
 
         return self::createFromKeyData($data);
@@ -129,7 +131,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     {
         $index = $this->indexOf($index);
         if ($index === null) {
-            throw new InvalidArgumentException('Undefined index.');
+            throw new InvalidKeySetException('Undefined index.');
         }
 
         return $this->keys[$index];
@@ -165,7 +167,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     public function selectKey(string $type, ?Algorithm $algorithm = null, array $restrictions = []): ?JWK
     {
         if (! in_array($type, ['enc', 'sig'], true)) {
-            throw new InvalidArgumentException('Allowed key types are "sig" or "enc".');
+            throw new InvalidKeySetException('Allowed key types are "sig" or "enc".');
         }
 
         $result = [];
@@ -272,7 +274,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
         if ($key->has('key_ops')) {
             $key_ops = $key->get('key_ops');
             if (! is_array($key_ops) || $key_ops !== array_filter($key_ops, static fn (mixed $v): bool => is_string($v))) {
-                throw new InvalidArgumentException(
+                throw new InvalidKeyException(
                     'Invalid key parameter "key_ops". Should be a list of key operations'
                 );
             }

--- a/src/Library/Core/Util/Base64UrlSafe.php
+++ b/src/Library/Core/Util/Base64UrlSafe.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
-use RangeException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\RangeException;
 use SensitiveParameter;
 use SodiumException;
 use function extension_loaded;

--- a/src/Library/Core/Util/BigInteger.php
+++ b/src/Library/Core/Util/BigInteger.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Jose\Component\Core\Util;
 
 use Brick\Math\BigInteger as BrickBigInteger;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use function chr;
 use function is_string;
 use function strlen;

--- a/src/Library/Core/Util/ECKey.php
+++ b/src/Library/Core/Util/ECKey.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedCurveException;
 use Jose\Component\Core\JWK;
-use RuntimeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\BitString;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
@@ -62,7 +64,7 @@ final readonly class ECKey
     {
         $curve = $jwk->get('crv');
         if (! is_string($curve)) {
-            throw new InvalidArgumentException('Unable to get the curve');
+            throw new InvalidKeyException('Unable to get the curve');
         }
         $length = (int) ceil(self::getCurveSize($curve) / 8);
         $ecPrivateKey = Sequence::create(
@@ -93,7 +95,7 @@ final readonly class ECKey
             'BP-256' => self::bp256PublicKey(),
             'BP-384' => self::bp384PublicKey(),
             'BP-512' => self::bp512PublicKey(),
-            default => throw new InvalidArgumentException('Unsupported curve.'),
+            default => throw new UnsupportedCurveException('Unsupported curve.'),
         };
         $der .= self::getKey($jwk);
         $pem = '-----BEGIN PUBLIC KEY-----' . "\n";
@@ -112,7 +114,7 @@ final readonly class ECKey
             'BP-256' => self::bp256PrivateKey($jwk),
             'BP-384' => self::bp384PrivateKey($jwk),
             'BP-512' => self::bp512PrivateKey($jwk),
-            default => throw new InvalidArgumentException('Unsupported curve.'),
+            default => throw new UnsupportedCurveException('Unsupported curve.'),
         };
         $der .= self::getKey($jwk);
         $pem = '-----BEGIN EC PRIVATE KEY-----' . "\n";
@@ -142,14 +144,14 @@ final readonly class ECKey
             'P-384', 'BP-384' => 384,
             'BP-512' => 512,
             'P-521' => 521,
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported.', $curve)),
         };
     }
 
     private static function createECKeyUsingOpenSSL(string $curve): array
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         $key = openssl_pkey_new([
             'curve_name' => self::getOpensslCurveName($curve),
@@ -169,7 +171,7 @@ final readonly class ECKey
         }
         $details = openssl_pkey_get_details($res);
         if ($details === false) {
-            throw new InvalidArgumentException('Unable to get the key details');
+            throw new InvalidKeyException('Unable to get the key details');
         }
         $curveSize = self::getCurveSize($curve);
 
@@ -202,7 +204,7 @@ final readonly class ECKey
             'BP-256' => '1.3.36.3.3.2.8.1.1.7',
             'BP-384' => '1.3.36.3.3.2.8.1.1.11',
             'BP-512' => '1.3.36.3.3.2.8.1.1.13',
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported.', $curve)),
         };
     }
 
@@ -216,7 +218,7 @@ final readonly class ECKey
             'BP-256' => 'brainpoolP256r1',
             'BP-384' => 'brainpoolP384r1',
             'BP-512' => 'brainpoolP512r1',
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported.', $curve)),
         };
     }
 
@@ -421,7 +423,7 @@ final readonly class ECKey
     {
         $data = unpack('H*', self::getPrivateKeyBytes($jwk, $length));
         if (! is_array($data) || ! isset($data[1]) || ! is_string($data[1])) {
-            throw new InvalidArgumentException('Unable to get the private key');
+            throw new InvalidKeyException('Unable to get the private key');
         }
 
         return $data[1];
@@ -434,7 +436,7 @@ final readonly class ECKey
     {
         $d = $jwk->get('d');
         if (! is_string($d)) {
-            throw new InvalidArgumentException('Unable to get the private key');
+            throw new InvalidKeyException('Unable to get the private key');
         }
 
         return str_pad(Base64UrlSafe::decodeNoPadding($d), $length, "\0", STR_PAD_LEFT);
@@ -444,17 +446,17 @@ final readonly class ECKey
     {
         $crv = $jwk->get('crv');
         if (! is_string($crv)) {
-            throw new InvalidArgumentException('Unable to get the curve');
+            throw new InvalidKeyException('Unable to get the curve');
         }
         $curveSize = self::getCurveSize($crv);
         $length = (int) ceil($curveSize / 8);
         $x = $jwk->get('x');
         if (! is_string($x)) {
-            throw new InvalidArgumentException('Unable to get the public key');
+            throw new InvalidKeyException('Unable to get the public key');
         }
         $y = $jwk->get('y');
         if (! is_string($y)) {
-            throw new InvalidArgumentException('Unable to get the public key');
+            throw new InvalidKeyException('Unable to get the public key');
         }
         $binX = ltrim(Base64UrlSafe::decodeNoPadding($x), "\0");
         $binY = ltrim(Base64UrlSafe::decodeNoPadding($y), "\0");

--- a/src/Library/Core/Util/ECSignature.php
+++ b/src/Library/Core/Util/ECSignature.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use function is_string;
 use function strlen;
 use const STR_PAD_LEFT;

--- a/src/Library/Core/Util/Ecc/Curve.php
+++ b/src/Library/Core/Util/Ecc/Curve.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jose\Component\Core\Util\Ecc;
 
 use Brick\Math\BigInteger;
+use Jose\Component\Core\Exception\RuntimeException;
 use Override;
-use RuntimeException;
 use Stringable;
 use const STR_PAD_LEFT;
 

--- a/src/Library/Core/Util/Ecc/Math.php
+++ b/src/Library/Core/Util/Ecc/Math.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Jose\Component\Core\Util\Ecc;
 
 use Brick\Math\BigInteger;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Util\BigInteger as CoreBigInteger;
 
 /**

--- a/src/Library/Core/Util/Ecc/Point.php
+++ b/src/Library/Core/Util/Ecc/Point.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Jose\Component\Core\Util\Ecc;
 
 use Brick\Math\BigInteger;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use function strlen;
 use const STR_PAD_LEFT;
 

--- a/src/Library/Core/Util/Hash.php
+++ b/src/Library/Core/Util/Hash.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final readonly class Hash
             'sha256' => self::sha256(),
             'sha384' => self::sha384(),
             'sha512' => self::sha512(),
-            default => throw new InvalidArgumentException('Unsupported hash function'),
+            default => throw new UnsupportedAlgorithmException('Unsupported hash function'),
         };
     }
 

--- a/src/Library/Core/Util/JsonConverter.php
+++ b/src/Library/Core/Util/JsonConverter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Throwable;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;

--- a/src/Library/Core/Util/KeyChecker.php
+++ b/src/Library/Core/Util/KeyChecker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use function in_array;
 use function is_array;
@@ -33,10 +33,10 @@ final readonly class KeyChecker
         }
         $alg = $key->get('alg');
         if (! is_string($alg)) {
-            throw new InvalidArgumentException('Invalid algorithm.');
+            throw new InvalidKeyException('Invalid algorithm.');
         }
         if ($alg !== $algorithm) {
-            throw new InvalidArgumentException(sprintf('Key is only allowed for algorithm "%s".', $alg));
+            throw new InvalidKeyException(sprintf('Key is only allowed for algorithm "%s".', $alg));
         }
     }
 
@@ -44,20 +44,20 @@ final readonly class KeyChecker
     {
         $ops = $key->get('key_ops');
         if (! is_array($ops)) {
-            throw new InvalidArgumentException('Invalid key parameter "key_ops". Should be a list of key operations');
+            throw new InvalidKeyException('Invalid key parameter "key_ops". Should be a list of key operations');
         }
 
         switch ($usage) {
             case 'verification':
                 if (! in_array('verify', $ops, true)) {
-                    throw new InvalidArgumentException('Key cannot be used to verify a signature');
+                    throw new InvalidKeyException('Key cannot be used to verify a signature');
                 }
 
                 break;
 
             case 'signature':
                 if (! in_array('sign', $ops, true)) {
-                    throw new InvalidArgumentException('Key cannot be used to sign');
+                    throw new InvalidKeyException('Key cannot be used to sign');
                 }
 
                 break;
@@ -68,7 +68,7 @@ final readonly class KeyChecker
                     $ops,
                     true
                 )) {
-                    throw new InvalidArgumentException('Key cannot be used to encrypt');
+                    throw new InvalidKeyException('Key cannot be used to encrypt');
                 }
 
                 break;
@@ -79,13 +79,13 @@ final readonly class KeyChecker
                     $ops,
                     true
                 )) {
-                    throw new InvalidArgumentException('Key cannot be used to decrypt');
+                    throw new InvalidKeyException('Key cannot be used to decrypt');
                 }
 
                 break;
 
             default:
-                throw new InvalidArgumentException('Unsupported key usage.');
+                throw new InvalidKeyException('Unsupported key usage.');
         }
     }
 
@@ -97,7 +97,7 @@ final readonly class KeyChecker
             case 'verification':
             case 'signature':
                 if ($use !== 'sig') {
-                    throw new InvalidArgumentException('Key cannot be used to sign or verify a signature.');
+                    throw new InvalidKeyException('Key cannot be used to sign or verify a signature.');
                 }
 
                 break;
@@ -105,13 +105,13 @@ final readonly class KeyChecker
             case 'encryption':
             case 'decryption':
                 if ($use !== 'enc') {
-                    throw new InvalidArgumentException('Key cannot be used to encrypt or decrypt.');
+                    throw new InvalidKeyException('Key cannot be used to encrypt or decrypt.');
                 }
 
                 break;
 
             default:
-                throw new InvalidArgumentException('Unsupported key usage.');
+                throw new InvalidKeyException('Unsupported key usage.');
         }
     }
 }

--- a/src/Library/Core/Util/OKPKey.php
+++ b/src/Library/Core/Util/OKPKey.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\UnsupportedCurveException;
 use Jose\Component\Core\JWK;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKey;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PrivateKeyInfo;
@@ -75,7 +76,7 @@ final readonly class OKPKey
             'Ed448' => Ed448PrivateKey::create($d),
             'X25519' => X25519PrivateKey::create($d),
             'X448' => X448PrivateKey::create($d),
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported.', $curve)),
         };
     }
 
@@ -89,7 +90,7 @@ final readonly class OKPKey
             'Ed448' => Ed448PublicKey::create($x),
             'X25519' => X25519PublicKey::create($x),
             'X448' => X448PublicKey::create($x),
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported.', $curve)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported.', $curve)),
         };
     }
 
@@ -97,7 +98,7 @@ final readonly class OKPKey
     {
         $value = $jwk->get($parameter);
         if (! is_string($value)) {
-            throw new InvalidArgumentException(sprintf('Unable to get the "%s" parameter', $parameter));
+            throw new InvalidKeyException(sprintf('Unable to get the "%s" parameter', $parameter));
         }
 
         return $value;

--- a/src/Library/Core/Util/RSAKey.php
+++ b/src/Library/Core/Util/RSAKey.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Jose\Component\Core\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\RuntimeException;
 use Jose\Component\Core\JWK;
-use RuntimeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\BitString;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
@@ -237,11 +237,11 @@ final class RSAKey
     {
         $unpacked = unpack('H*', Base64UrlSafe::decodeNoPadding($value));
         if (! is_array($unpacked) || count($unpacked) === 0) {
-            throw new InvalidArgumentException('Unable to get the private key');
+            throw new InvalidKeyException('Unable to get the private key');
         }
         $hexadecimal = current($unpacked);
         if (! is_string($hexadecimal) || $hexadecimal === '') {
-            throw new InvalidArgumentException('Unable to get the private key');
+            throw new InvalidKeyException('Unable to get the private key');
         }
 
         return \Brick\Math\BigInteger::fromBase($hexadecimal, 16)->toBase(10);

--- a/src/Library/Encryption/Algorithm/ContentEncryption/AESCBCHS.php
+++ b/src/Library/Encryption/Algorithm/ContentEncryption/AESCBCHS.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\ContentEncryption;
 
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
 use Override;
-use RuntimeException;
 use function extension_loaded;
 use function strlen;
 use const OPENSSL_RAW_DATA;
@@ -17,7 +19,7 @@ abstract readonly class AESCBCHS implements ContentEncryptionAlgorithm
     public function __construct()
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
     }
 
@@ -39,7 +41,7 @@ abstract readonly class AESCBCHS implements ContentEncryptionAlgorithm
         $k = substr($cek, $this->getCEKSize() / 16);
         $result = openssl_encrypt($data, $this->getMode(), $k, OPENSSL_RAW_DATA, $iv);
         if ($result === false) {
-            throw new RuntimeException('Unable to encrypt the content');
+            throw new EncryptionFailedException('Unable to encrypt the content');
         }
 
         $tag = $this->calculateAuthenticationTag($result, $cek, $iv, $aad, $encoded_protected_header);
@@ -57,13 +59,13 @@ abstract readonly class AESCBCHS implements ContentEncryptionAlgorithm
         string $tag
     ): string {
         if (! $this->isTagValid($data, $cek, $iv, $aad, $encoded_protected_header, $tag)) {
-            throw new RuntimeException('Unable to decrypt or to verify the tag.');
+            throw new DecryptionFailedException('Unable to decrypt or to verify the tag.');
         }
         $k = substr($cek, $this->getCEKSize() / 16);
 
         $result = openssl_decrypt($data, $this->getMode(), $k, OPENSSL_RAW_DATA, $iv);
         if ($result === false) {
-            throw new RuntimeException('Unable to decrypt or to verify the tag.');
+            throw new DecryptionFailedException('Unable to decrypt or to verify the tag.');
         }
 
         return $result;

--- a/src/Library/Encryption/Algorithm/ContentEncryption/AESGCM.php
+++ b/src/Library/Encryption/Algorithm/ContentEncryption/AESGCM.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\ContentEncryption;
 
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
 use Override;
-use RuntimeException;
 use function extension_loaded;
 use const OPENSSL_RAW_DATA;
 
@@ -16,7 +18,7 @@ abstract readonly class AESGCM implements ContentEncryptionAlgorithm
     public function __construct()
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
     }
 
@@ -42,7 +44,7 @@ abstract readonly class AESGCM implements ContentEncryptionAlgorithm
         $tag = '';
         $result = openssl_encrypt($data, $this->getMode(), $cek, OPENSSL_RAW_DATA, $iv, $tag, $calculated_aad);
         if ($result === false) {
-            throw new RuntimeException('Unable to encrypt the content');
+            throw new EncryptionFailedException('Unable to encrypt the content');
         }
 
         return $result;
@@ -64,7 +66,7 @@ abstract readonly class AESGCM implements ContentEncryptionAlgorithm
 
         $result = openssl_decrypt($data, $this->getMode(), $cek, OPENSSL_RAW_DATA, $iv, $tag, $calculated_aad);
         if ($result === false) {
-            throw new RuntimeException('Unable to decrypt the content');
+            throw new DecryptionFailedException('Unable to decrypt the content');
         }
 
         return $result;

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AESGCMKW.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AESGCMKW.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
 use AESKW\Wrapper as WrapperInterface;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
-use RuntimeException;
 use function extension_loaded;
 use function in_array;
 use function is_string;
@@ -21,10 +24,10 @@ abstract readonly class AESGCMKW implements KeyWrapping
     public function __construct()
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         if (! interface_exists(WrapperInterface::class)) {
-            throw new RuntimeException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
+            throw new MissingDependencyException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
         }
     }
 
@@ -49,7 +52,7 @@ abstract readonly class AESGCMKW implements KeyWrapping
         $tag = '';
         $encrypted_cek = openssl_encrypt($cek, $mode, $kek, OPENSSL_RAW_DATA, $iv, $tag, '');
         if ($encrypted_cek === false) {
-            throw new RuntimeException('Unable to encrypt the CEK');
+            throw new EncryptionFailedException('Unable to encrypt the CEK');
         }
         $additionalHeader['tag'] = Base64UrlSafe::encodeUnpadded($tag);
 
@@ -63,10 +66,10 @@ abstract readonly class AESGCMKW implements KeyWrapping
     public function unwrapKey(JWK $key, string $encrypted_cek, array $completeHeader): string
     {
         $kek = $this->getKey($key);
-        (isset($completeHeader['iv']) && is_string($completeHeader['iv'])) || throw new InvalidArgumentException(
+        (isset($completeHeader['iv']) && is_string($completeHeader['iv'])) || throw new InvalidHeaderParameterException(
             'Parameter "iv" is missing.'
         );
-        (isset($completeHeader['tag']) && is_string($completeHeader['tag'])) || throw new InvalidArgumentException(
+        (isset($completeHeader['tag']) && is_string($completeHeader['tag'])) || throw new InvalidHeaderParameterException(
             'Parameter "tag" is missing.'
         );
 
@@ -76,7 +79,7 @@ abstract readonly class AESGCMKW implements KeyWrapping
         $mode = sprintf('aes-%d-gcm', $this->getKeySize());
         $cek = openssl_decrypt($encrypted_cek, $mode, $kek, OPENSSL_RAW_DATA, $iv, $tag, '');
         if ($cek === false) {
-            throw new RuntimeException('Unable to decrypt the CEK');
+            throw new DecryptionFailedException('Unable to decrypt the CEK');
         }
 
         return $cek;
@@ -91,14 +94,14 @@ abstract readonly class AESGCMKW implements KeyWrapping
     protected function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AESKW.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AESKW.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
 use AESKW\Wrapper as WrapperInterface;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
-use RuntimeException;
 use function in_array;
 use function is_string;
 
@@ -18,7 +18,7 @@ abstract readonly class AESKW implements KeyWrapping
     public function __construct()
     {
         if (! interface_exists(WrapperInterface::class)) {
-            throw new RuntimeException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
+            throw new MissingDependencyException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
         }
     }
 
@@ -64,14 +64,14 @@ abstract readonly class AESKW implements KeyWrapping
     private function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDH.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
 use Brick\Math\BigInteger;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedCurveException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\Ecc\BrainpoolCurve;
@@ -16,7 +21,6 @@ use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\ConcatKDF;
 use Override;
-use RuntimeException;
 use Throwable;
 use function array_key_exists;
 use function extension_loaded;
@@ -61,9 +65,9 @@ abstract readonly class AbstractECDH implements KeyAgreement
         $agreed_key = $this->calculateAgreementKey($private_key, $public_key);
 
         $apu = array_key_exists('apu', $complete_header) ? $complete_header['apu'] : '';
-        is_string($apu) || throw new InvalidArgumentException('Invalid APU.');
+        is_string($apu) || throw new InvalidHeaderParameterException('Invalid APU.');
         $apv = array_key_exists('apv', $complete_header) ? $complete_header['apv'] : '';
-        is_string($apv) || throw new InvalidArgumentException('Invalid APU.');
+        is_string($apv) || throw new InvalidHeaderParameterException('Invalid APU.');
 
         return ConcatKDF::generate($agreed_key, $algorithm, $encryptionKeyLength, $apu, $apv);
     }
@@ -78,7 +82,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
     {
         $crv = $public_key->get('crv');
         if (! is_string($crv)) {
-            throw new InvalidArgumentException('Invalid key parameter "crv"');
+            throw new InvalidKeyException('Invalid key parameter "crv"');
         }
         switch ($crv) {
             case 'P-256':
@@ -105,15 +109,15 @@ abstract readonly class AbstractECDH implements KeyAgreement
                 }
                 $x = $public_key->get('x');
                 if (! is_string($x)) {
-                    throw new InvalidArgumentException('Invalid key parameter "x"');
+                    throw new InvalidKeyException('Invalid key parameter "x"');
                 }
                 $y = $public_key->get('y');
                 if (! is_string($y)) {
-                    throw new InvalidArgumentException('Invalid key parameter "y"');
+                    throw new InvalidKeyException('Invalid key parameter "y"');
                 }
                 $d = $private_key->get('d');
                 if (! is_string($d)) {
-                    throw new InvalidArgumentException('Invalid key parameter "d"');
+                    throw new InvalidKeyException('Invalid key parameter "d"');
                 }
 
                 $rec_x = $this->convertBase64ToBigInteger($x);
@@ -129,11 +133,11 @@ abstract readonly class AbstractECDH implements KeyAgreement
                 $this->checkSodiumExtensionIsAvailable();
                 $x = $public_key->get('x');
                 if (! is_string($x)) {
-                    throw new InvalidArgumentException('Invalid key parameter "x"');
+                    throw new InvalidKeyException('Invalid key parameter "x"');
                 }
                 $d = $private_key->get('d');
                 if (! is_string($d)) {
-                    throw new InvalidArgumentException('Invalid key parameter "d"');
+                    throw new InvalidKeyException('Invalid key parameter "d"');
                 }
                 $sKey = Base64UrlSafe::decodeNoPadding($d);
                 $recipientPublickey = Base64UrlSafe::decodeNoPadding($x);
@@ -141,7 +145,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
                 return sodium_crypto_scalarmult($sKey, $recipientPublickey);
 
             default:
-                throw new InvalidArgumentException(sprintf('The curve "%s" is not supported', $crv));
+                throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported', $crv));
         }
     }
 
@@ -159,12 +163,12 @@ abstract readonly class AbstractECDH implements KeyAgreement
 
         $crv = $public_key->get('crv');
         if (! is_string($crv)) {
-            throw new InvalidArgumentException('Invalid key parameter "crv"');
+            throw new InvalidKeyException('Invalid key parameter "crv"');
         }
         $private_key = match ($crv) {
             'P-256', 'P-384', 'P-521', 'BP-256', 'BP-384', 'BP-512' => $senderKey ?? ECKey::createECKey($crv),
             'X25519' => $senderKey ?? $this->createOKPKey('X25519'),
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported', $crv)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported', $crv)),
         };
         $epk = $private_key->toPublic()
             ->all();
@@ -183,7 +187,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
         $private_key = $recipient_key;
         $public_key = $this->getPublicKey($complete_header);
         if ($private_key->get('crv') !== $public_key->get('crv')) {
-            throw new InvalidArgumentException('Curves are different');
+            throw new InvalidKeyException('Curves are different');
         }
 
         return [$public_key, $private_key];
@@ -195,10 +199,10 @@ abstract readonly class AbstractECDH implements KeyAgreement
     private function getPublicKey(array $complete_header): JWK
     {
         if (! isset($complete_header['epk'])) {
-            throw new InvalidArgumentException('The header parameter "epk" is missing.');
+            throw new InvalidHeaderParameterException('The header parameter "epk" is missing.');
         }
         if (! is_array($complete_header['epk'])) {
-            throw new InvalidArgumentException('The header parameter "epk" is not an array of parameters');
+            throw new InvalidHeaderParameterException('The header parameter "epk" is not an array of parameters');
         }
         $public_key = new JWK($complete_header['epk']);
         $this->checkKey($public_key, false);
@@ -209,17 +213,17 @@ abstract readonly class AbstractECDH implements KeyAgreement
     private function checkKey(JWK $key, bool $is_private): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         foreach (['x', 'crv'] as $k) {
             if (! $key->has($k)) {
-                throw new InvalidArgumentException(sprintf('The key parameter "%s" is missing.', $k));
+                throw new InvalidKeyException(sprintf('The key parameter "%s" is missing.', $k));
             }
         }
 
         $crv = $key->get('crv');
         if (! is_string($crv)) {
-            throw new InvalidArgumentException('Invalid key parameter "crv"');
+            throw new InvalidKeyException('Invalid key parameter "crv"');
         }
         switch ($crv) {
             case 'P-256':
@@ -229,7 +233,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
             case 'BP-384':
             case 'BP-512':
                 if (! $key->has('y')) {
-                    throw new InvalidArgumentException('The key parameter "y" is missing.');
+                    throw new InvalidKeyException('The key parameter "y" is missing.');
                 }
 
                 break;
@@ -238,10 +242,10 @@ abstract readonly class AbstractECDH implements KeyAgreement
                 break;
 
             default:
-                throw new InvalidArgumentException(sprintf('The curve "%s" is not supported', $crv));
+                throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported', $crv));
         }
         if ($is_private && ! $key->has('d')) {
-            throw new InvalidArgumentException('The key parameter "d" is missing.');
+            throw new InvalidKeyException('The key parameter "d" is missing.');
         }
     }
 
@@ -254,7 +258,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
             'BP-256' => BrainpoolCurve::curve256(),
             'BP-384' => BrainpoolCurve::curve384(),
             'BP-512' => BrainpoolCurve::curve512(),
-            default => throw new InvalidArgumentException(sprintf('The curve "%s" is not supported', $crv)),
+            default => throw new UnsupportedCurveException(sprintf('The curve "%s" is not supported', $crv)),
         };
     }
 
@@ -312,7 +316,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
                 break;
 
             default:
-                throw new InvalidArgumentException(sprintf('Unsupported "%s" curve', $curve));
+                throw new UnsupportedCurveException(sprintf('Unsupported "%s" curve', $curve));
         }
 
         return new JWK([
@@ -326,7 +330,7 @@ abstract readonly class AbstractECDH implements KeyAgreement
     private function checkSodiumExtensionIsAvailable(): void
     {
         if (! extension_loaded('sodium')) {
-            throw new RuntimeException('The extension "sodium" is not available. Please install it to use this method');
+            throw new MissingDependencyException('The extension "sodium" is not available. Please install it to use this method');
         }
     }
 }

--- a/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDHAESKW.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/AbstractECDHAESKW.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
 use AESKW\Wrapper as WrapperInterface;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Override;
-use RuntimeException;
 
 abstract readonly class AbstractECDHAESKW implements KeyAgreementWithKeyWrapping
 {
     public function __construct()
     {
         if (! interface_exists(WrapperInterface::class)) {
-            throw new RuntimeException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
+            throw new MissingDependencyException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
         }
     }
 

--- a/src/Library/Encryption/Algorithm/KeyEncryption/Dir.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/Dir.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
@@ -17,14 +17,14 @@ final readonly class Dir implements DirectEncryption
     public function getCEK(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);

--- a/src/Library/Encryption/Algorithm/KeyEncryption/ECDHSS.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/ECDHSS.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
+use Jose\Component\Core\Exception\LogicException;
 use Jose\Component\Core\JWK;
-use LogicException;
 use Override;
 
 final readonly class ECDHSS extends AbstractECDH

--- a/src/Library/Encryption/Algorithm/KeyEncryption/PBES2AESKW.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/PBES2AESKW.php
@@ -8,11 +8,13 @@ use AESKW\A128KW;
 use AESKW\A192KW;
 use AESKW\A256KW;
 use AESKW\Wrapper as WrapperInterface;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
-use RuntimeException;
 use function in_array;
 use function is_int;
 use function is_string;
@@ -28,7 +30,7 @@ abstract readonly class PBES2AESKW implements KeyWrapping
         private int $max_count = self::DEFAULT_MAX_COUNT
     ) {
         if (! interface_exists(WrapperInterface::class)) {
-            throw new RuntimeException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
+            throw new MissingDependencyException('Please install "spomky-labs/aes-key-wrap" to use AES-KW algorithms');
         }
     }
 
@@ -81,10 +83,10 @@ abstract readonly class PBES2AESKW implements KeyWrapping
         $hash_algorithm = $this->getHashAlgorithm();
         $key_size = $this->getKeySize();
         $p2s = $completeHeader['p2s'];
-        is_string($p2s) || throw new InvalidArgumentException('Invalid salt.');
+        is_string($p2s) || throw new InvalidHeaderParameterException('Invalid salt.');
         $salt = $completeHeader['alg'] . "\x00" . Base64UrlSafe::decodeNoPadding($p2s);
         $count = $completeHeader['p2c'];
-        is_int($count) || throw new InvalidArgumentException('Invalid counter.');
+        is_int($count) || throw new InvalidHeaderParameterException('Invalid counter.');
 
         $derived_key = hash_pbkdf2($hash_algorithm, $password, $salt, $count, $key_size, true);
 
@@ -100,14 +102,14 @@ abstract readonly class PBES2AESKW implements KeyWrapping
     protected function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);
@@ -119,10 +121,10 @@ abstract readonly class PBES2AESKW implements KeyWrapping
     protected function checkHeaderAlgorithm(array $header): void
     {
         if (! isset($header['alg'])) {
-            throw new InvalidArgumentException('The header parameter "alg" is missing.');
+            throw new InvalidHeaderParameterException('The header parameter "alg" is missing.');
         }
         if (! is_string($header['alg'])) {
-            throw new InvalidArgumentException('The header parameter "alg" is not valid.');
+            throw new InvalidHeaderParameterException('The header parameter "alg" is not valid.');
         }
     }
 
@@ -132,16 +134,16 @@ abstract readonly class PBES2AESKW implements KeyWrapping
     protected function checkHeaderAdditionalParameters(array $header): void
     {
         if (! isset($header['p2s'])) {
-            throw new InvalidArgumentException('The header parameter "p2s" is missing.');
+            throw new InvalidHeaderParameterException('The header parameter "p2s" is missing.');
         }
         if (! is_string($header['p2s'])) {
-            throw new InvalidArgumentException('The header parameter "p2s" is not valid.');
+            throw new InvalidHeaderParameterException('The header parameter "p2s" is not valid.');
         }
         if (! isset($header['p2c'])) {
-            throw new InvalidArgumentException('The header parameter "p2c" is missing.');
+            throw new InvalidHeaderParameterException('The header parameter "p2c" is missing.');
         }
         if (! is_int($header['p2c']) || $header['p2c'] <= 0) {
-            throw new InvalidArgumentException('The header parameter "p2c" is not valid.');
+            throw new InvalidHeaderParameterException('The header parameter "p2c" is not valid.');
         }
         if ($header['p2c'] > $this->max_count) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Library/Encryption/Algorithm/KeyEncryption/RSA.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/RSA.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\RSAKey;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\RSACrypt;
@@ -40,7 +40,7 @@ abstract readonly class RSA implements KeyEncryption
     {
         $this->checkKey($key);
         if (! $key->has('d')) {
-            throw new InvalidArgumentException('The key is not a private key');
+            throw new InvalidKeyException('The key is not a private key');
         }
         $priv = RSAKey::createFromJWK($key);
 
@@ -56,7 +56,7 @@ abstract readonly class RSA implements KeyEncryption
     protected function checkKey(JWK $key): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
     }
 

--- a/src/Library/Encryption/Algorithm/KeyEncryption/RSA15.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/RSA15.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\RSAKey;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\RSACrypt;
@@ -51,7 +51,7 @@ final readonly class RSA15 extends RSA
         $encryptionKeyLength = func_num_args() > 3 ? func_get_arg(3) : null;
         $this->checkKey($key);
         if (! $key->has('d')) {
-            throw new InvalidArgumentException('The key is not a private key');
+            throw new InvalidKeyException('The key is not a private key');
         }
         $priv = RSAKey::createFromJWK($key);
 

--- a/src/Library/Encryption/Algorithm/KeyEncryption/Util/ConcatKDF.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/Util/ConcatKDF.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use function strlen;
 use const STR_PAD_LEFT;

--- a/src/Library/Encryption/Algorithm/KeyEncryption/Util/RSACrypt.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/Util/RSACrypt.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\LogicException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\Util\BigInteger;
 use Jose\Component\Core\Util\Hash;
 use Jose\Component\Core\Util\RSAKey;
-use LogicException;
-use RuntimeException;
 use function chr;
 use function count;
 use function ord;
@@ -43,7 +44,7 @@ final readonly class RSACrypt
             case self::ENCRYPTION_PKCS1:
                 return self::encryptWithRSA15($key, $data);
             default:
-                throw new InvalidArgumentException('Unsupported mode.');
+                throw new UnsupportedAlgorithmException('Unsupported mode.');
         }
     }
 
@@ -64,7 +65,7 @@ final readonly class RSACrypt
             case self::ENCRYPTION_PKCS1:
                 return self::decryptWithRSA15($key, $plaintext, $expectedKeyLength);
             default:
-                throw new InvalidArgumentException('Unsupported mode.');
+                throw new UnsupportedAlgorithmException('Unsupported mode.');
         }
     }
 

--- a/src/Library/Encryption/JWE.php
+++ b/src/Library/Encryption/JWE.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use Jose\Component\Core\JWT;
 use Override;
 use function array_key_exists;
@@ -143,7 +144,7 @@ class JWE implements JWT
     public function getSharedProtectedHeaderParameter(string $key)
     {
         if (! $this->hasSharedProtectedHeaderParameter($key)) {
-            throw new InvalidArgumentException(sprintf('The shared protected header "%s" does not exist.', $key));
+            throw new InvalidHeaderParameterException(sprintf('The shared protected header "%s" does not exist.', $key));
         }
 
         return $this->sharedProtectedHeader[$key];
@@ -178,7 +179,7 @@ class JWE implements JWT
     public function getSharedHeaderParameter(string $key)
     {
         if (! $this->hasSharedHeaderParameter($key)) {
-            throw new InvalidArgumentException(sprintf('The shared header "%s" does not exist.', $key));
+            throw new InvalidHeaderParameterException(sprintf('The shared header "%s" does not exist.', $key));
         }
 
         return $this->sharedHeader[$key];

--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption;
 
-use InvalidArgumentException;
 use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\LogicException;
+use Jose\Component\Core\Exception\MissingPayloadLogicException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\InheritanceChecker;
@@ -18,8 +23,6 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyAgreementWithKeyWrappin
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyEncryption;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\KeyWrapping;
 use Jose\Component\Encryption\Algorithm\KeyEncryptionAlgorithm;
-use LogicException;
-use RuntimeException;
 use function array_key_exists;
 use function count;
 use function intdiv;
@@ -210,7 +213,7 @@ class JWEBuilder implements JWEBuilderInterface
     public function build(): JWE
     {
         if ($this->payload === null) {
-            throw new LogicException('Payload not set.');
+            throw new MissingPayloadLogicException('Payload not set.');
         }
         if (count($this->recipients) === 0) {
             throw new LogicException('No recipient.');
@@ -339,11 +342,11 @@ class JWEBuilder implements JWEBuilderInterface
                 continue;
             }
             if ($current->name() !== $contentEncryptionAlgorithm->name()) {
-                throw new InvalidArgumentException('Inconsistent content encryption algorithm');
+                throw new UnsupportedAlgorithmException('Inconsistent content encryption algorithm');
             }
         }
         if ($contentEncryptionAlgorithm === null) {
-            throw new InvalidArgumentException('Invalid content encryption algorithm');
+            throw new UnsupportedAlgorithmException('Invalid content encryption algorithm');
         }
 
         return $contentEncryptionAlgorithm;
@@ -526,7 +529,7 @@ class JWEBuilder implements JWEBuilderInterface
             return null;
         }
 
-        throw new InvalidArgumentException('Unsupported key encryption algorithm.');
+        throw new UnsupportedAlgorithmException('Unsupported key encryption algorithm.');
     }
 
     /**
@@ -616,7 +619,7 @@ class JWEBuilder implements JWEBuilderInterface
                 }
                 $algorithm = $keyEncryptionAlgorithms[0];
                 if (! $algorithm instanceof KeyAgreement) {
-                    throw new InvalidArgumentException('Invalid content encryption algorithm');
+                    throw new UnsupportedAlgorithmException('Invalid content encryption algorithm');
                 }
 
                 return $algorithm->getAgreementKey(
@@ -702,7 +705,7 @@ class JWEBuilder implements JWEBuilderInterface
     {
         $alg = $completeHeader['alg'] ?? null;
         if (! is_string($alg)) {
-            throw new InvalidArgumentException('Parameter "alg" is missing.');
+            throw new InvalidHeaderParameterException('Parameter "alg" is missing.');
         }
         $keyEncryptionAlgorithm = $this->keyEncryptionAlgorithmManager->get($alg);
         if (! $keyEncryptionAlgorithm instanceof KeyEncryptionAlgorithm) {
@@ -722,11 +725,11 @@ class JWEBuilder implements JWEBuilderInterface
     {
         $enc = $completeHeader['enc'] ?? null;
         if (! is_string($enc)) {
-            throw new InvalidArgumentException('Parameter "enc" is missing.');
+            throw new InvalidHeaderParameterException('Parameter "enc" is missing.');
         }
         $contentEncryptionAlgorithm = $this->contentEncryptionAlgorithmManager->get($enc);
         if (! $contentEncryptionAlgorithm instanceof ContentEncryptionAlgorithm) {
-            throw new InvalidArgumentException(sprintf(
+            throw new UnsupportedAlgorithmException(sprintf(
                 'The content encryption algorithm "%s" is not supported or not a content encryption algorithm instance.',
                 $enc
             ));
@@ -743,7 +746,7 @@ class JWEBuilder implements JWEBuilderInterface
     {
         $inter = array_intersect_key($header1, $header2);
         if (count($inter) !== 0) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidHeaderParameterException(sprintf(
                 'The header contains duplicated entries: %s.',
                 implode(', ', array_keys($inter))
             ));

--- a/src/Library/Encryption/JWEDecrypter.php
+++ b/src/Library/Encryption/JWEDecrypter.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption;
 
-use InvalidArgumentException;
 use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\InheritanceChecker;
@@ -111,7 +114,7 @@ class JWEDecrypter implements JWEDecrypterInterface
             $onError = null;
         }
         if ($jwkset->count() === 0) {
-            throw new InvalidArgumentException('No key in the key set.');
+            throw new InvalidKeySetException('No key in the key set.');
         }
         if ($jwe->getPayload() !== null) {
             return true;
@@ -274,7 +277,7 @@ class JWEDecrypter implements JWEDecrypterInterface
             );
         }
 
-        throw new InvalidArgumentException('Unsupported CEK generation');
+        throw new UnsupportedAlgorithmException('Unsupported CEK generation');
     }
 
     private function decryptPayload(
@@ -296,7 +299,7 @@ class JWEDecrypter implements JWEDecrypterInterface
     {
         foreach (['enc', 'alg'] as $key) {
             if (! isset($completeHeaders[$key])) {
-                throw new InvalidArgumentException(sprintf("Parameter '%s' is missing.", $key));
+                throw new InvalidHeaderParameterException(sprintf("Parameter '%s' is missing.", $key));
             }
         }
     }
@@ -330,7 +333,7 @@ class JWEDecrypter implements JWEDecrypterInterface
         }
         $content_encryption_algorithm = $this->contentEncryptionAlgorithmManager->get($enc);
         if (! $content_encryption_algorithm instanceof ContentEncryptionAlgorithm) {
-            throw new InvalidArgumentException(sprintf(
+            throw new UnsupportedAlgorithmException(sprintf(
                 'The content encryption algorithm "%s" is not supported or does not implement the ContentEncryption interface.',
                 $enc
             ));
@@ -343,7 +346,7 @@ class JWEDecrypter implements JWEDecrypterInterface
     {
         $inter = array_intersect_key($header1, $header2);
         if (count($inter) !== 0) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidHeaderParameterException(sprintf(
                 'The header contains duplicated entries: %s.',
                 implode(', ', array_keys($inter))
             ));

--- a/src/Library/Encryption/JWELoader.php
+++ b/src/Library/Encryption/JWELoader.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption;
 
 use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\Exception\InvalidTokenException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -88,7 +88,7 @@ class JWELoader implements JWELoaderInterface
             $lastError = $throwable;
         }
 
-        throw new RuntimeException('Unable to load and decrypt the token.', 0, $lastError);
+        throw new InvalidTokenException('Unable to load and decrypt the token.', 0, $lastError);
     }
 
     private function processRecipient(JWE &$jwe, JWKSet $keyset, int $recipient, ?Throwable &$lastError): bool

--- a/src/Library/Encryption/Recipient.php
+++ b/src/Library/Encryption/Recipient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use function array_key_exists;
 use function sprintf;
 
@@ -37,7 +37,7 @@ final readonly class Recipient
     public function getHeaderParameter(string $key)
     {
         if (! $this->hasHeaderParameter($key)) {
-            throw new InvalidArgumentException(sprintf('The header "%s" does not exist.', $key));
+            throw new InvalidHeaderParameterException(sprintf('The header "%s" does not exist.', $key));
         }
 
         return $this->header[$key];

--- a/src/Library/Encryption/Serializer/CompactSerializer.php
+++ b/src/Library/Encryption/Serializer/CompactSerializer.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\LogicException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\Recipient;
-use LogicException;
 use Override;
 use Throwable;
 use function count;
@@ -65,7 +65,7 @@ final readonly class CompactSerializer implements JWESerializer
     {
         $parts = explode('.', $input, 6);
         if (count($parts) !== 5) {
-            throw new InvalidArgumentException('Unsupported input');
+            throw new InvalidSerializationException('Unsupported input');
         }
 
         try {
@@ -74,7 +74,7 @@ final readonly class CompactSerializer implements JWESerializer
                 Base64UrlSafe::decodeNoPadding($encodedSharedProtectedHeader)
             );
             if (! is_array($sharedProtectedHeader)) {
-                throw new InvalidArgumentException('Unsupported input.');
+                throw new InvalidSerializationException('Unsupported input.');
             }
             $encryptedKey = $parts[1] === '' ? null : Base64UrlSafe::decodeNoPadding($parts[1]);
             $iv = Base64UrlSafe::decodeNoPadding($parts[2]);
@@ -92,7 +92,7 @@ final readonly class CompactSerializer implements JWESerializer
                 [new Recipient([], $encryptedKey)]
             );
         } catch (Throwable $throwable) {
-            throw new InvalidArgumentException('Unsupported input', $throwable->getCode(), $throwable);
+            throw new InvalidSerializationException('Unsupported input', $throwable->getCode(), $throwable);
         }
     }
 

--- a/src/Library/Encryption/Serializer/JSONFlattenedSerializer.php
+++ b/src/Library/Encryption/Serializer/JSONFlattenedSerializer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Encryption\JWE;
@@ -66,7 +66,7 @@ final readonly class JSONFlattenedSerializer implements JWESerializer
     {
         $data = JsonConverter::decode($input);
         if (! is_array($data)) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
         $this->checkData($data);
 
@@ -95,7 +95,7 @@ final readonly class JSONFlattenedSerializer implements JWESerializer
     private function checkData(?array $data): void
     {
         if ($data === null || ! isset($data['ciphertext']) || isset($data['recipients'])) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
     }
 

--- a/src/Library/Encryption/Serializer/JSONGeneralSerializer.php
+++ b/src/Library/Encryption/Serializer/JSONGeneralSerializer.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\LogicException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\Recipient;
-use LogicException;
 use Override;
 use function array_key_exists;
 use function count;
@@ -72,7 +72,7 @@ final readonly class JSONGeneralSerializer implements JWESerializer
     {
         $data = JsonConverter::decode($input);
         if (! is_array($data)) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
         $this->checkData($data);
 
@@ -102,7 +102,7 @@ final readonly class JSONGeneralSerializer implements JWESerializer
     private function checkData(?array $data): void
     {
         if ($data === null || ! isset($data['ciphertext']) || ! isset($data['recipients'])) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
     }
 

--- a/src/Library/Encryption/Serializer/JWESerializerManager.php
+++ b/src/Library/Encryption/Serializer/JWESerializerManager.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Jose\Component\Encryption\Serializer;
 
 use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\UnsupportedSerializerException;
 use Jose\Component\Encryption\JWE;
 use function sprintf;
 
@@ -41,7 +43,7 @@ final class JWESerializerManager
     public function serialize(string $name, JWE $jws, ?int $recipientIndex = null): string
     {
         if (! isset($this->serializers[$name])) {
-            throw new InvalidArgumentException(sprintf('Unsupported serializer "%s".', $name));
+            throw new UnsupportedSerializerException(sprintf('Unsupported serializer "%s".', $name));
         }
 
         return $this->serializers[$name]->serialize($jws, $recipientIndex);
@@ -72,7 +74,7 @@ final class JWESerializerManager
             }
         }
 
-        throw new InvalidArgumentException('Unsupported input.', 0, $lastError);
+        throw new InvalidSerializationException('Unsupported input.', 0, $lastError);
     }
 
     /**

--- a/src/Library/Encryption/Serializer/JWESerializerManagerFactory.php
+++ b/src/Library/Encryption/Serializer/JWESerializerManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\UnsupportedSerializerException;
 use function sprintf;
 
 final class JWESerializerManagerFactory
@@ -24,7 +24,7 @@ final class JWESerializerManagerFactory
         $serializers = [];
         foreach ($names as $name) {
             if (! isset($this->serializers[$name])) {
-                throw new InvalidArgumentException(sprintf('Unsupported serializer "%s".', $name));
+                throw new UnsupportedSerializerException(sprintf('Unsupported serializer "%s".', $name));
             }
             $serializers[] = $this->serializers[$name];
         }

--- a/src/Library/KeyManagement/Analyzer/RsaAnalyzer.php
+++ b/src/Library/KeyManagement/Analyzer/RsaAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement\Analyzer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
@@ -36,7 +36,7 @@ final readonly class RsaAnalyzer implements KeyAnalyzer
         }
         $exponent = unpack('l', str_pad(Base64UrlSafe::decodeNoPadding($e), 4, "\0", STR_PAD_RIGHT));
         if (! is_array($exponent) || ! isset($exponent[1])) {
-            throw new InvalidArgumentException('Unable to get the private key');
+            throw new InvalidKeyException('Unable to get the private key');
         }
         if ($exponent[1] < 65537) {
             $bag->add(Message::high('The exponent is too low. It should be at least 65537.'));

--- a/src/Library/KeyManagement/JKUFactory.php
+++ b/src/Library/KeyManagement/JKUFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement;
 
+use Jose\Component\Core\Exception\RuntimeException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
-use RuntimeException;
 use function is_array;
 
 class JKUFactory extends UrlKeySetFactory

--- a/src/Library/KeyManagement/JWKFactory.php
+++ b/src/Library/KeyManagement/JWKFactory.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedCurveException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\Base64UrlSafe;
@@ -12,7 +15,6 @@ use Jose\Component\Core\Util\ECKey;
 use Jose\Component\KeyManagement\KeyConverter\KeyConverter;
 use Jose\Component\KeyManagement\KeyConverter\RSAKey;
 use OpenSSLCertificate;
-use RuntimeException;
 use Throwable;
 use function array_key_exists;
 use function extension_loaded;
@@ -37,13 +39,13 @@ class JWKFactory
     public static function createRSAKey(int $size, array $values = []): JWK
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         if ($size % 8 !== 0) {
-            throw new InvalidArgumentException('Invalid key size.');
+            throw new InvalidKeyException('Invalid key size.');
         }
         if ($size < 512) {
-            throw new InvalidArgumentException('Key length is too short. It needs to be at least 512 bits.');
+            throw new InvalidKeyException('Key length is too short. It needs to be at least 512 bits.');
         }
 
         $key = openssl_pkey_new([
@@ -51,11 +53,11 @@ class JWKFactory
             'private_key_type' => OPENSSL_KEYTYPE_RSA,
         ]);
         if ($key === false) {
-            throw new InvalidArgumentException('Unable to create the key');
+            throw new InvalidKeyException('Unable to create the key');
         }
         $details = openssl_pkey_get_details($key);
         if (! is_array($details)) {
-            throw new InvalidArgumentException('Unable to create the key');
+            throw new InvalidKeyException('Unable to create the key');
         }
         $rsa = RSAKey::createFromKeyDetails($details['rsa']);
         $values = array_merge($values, $rsa->toArray());
@@ -83,7 +85,7 @@ class JWKFactory
     public static function createOctKey(int $size, array $values = []): JWK
     {
         if ($size < 8 || $size % 8 !== 0) {
-            throw new InvalidArgumentException('Invalid key size.');
+            throw new InvalidKeyException('Invalid key size.');
         }
 
         return self::createFromSecret(random_bytes(max(1, intdiv($size, 8))), $values);
@@ -98,7 +100,7 @@ class JWKFactory
     public static function createOKPKey(string $curve, array $values = []): JWK
     {
         if (! extension_loaded('sodium')) {
-            throw new RuntimeException('The extension "sodium" is not available. Please install it to use this method');
+            throw new MissingDependencyException('The extension "sodium" is not available. Please install it to use this method');
         }
 
         switch ($curve) {
@@ -119,7 +121,7 @@ class JWKFactory
                 break;
 
             default:
-                throw new InvalidArgumentException(sprintf('Unsupported "%s" curve', $curve));
+                throw new UnsupportedCurveException(sprintf('Unsupported "%s" curve', $curve));
         }
 
         $values = [
@@ -158,7 +160,7 @@ class JWKFactory
     {
         $json = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         if (! is_array($json)) {
-            throw new InvalidArgumentException('Invalid key or key set.');
+            throw new InvalidKeyException('Invalid key or key set.');
         }
 
         return self::createFromValues($json);

--- a/src/Library/KeyManagement/KeyConverter/ECKey.php
+++ b/src/Library/KeyManagement/KeyConverter/ECKey.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement\KeyConverter;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\EC\ECPrivateKey;
@@ -75,7 +76,7 @@ final class ECKey
             ];
         } catch (Throwable) {
         }
-        throw new InvalidArgumentException('Unable to load the key.');
+        throw new InvalidKeyException('Unable to load the key.');
     }
 
     private static function getCurve(string $oid): string
@@ -83,7 +84,7 @@ final class ECKey
         $curves = self::getSupportedCurves();
         $curve = array_search($oid, $curves, true);
         if (! is_string($curve)) {
-            throw new InvalidArgumentException('Unsupported OID.');
+            throw new InvalidKeyException('Unsupported OID.');
         }
 
         return $curve;
@@ -116,7 +117,7 @@ final class ECKey
         }
 
         if ($jwk['kty'] !== 'EC') {
-            throw new InvalidArgumentException('JWK is not an Elliptic Curve key.');
+            throw new InvalidKeyException('JWK is not an Elliptic Curve key.');
         }
         $this->values = $jwk;
     }

--- a/src/Library/KeyManagement/KeyConverter/KeyConverter.php
+++ b/src/Library/KeyManagement/KeyConverter/KeyConverter.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Jose\Component\KeyManagement\KeyConverter;
 
 use Brick\Math\BigInteger;
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use OpenSSLCertificate;
 use ParagonIE\Sodium\Core\Ed25519;
-use RuntimeException;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
@@ -59,7 +61,7 @@ final readonly class KeyConverter
     public static function loadKeyFromCertificate(string $certificate): array
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
 
         $errorReporting = error_reporting(E_ERROR | E_PARSE);
@@ -87,7 +89,7 @@ final readonly class KeyConverter
     public static function loadKeyFromX509Resource(OpenSSLCertificate $res): array
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         $key = openssl_pkey_get_public($res);
         if ($key === false) {
@@ -130,7 +132,7 @@ final readonly class KeyConverter
     {
         $content = file_get_contents($file);
         if (! is_string($content)) {
-            throw new InvalidArgumentException('Unable to load the key from the file.');
+            throw new InvalidKeyException('Unable to load the key from the file.');
         }
 
         return self::loadFromKey($content, $password);
@@ -158,7 +160,7 @@ final readonly class KeyConverter
     public static function loadFromX5C(array $x5c): array
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         if (count($x5c) === 0) {
             throw new InvalidArgumentException('The certificate chain is empty');
@@ -199,7 +201,7 @@ final readonly class KeyConverter
     private static function loadKeyFromPEM(string $pem, ?string $password = null): array
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
 
         if (preg_match('#DEK-Info: (.+),(.+)#', $pem, $matches) === 1) {
@@ -209,7 +211,7 @@ final readonly class KeyConverter
         if (preg_match('#BEGIN ENCRYPTED PRIVATE KEY(.+)(.+)#', $pem) === 1) {
             $decrypted = openssl_pkey_get_private($pem, $password);
             if ($decrypted === false) {
-                throw new InvalidArgumentException('Unable to decrypt the key.');
+                throw new InvalidKeyException('Unable to decrypt the key.');
             }
             openssl_pkey_export($decrypted, $pem);
         }
@@ -220,13 +222,13 @@ final readonly class KeyConverter
             $res = openssl_pkey_get_public($pem);
         }
         if ($res === false) {
-            throw new InvalidArgumentException('Unable to load the key.');
+            throw new InvalidKeyException('Unable to load the key.');
         }
 
         $details = openssl_pkey_get_details($res);
         if (! is_array($details) || ! array_key_exists('type', $details)
             || ! array_key_exists('key', $details) || ! is_string($details['key'])) {
-            throw new InvalidArgumentException('Unable to get details of the key');
+            throw new InvalidKeyException('Unable to get details of the key');
         }
 
         return match ($details['type']) {
@@ -237,7 +239,7 @@ final readonly class KeyConverter
             6 => self::tryToLoadX448Key($details), // OPENSSL_KEYTYPE_X448
             7 => self::tryToLoadED448Key($details), // OPENSSL_KEYTYPE_ED448
             -1 => self::tryToLoadOtherKeyTypes($details, $pem),
-            default => throw new InvalidArgumentException('Unsupported key type'),
+            default => throw new InvalidKeyException('Unsupported key type'),
         };
     }
 
@@ -260,7 +262,7 @@ final readonly class KeyConverter
         } catch (Throwable) {
             // no break
         }
-        throw new InvalidArgumentException('Unable to load the key.');
+        throw new InvalidKeyException('Unable to load the key.');
     }
 
     /**
@@ -369,7 +371,7 @@ final readonly class KeyConverter
         return match ($pem->type()) {
             PEM::TYPE_PUBLIC_KEY => self::loadPublicKey($pem),
             PEM::TYPE_PRIVATE_KEY => self::loadPrivateKey($details, $pem),
-            default => throw new InvalidArgumentException('Unsupported key type'),
+            default => throw new InvalidKeyException('Unsupported key type'),
         };
     }
 
@@ -410,10 +412,10 @@ final readonly class KeyConverter
                         'd' => Base64UrlSafe::encodeUnpadded($key->privateKeyData()),
                     ];
                 default:
-                    throw new InvalidArgumentException('Unsupported key type');
+                    throw new InvalidKeyException('Unsupported key type');
             }
         } catch (Throwable $e) {
-            throw new InvalidArgumentException('Unable to load the key.', 0, $e);
+            throw new InvalidKeyException('Unable to load the key.', 0, $e);
         }
     }
 
@@ -436,14 +438,14 @@ final readonly class KeyConverter
                     'x' => Base64UrlSafe::encodeUnpadded((string) $key->subjectPublicKey()),
                 ];
             default:
-                throw new InvalidArgumentException('Unsupported key type');
+                throw new InvalidKeyException('Unsupported key type');
         }
     }
 
     private static function convertDecimalToBas64Url(string $decimal): string
     {
         if ($decimal === '') {
-            throw new InvalidArgumentException('Unsupported key type');
+            throw new InvalidKeyException('Unsupported key type');
         }
 
         return Base64UrlSafe::encodeUnpadded(BigInteger::fromBase($decimal, 10)->toBytes());
@@ -452,7 +454,7 @@ final readonly class KeyConverter
     private static function checkType(string $curve): void
     {
         $curves = ['Ed448ph', 'Ed25519ph', 'Ed448', 'Ed25519', 'X448', 'X25519'];
-        in_array($curve, $curves, true) || throw new InvalidArgumentException('Unsupported key type.');
+        in_array($curve, $curves, true) || throw new InvalidKeyException('Unsupported key type.');
     }
 
     /**
@@ -467,7 +469,7 @@ final readonly class KeyConverter
             '1.3.101.112' => 'Ed25519',
             '1.3.101.111' => 'X448',
             '1.3.101.110' => 'X25519',
-            default => throw new InvalidArgumentException('Unsupported key type.'),
+            default => throw new InvalidKeyException('Unsupported key type.'),
         };
     }
 
@@ -478,7 +480,7 @@ final readonly class KeyConverter
     {
         $number = preg_match_all('#(-.*-)#', $pem, $matches, PREG_PATTERN_ORDER);
         if ($number !== 2) {
-            throw new InvalidArgumentException('Unable to load the key');
+            throw new InvalidKeyException('Unable to load the key');
         }
 
         $ciphertext = preg_replace('#-.*-|\r|\n| #', '', $pem);
@@ -494,7 +496,7 @@ final readonly class KeyConverter
     private static function decodePem(string $pem, array $matches, ?string $password = null): string
     {
         if ($password === null) {
-            throw new InvalidArgumentException('Password required for encrypted keys.');
+            throw new InvalidKeyException('Password required for encrypted keys.');
         }
 
         $iv = pack('H*', trim($matches[2]));
@@ -509,11 +511,11 @@ final readonly class KeyConverter
 
         $decoded = openssl_decrypt($ciphertext, strtolower($matches[1]), $symkey, OPENSSL_RAW_DATA, $iv);
         if ($decoded === false) {
-            throw new RuntimeException('Unable to decrypt the key');
+            throw new DecryptionFailedException('Unable to decrypt the key');
         }
         $number = preg_match_all('#-{5}.*-{5}#', $pem, $result);
         if ($number !== 2) {
-            throw new InvalidArgumentException('Unable to load the key');
+            throw new InvalidKeyException('Unable to load the key');
         }
 
         $pem = $result[0][0] . "\n";

--- a/src/Library/KeyManagement/KeyConverter/RSAKey.php
+++ b/src/Library/KeyManagement/KeyConverter/RSAKey.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement\KeyConverter;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\BigInteger;
-use RuntimeException;
 use function array_key_exists;
 use function assert;
 use function extension_loaded;
@@ -65,23 +65,23 @@ final class RSAKey
     public static function createFromPEM(string $pem): self
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         $res = openssl_pkey_get_private($pem);
         if ($res === false) {
             $res = openssl_pkey_get_public($pem);
         }
         if ($res === false) {
-            throw new InvalidArgumentException('Unable to load the key.');
+            throw new InvalidKeyException('Unable to load the key.');
         }
 
         $details = openssl_pkey_get_details($res);
         if (! is_array($details) || ! isset($details['rsa'])) {
-            throw new InvalidArgumentException('Unable to load the key.');
+            throw new InvalidKeyException('Unable to load the key.');
         }
         $data = $details['rsa'];
         if (! is_array($data)) {
-            throw new InvalidArgumentException('Unable to load the key.');
+            throw new InvalidKeyException('Unable to load the key.');
         }
 
         return self::createFromKeyDetails($data);
@@ -140,10 +140,10 @@ final class RSAKey
     private function loadJWK(array $jwk): void
     {
         if (! array_key_exists('kty', $jwk)) {
-            throw new InvalidArgumentException('The key parameter "kty" is missing.');
+            throw new InvalidKeyException('The key parameter "kty" is missing.');
         }
         if ($jwk['kty'] !== 'RSA') {
-            throw new InvalidArgumentException('The JWK is not a RSA key.');
+            throw new InvalidKeyException('The JWK is not a RSA key.');
         }
 
         $this->values = $jwk;
@@ -238,7 +238,7 @@ final class RSAKey
                 }
             }
             if ($y === null) {
-                throw new InvalidArgumentException('Unable to find prime factors.');
+                throw new InvalidKeyException('Unable to find prime factors.');
             }
             if ($found) {
                 $p = $y->subtract($one)
@@ -249,6 +249,6 @@ final class RSAKey
             }
         }
 
-        throw new InvalidArgumentException('Unable to find prime factors.');
+        throw new InvalidKeyException('Unable to find prime factors.');
     }
 }

--- a/src/Library/KeyManagement/UrlKeySetFactory.php
+++ b/src/Library/KeyManagement/UrlKeySetFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement;
 
+use Jose\Component\Core\Exception\RuntimeException;
 use Psr\Cache\CacheItemPoolInterface;
-use RuntimeException;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Library/KeyManagement/X5UFactory.php
+++ b/src/Library/KeyManagement/X5UFactory.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement;
 
+use Jose\Component\Core\Exception\RuntimeException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\KeyManagement\KeyConverter\KeyConverter;
-use RuntimeException;
 use function assert;
 use function is_array;
 use function is_string;

--- a/src/Library/NestedToken/NestedTokenLoader.php
+++ b/src/Library/NestedToken/NestedTokenLoader.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Jose\Component\NestedToken;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidPayloadException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Encryption\JWE;
@@ -36,7 +38,7 @@ class NestedTokenLoader implements NestedTokenLoaderInterface
         $jwe = $this->jweLoader->loadAndDecryptWithKeySet($token, $encryptionKeySet, $recipient);
         $this->checkContentTypeHeader($jwe, $recipient);
         if ($jwe->getPayload() === null) {
-            throw new InvalidArgumentException('The token has no payload.');
+            throw new InvalidPayloadException('The token has no payload.');
         }
 
         return $this->jwsLoader->loadAndVerifyWithKeySet($jwe->getPayload(), $signatureKeySet, $signature);
@@ -53,7 +55,7 @@ class NestedTokenLoader implements NestedTokenLoaderInterface
             default => throw new InvalidArgumentException('The token is not a nested token.'),
         };
         if (! is_string($cty)) {
-            throw new InvalidArgumentException('Invalid "cty" header parameter.');
+            throw new InvalidHeaderParameterException('Invalid "cty" header parameter.');
         }
 
         if (strcasecmp($cty, 'jwt') !== 0) {

--- a/src/Library/Signature/Algorithm/ECDSA.php
+++ b/src/Library/Signature/Algorithm/ECDSA.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\LogicException;
+use Jose\Component\Core\Exception\MissingDependencyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\Core\Util\ECSignature;
-use LogicException;
 use Override;
-use RuntimeException;
 use Throwable;
 use function defined;
 use function extension_loaded;
@@ -22,7 +22,7 @@ abstract readonly class ECDSA implements SignatureAlgorithm
     public function __construct()
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
         if (! defined('OPENSSL_KEYTYPE_EC')) {
             throw new LogicException('Elliptic Curve key type not supported by your environment.');
@@ -40,7 +40,7 @@ abstract readonly class ECDSA implements SignatureAlgorithm
     {
         $this->checkKey($key);
         if (! $key->has('d')) {
-            throw new InvalidArgumentException('The EC key is not private');
+            throw new InvalidKeyException('The EC key is not private');
         }
         $pem = ECKey::convertPrivateKeyToPEM($key);
         openssl_sign($input, $signature, $pem, $this->getHashAlgorithm());
@@ -70,11 +70,11 @@ abstract readonly class ECDSA implements SignatureAlgorithm
     private function checkKey(JWK $key): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         foreach (['x', 'y', 'crv'] as $k) {
             if (! $key->has($k)) {
-                throw new InvalidArgumentException(sprintf('The key parameter "%s" is missing.', $k));
+                throw new InvalidKeyException(sprintf('The key parameter "%s" is missing.', $k));
             }
         }
     }

--- a/src/Library/Signature/Algorithm/EdDSA.php
+++ b/src/Library/Signature/Algorithm/EdDSA.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\UnsupportedCurveException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
 use ParagonIE\Sodium\Core\Ed25519;
-use RuntimeException;
 use function assert;
 use function extension_loaded;
 use function in_array;
@@ -21,7 +22,7 @@ final readonly class EdDSA implements SignatureAlgorithm
     public function __construct()
     {
         if (! extension_loaded('sodium')) {
-            throw new RuntimeException('The extension "sodium" is not available. Please install it to use this method');
+            throw new MissingDependencyException('The extension "sodium" is not available. Please install it to use this method');
         }
     }
 
@@ -39,11 +40,11 @@ final readonly class EdDSA implements SignatureAlgorithm
     {
         $this->checkKey($key);
         if (! $key->has('d')) {
-            throw new InvalidArgumentException('The EC key is not private');
+            throw new InvalidKeyException('The EC key is not private');
         }
         $d = $key->get('d');
         if (! is_string($d) || $d === '') {
-            throw new InvalidArgumentException('Invalid "d" parameter.');
+            throw new InvalidKeyException('Invalid "d" parameter.');
         }
         if (! $key->has('x')) {
             $x = self::getPublicKey($key);
@@ -51,7 +52,7 @@ final readonly class EdDSA implements SignatureAlgorithm
             $x = $key->get('x');
         }
         if (! is_string($x) || $x === '') {
-            throw new InvalidArgumentException('Invalid "x" parameter.');
+            throw new InvalidKeyException('Invalid "x" parameter.');
         }
         /** @var non-empty-string $x */
         $x = Base64UrlSafe::decodeNoPadding($x);
@@ -61,7 +62,7 @@ final readonly class EdDSA implements SignatureAlgorithm
 
         return match ($key->get('crv')) {
             'Ed25519' => sodium_crypto_sign_detached($input, $secret),
-            default => throw new InvalidArgumentException('Unsupported curve'),
+            default => throw new UnsupportedCurveException('Unsupported curve'),
         };
     }
 
@@ -74,7 +75,7 @@ final readonly class EdDSA implements SignatureAlgorithm
         $this->checkKey($key);
         $x = $key->get('x');
         if (! is_string($x)) {
-            throw new InvalidArgumentException('Invalid "x" parameter.');
+            throw new InvalidKeyException('Invalid "x" parameter.');
         }
 
         /** @var non-empty-string $public */
@@ -82,7 +83,7 @@ final readonly class EdDSA implements SignatureAlgorithm
 
         return match ($key->get('crv')) {
             'Ed25519' => sodium_crypto_sign_verify_detached($signature, $input, $public),
-            default => throw new InvalidArgumentException('Unsupported curve'),
+            default => throw new UnsupportedCurveException('Unsupported curve'),
         };
     }
 
@@ -106,22 +107,22 @@ final readonly class EdDSA implements SignatureAlgorithm
                 }
                 // no break
             default:
-                throw new InvalidArgumentException('Unsupported key type');
+                throw new InvalidKeyException('Unsupported key type');
         }
     }
 
     private function checkKey(JWK $key): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         foreach (['x', 'crv'] as $k) {
             if (! $key->has($k)) {
-                throw new InvalidArgumentException(sprintf('The key parameter "%s" is missing.', $k));
+                throw new InvalidKeyException(sprintf('The key parameter "%s" is missing.', $k));
             }
         }
         if ($key->get('crv') !== 'Ed25519') {
-            throw new InvalidArgumentException('Unsupported curve.');
+            throw new UnsupportedCurveException('Unsupported curve.');
         }
     }
 }

--- a/src/Library/Signature/Algorithm/HMAC.php
+++ b/src/Library/Signature/Algorithm/HMAC.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Override;
@@ -36,14 +36,14 @@ abstract readonly class HMAC implements MacAlgorithm
     protected function getKey(JWK $key): string
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         if (! $key->has('k')) {
-            throw new InvalidArgumentException('The key parameter "k" is missing.');
+            throw new InvalidKeyException('The key parameter "k" is missing.');
         }
         $k = $key->get('k');
         if (! is_string($k)) {
-            throw new InvalidArgumentException('The key parameter "k" is invalid.');
+            throw new InvalidKeyException('The key parameter "k" is invalid.');
         }
 
         return Base64UrlSafe::decodeNoPadding($k);

--- a/src/Library/Signature/Algorithm/HS256.php
+++ b/src/Library/Signature/Algorithm/HS256.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Override;
 use function strlen;
@@ -28,7 +28,7 @@ final readonly class HS256 extends HMAC
     {
         $k = parent::getKey($key);
         if (strlen($k) < 32) {
-            throw new InvalidArgumentException('Invalid key length.');
+            throw new InvalidKeyException('Invalid key length.');
         }
 
         return $k;

--- a/src/Library/Signature/Algorithm/HS384.php
+++ b/src/Library/Signature/Algorithm/HS384.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Override;
 use function strlen;
@@ -28,7 +28,7 @@ final readonly class HS384 extends HMAC
     {
         $k = parent::getKey($key);
         if (strlen($k) < 48) {
-            throw new InvalidArgumentException('Invalid key length.');
+            throw new InvalidKeyException('Invalid key length.');
         }
 
         return $k;

--- a/src/Library/Signature/Algorithm/HS512.php
+++ b/src/Library/Signature/Algorithm/HS512.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Override;
 use function strlen;
@@ -28,7 +28,7 @@ final readonly class HS512 extends HMAC
     {
         $k = parent::getKey($key);
         if (strlen($k) < 64) {
-            throw new InvalidArgumentException('Invalid key length.');
+            throw new InvalidKeyException('Invalid key length.');
         }
 
         return $k;

--- a/src/Library/Signature/Algorithm/None.php
+++ b/src/Library/Signature/Algorithm/None.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Override;
 use function in_array;
@@ -40,7 +40,7 @@ final readonly class None implements SignatureAlgorithm
     private function checkKey(JWK $key): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
     }
 }

--- a/src/Library/Signature/Algorithm/RSAPKCS1.php
+++ b/src/Library/Signature/Algorithm/RSAPKCS1.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\RuntimeException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\RSAKey;
 use Override;
-use RuntimeException;
 use function extension_loaded;
 use function in_array;
 use function sprintf;
@@ -18,7 +19,7 @@ abstract readonly class RSAPKCS1 implements SignatureAlgorithm
     public function __construct()
     {
         if (! extension_loaded('openssl')) {
-            throw new RuntimeException('Please install the OpenSSL extension');
+            throw new MissingDependencyException('Please install the OpenSSL extension');
         }
     }
 
@@ -42,7 +43,7 @@ abstract readonly class RSAPKCS1 implements SignatureAlgorithm
     {
         $this->checkKey($key);
         if (! $key->has('d')) {
-            throw new InvalidArgumentException('The key is not a private key.');
+            throw new InvalidKeyException('The key is not a private key.');
         }
 
         $priv = RSAKey::createFromJWK($key);
@@ -60,11 +61,11 @@ abstract readonly class RSAPKCS1 implements SignatureAlgorithm
     private function checkKey(JWK $key): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         foreach (['n', 'e'] as $k) {
             if (! $key->has($k)) {
-                throw new InvalidArgumentException(sprintf('The key parameter "%s" is missing.', $k));
+                throw new InvalidKeyException(sprintf('The key parameter "%s" is missing.', $k));
             }
         }
     }

--- a/src/Library/Signature/Algorithm/RSAPSS.php
+++ b/src/Library/Signature/Algorithm/RSAPSS.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\RSAKey;
 use Jose\Component\Signature\Algorithm\Util\RSA as JoseRSA;
@@ -37,7 +37,7 @@ abstract readonly class RSAPSS implements SignatureAlgorithm
     {
         $this->checkKey($key);
         if (! $key->has('d')) {
-            throw new InvalidArgumentException('The key is not a private key.');
+            throw new InvalidKeyException('The key is not a private key.');
         }
 
         $priv = RSAKey::createFromJWK($key);
@@ -50,11 +50,11 @@ abstract readonly class RSAPSS implements SignatureAlgorithm
     private function checkKey(JWK $key): void
     {
         if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidArgumentException('Wrong key type.');
+            throw new InvalidKeyException('Wrong key type.');
         }
         foreach (['n', 'e'] as $k) {
             if (! $key->has($k)) {
-                throw new InvalidArgumentException(sprintf('The key parameter "%s" is missing.', $k));
+                throw new InvalidKeyException(sprintf('The key parameter "%s" is missing.', $k));
             }
         }
     }

--- a/src/Library/Signature/Algorithm/Util/RSA.php
+++ b/src/Library/Signature/Algorithm/Util/RSA.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm\Util;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\Util\BigInteger;
 use Jose\Component\Core\Util\Hash;
 use Jose\Component\Core\Util\RSAKey;
-use RuntimeException;
 use function chr;
 use function extension_loaded;
 use function ord;
@@ -41,7 +43,7 @@ final readonly class RSA
 
             case self::SIGNATURE_PKCS1:
                 if (! extension_loaded('openssl')) {
-                    throw new RuntimeException('Please install the OpenSSL extension');
+                    throw new MissingDependencyException('Please install the OpenSSL extension');
                 }
                 $result = openssl_sign($message, $signature, $key->toPEM(), $hash);
                 if (! $result) {
@@ -51,7 +53,7 @@ final readonly class RSA
                 return $signature;
 
             default:
-                throw new InvalidArgumentException('Unsupported mode.');
+                throw new UnsupportedAlgorithmException('Unsupported mode.');
         }
     }
 
@@ -80,11 +82,11 @@ final readonly class RSA
                 return self::verifyWithPSS($key, $message, $signature, $hash);
             case self::SIGNATURE_PKCS1:
                 if (! extension_loaded('openssl')) {
-                    throw new RuntimeException('Please install the OpenSSL extension');
+                    throw new MissingDependencyException('Please install the OpenSSL extension');
                 }
                 return openssl_verify($message, $signature, $key->toPEM(), $hash) === 1;
             default:
-                throw new InvalidArgumentException('Unsupported mode.');
+                throw new UnsupportedAlgorithmException('Unsupported mode.');
         }
     }
 

--- a/src/Library/Signature/JWS.php
+++ b/src/Library/Signature/JWS.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWT;
 use Override;
 use function count;

--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -6,6 +6,13 @@ namespace Jose\Component\Signature;
 
 use InvalidArgumentException;
 use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\InvalidPayloadException;
+use Jose\Component\Core\Exception\LogicException;
+use Jose\Component\Core\Exception\MissingPayloadRuntimeException;
+use Jose\Component\Core\Exception\RuntimeException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\InheritanceChecker;
@@ -13,9 +20,7 @@ use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
 use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
-use LogicException;
 use RangeException;
-use RuntimeException;
 use function array_key_exists;
 use function count;
 use function in_array;
@@ -122,14 +127,14 @@ class JWSBuilder implements JWSBuilderInterface
      * value is decoded and must be a canonical Base64Url string without padding, the only form this library produces
      * and accepts everywhere else.
      *
-     * @throws InvalidArgumentException if the payload is not a canonical Base64Url string without padding
+     * @throws InvalidPayloadException if the payload is not a canonical Base64Url string without padding
      */
     public function withEncodedPayload(string $payload, bool $isPayloadDetached = false): self
     {
         try {
             $decodedPayload = Base64UrlSafe::decodeNoPadding($payload);
         } catch (InvalidArgumentException|RangeException $throwable) {
-            throw new InvalidArgumentException(
+            throw new InvalidPayloadException(
                 'The payload must be a Base64Url encoded string without padding.',
                 0,
                 $throwable
@@ -171,14 +176,14 @@ class JWSBuilder implements JWSBuilderInterface
     public function build(): JWS
     {
         if ($this->payload === null) {
-            throw new RuntimeException('The payload is not set.');
+            throw new MissingPayloadRuntimeException('The payload is not set.');
         }
         if (count($this->signatures) === 0) {
             throw new RuntimeException('At least one signature must be set.');
         }
         $isPayloadEncoded = $this->getPayloadEncoding();
         if ($this->isPayloadAlreadyEncoded && $isPayloadEncoded === false) {
-            throw new InvalidArgumentException(
+            throw new InvalidPayloadException(
                 'An encoded payload cannot be used when the protected header parameter "b64" is set to false.'
             );
         }
@@ -188,7 +193,7 @@ class JWSBuilder implements JWSBuilderInterface
         );
 
         if ($isPayloadEncoded === false && $this->isPayloadDetached === false) {
-            mb_detect_encoding($this->payload, 'UTF-8', true) !== false || throw new InvalidArgumentException(
+            mb_detect_encoding($this->payload, 'UTF-8', true) !== false || throw new InvalidPayloadException(
                 'The payload must be encoded in UTF-8'
             );
         }
@@ -241,7 +246,7 @@ class JWSBuilder implements JWSBuilderInterface
     /**
      * Returns the payload encoding shared by all the signatures.
      *
-     * @throws InvalidArgumentException if the signatures do not agree on the encoding of the payload
+     * @throws InvalidPayloadException if the signatures do not agree on the encoding of the payload
      */
     private function getPayloadEncoding(): bool
     {
@@ -254,7 +259,7 @@ class JWSBuilder implements JWSBuilderInterface
                 continue;
             }
             if ($isPayloadEncoded !== $currentEncoding) {
-                throw new InvalidArgumentException('Foreign payload encoding detected.');
+                throw new InvalidPayloadException('Foreign payload encoding detected.');
             }
         }
 
@@ -296,16 +301,16 @@ class JWSBuilder implements JWSBuilderInterface
         $completeHeader = [...$header, ...$protectedHeader];
         $alg = $completeHeader['alg'] ?? null;
         if (! is_string($alg)) {
-            throw new InvalidArgumentException('No "alg" parameter set in the header.');
+            throw new InvalidHeaderParameterException('No "alg" parameter set in the header.');
         }
         $keyAlg = $key->has('alg') ? $key->get('alg') : null;
         if (is_string($keyAlg) && $keyAlg !== $alg) {
-            throw new InvalidArgumentException(sprintf('The algorithm "%s" is not allowed with this key.', $alg));
+            throw new InvalidKeyException(sprintf('The algorithm "%s" is not allowed with this key.', $alg));
         }
 
         $algorithm = $this->signatureAlgorithmManager->get($alg);
         if (! $algorithm instanceof SignatureAlgorithm && ! $algorithm instanceof MacAlgorithm) {
-            throw new InvalidArgumentException(sprintf('The algorithm "%s" is not supported.', $alg));
+            throw new UnsupportedAlgorithmException(sprintf('The algorithm "%s" is not supported.', $alg));
         }
 
         return $algorithm;
@@ -319,7 +324,7 @@ class JWSBuilder implements JWSBuilderInterface
     {
         $inter = array_intersect_key($header1, $header2);
         if (count($inter) !== 0) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidHeaderParameterException(sprintf(
                 'The header contains duplicated entries: %s.',
                 implode(', ', array_keys($inter))
             ));

--- a/src/Library/Signature/JWSLoader.php
+++ b/src/Library/Signature/JWSLoader.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature;
 
-use Exception;
 use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\Exception\InvalidTokenException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\InheritanceChecker;
@@ -92,7 +92,7 @@ class JWSLoader implements JWSLoaderInterface
             $lastError = $throwable;
         }
 
-        throw new Exception('Unable to load and verify the token.', 0, $lastError);
+        throw new InvalidTokenException('Unable to load and verify the token.', 0, $lastError);
     }
 
     private function processSignature(

--- a/src/Library/Signature/JWSTokenSupport.php
+++ b/src/Library/Signature/JWSTokenSupport.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature;
 
-use InvalidArgumentException;
 use Jose\Component\Checker\TokenTypeSupport;
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWT;
 use Override;
 

--- a/src/Library/Signature/JWSVerifier.php
+++ b/src/Library/Signature/JWSVerifier.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature;
 
-use InvalidArgumentException;
 use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Exception\InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
+use Jose\Component\Core\Exception\InvalidPayloadException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\Base64UrlSafe;
@@ -81,7 +85,7 @@ class JWSVerifier implements JWSVerifierInterface
             $onError = null;
         }
         if ($jwkset->count() === 0) {
-            throw new InvalidArgumentException('There is no key in the key set.');
+            throw new InvalidKeySetException('There is no key in the key set.');
         }
         if ($jws->countSignatures() === 0) {
             throw new InvalidArgumentException('The JWS does not contain any signature.');
@@ -154,10 +158,10 @@ class JWSVerifier implements JWSVerifierInterface
     {
         $isPayloadEmpty = $this->isPayloadEmpty($jws->getPayload());
         if ($detachedPayload !== null && ! $isPayloadEmpty) {
-            throw new InvalidArgumentException('A detached payload is set, but the JWS already has a payload.');
+            throw new InvalidPayloadException('A detached payload is set, but the JWS already has a payload.');
         }
         if ($isPayloadEmpty && $detachedPayload === null) {
-            throw new InvalidArgumentException('The JWS has a detached payload, but no payload is provided.');
+            throw new InvalidPayloadException('The JWS has a detached payload, but no payload is provided.');
         }
     }
 
@@ -168,13 +172,13 @@ class JWSVerifier implements JWSVerifierInterface
     {
         $protectedHeader = $signature->getProtectedHeader();
         if (! isset($protectedHeader['alg'])) {
-            throw new InvalidArgumentException('No "alg" parameter set in the protected header.');
+            throw new InvalidHeaderParameterException('No "alg" parameter set in the protected header.');
         }
         $alg = $protectedHeader['alg'];
 
         $algorithm = $this->signatureAlgorithmManager->get($alg);
         if (! $algorithm instanceof SignatureAlgorithm && ! $algorithm instanceof MacAlgorithm) {
-            throw new InvalidArgumentException(sprintf(
+            throw new UnsupportedAlgorithmException(sprintf(
                 'The algorithm "%s" is not supported or is not a signature or MAC algorithm.',
                 $alg
             ));

--- a/src/Library/Signature/Serializer/CompactSerializer.php
+++ b/src/Library/Signature/Serializer/CompactSerializer.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\LogicException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Signature\JWS;
-use LogicException;
 use Override;
 use Throwable;
 use function count;
@@ -69,14 +69,14 @@ final readonly class CompactSerializer extends Serializer
     {
         $parts = explode('.', $input, 4);
         if (count($parts) !== 3) {
-            throw new InvalidArgumentException('Unsupported input');
+            throw new InvalidSerializationException('Unsupported input');
         }
 
         try {
             $encodedProtectedHeader = $parts[0];
             $protectedHeader = JsonConverter::decode(Base64UrlSafe::decodeNoPadding($parts[0]));
             if (! is_array($protectedHeader)) {
-                throw new InvalidArgumentException('Bad protected header.');
+                throw new InvalidSerializationException('Bad protected header.');
             }
             $hasPayload = $parts[1] !== '';
             if (! $hasPayload) {
@@ -94,7 +94,7 @@ final readonly class CompactSerializer extends Serializer
 
             return $jws->addSignature($signature, $protectedHeader, $encodedProtectedHeader);
         } catch (Throwable $throwable) {
-            throw new InvalidArgumentException('Unsupported input', $throwable->getCode(), $throwable);
+            throw new InvalidSerializationException('Unsupported input', $throwable->getCode(), $throwable);
         }
     }
 }

--- a/src/Library/Signature/Serializer/JSONFlattenedSerializer.php
+++ b/src/Library/Signature/Serializer/JSONFlattenedSerializer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Signature\JWS;
@@ -59,10 +59,10 @@ final readonly class JSONFlattenedSerializer extends Serializer
     {
         $data = JsonConverter::decode($input);
         if (! is_array($data)) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
         if (! isset($data['signature'])) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
         $signature = Base64UrlSafe::decodeNoPadding($data['signature']);
 
@@ -70,7 +70,7 @@ final readonly class JSONFlattenedSerializer extends Serializer
             $encodedProtectedHeader = $data['protected'];
             $protectedHeader = JsonConverter::decode(Base64UrlSafe::decodeNoPadding($data['protected']));
             if (! is_array($protectedHeader)) {
-                throw new InvalidArgumentException('Bad protected header.');
+                throw new InvalidSerializationException('Bad protected header.');
             }
         } else {
             $encodedProtectedHeader = null;
@@ -78,7 +78,7 @@ final readonly class JSONFlattenedSerializer extends Serializer
         }
         if (isset($data['header'])) {
             if (! is_array($data['header'])) {
-                throw new InvalidArgumentException('Bad header.');
+                throw new InvalidSerializationException('Bad header.');
             }
             $header = $data['header'];
         } else {

--- a/src/Library/Signature/Serializer/JSONGeneralSerializer.php
+++ b/src/Library/Signature/Serializer/JSONGeneralSerializer.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidPayloadException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\LogicException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Signature\JWS;
-use LogicException;
 use Override;
 use function array_key_exists;
 use function count;
@@ -71,10 +72,10 @@ final readonly class JSONGeneralSerializer extends Serializer
     {
         $data = JsonConverter::decode($input);
         if (! is_array($data)) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
         if (! isset($data['signatures'])) {
-            throw new InvalidArgumentException('Unsupported input.');
+            throw new InvalidSerializationException('Unsupported input.');
         }
 
         $isPayloadEncoded = null;
@@ -82,7 +83,7 @@ final readonly class JSONGeneralSerializer extends Serializer
         $signatures = [];
         foreach ($data['signatures'] as $signature) {
             if (! isset($signature['signature'])) {
-                throw new InvalidArgumentException('Unsupported input.');
+                throw new InvalidSerializationException('Unsupported input.');
             }
             [$encodedProtectedHeader, $protectedHeader, $header] = $this->processHeaders($signature);
             $signatures[] = [
@@ -117,7 +118,7 @@ final readonly class JSONGeneralSerializer extends Serializer
             return $this->isPayloadEncoded($protectedHeader);
         }
         if ($this->isPayloadEncoded($protectedHeader) !== $isPayloadEncoded) {
-            throw new InvalidArgumentException('Foreign payload encoding detected.');
+            throw new InvalidPayloadException('Foreign payload encoding detected.');
         }
 
         return $isPayloadEncoded;

--- a/src/Library/Signature/Serializer/JWSSerializerManager.php
+++ b/src/Library/Signature/Serializer/JWSSerializerManager.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Jose\Component\Signature\Serializer;
 
 use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\UnsupportedSerializerException;
 use Jose\Component\Signature\JWS;
 use function sprintf;
 
@@ -39,7 +41,7 @@ final class JWSSerializerManager
     public function serialize(string $name, JWS $jws, ?int $signatureIndex = null): string
     {
         if (! isset($this->serializers[$name])) {
-            throw new InvalidArgumentException(sprintf('Unsupported serializer "%s".', $name));
+            throw new UnsupportedSerializerException(sprintf('Unsupported serializer "%s".', $name));
         }
 
         return $this->serializers[$name]->serialize($jws, $signatureIndex);
@@ -70,7 +72,7 @@ final class JWSSerializerManager
             }
         }
 
-        throw new InvalidArgumentException('Unsupported input.', 0, $lastError);
+        throw new InvalidSerializationException('Unsupported input.', 0, $lastError);
     }
 
     private function add(JWSSerializer $serializer): void

--- a/src/Library/Signature/Serializer/JWSSerializerManagerFactory.php
+++ b/src/Library/Signature/Serializer/JWSSerializerManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Serializer;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\UnsupportedSerializerException;
 use function sprintf;
 
 final class JWSSerializerManagerFactory
@@ -22,7 +22,7 @@ final class JWSSerializerManagerFactory
         $serializers = [];
         foreach ($names as $name) {
             if (! isset($this->serializers[$name])) {
-                throw new InvalidArgumentException(sprintf('Unsupported serializer "%s".', $name));
+                throw new UnsupportedSerializerException(sprintf('Unsupported serializer "%s".', $name));
             }
             $serializers[] = $this->serializers[$name];
         }

--- a/src/Library/Signature/Signature.php
+++ b/src/Library/Signature/Signature.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature;
 
-use InvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use function array_key_exists;
 use function sprintf;
 
@@ -72,7 +72,7 @@ class Signature
             return $this->getProtectedHeader()[$key];
         }
 
-        throw new InvalidArgumentException(sprintf('The protected header "%s" does not exist', $key));
+        throw new InvalidHeaderParameterException(sprintf('The protected header "%s" does not exist', $key));
     }
 
     /**
@@ -98,7 +98,7 @@ class Signature
             return $this->header[$key];
         }
 
-        throw new InvalidArgumentException(sprintf('The header "%s" does not exist', $key));
+        throw new InvalidHeaderParameterException(sprintf('The header "%s" does not exist', $key));
     }
 
     /**

--- a/tests/Component/Core/JoseExceptionTest.php
+++ b/tests/Component/Core/JoseExceptionTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Core;
+
+use InvalidArgumentException;
+use Jose\Component\Checker\AlgorithmChecker;
+use Jose\Component\Checker\InvalidHeaderException;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Exception\DecryptionFailedException;
+use Jose\Component\Core\Exception\EncryptionFailedException;
+use Jose\Component\Core\Exception\InvalidArgumentException as JoseInvalidArgumentException;
+use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\Exception\InvalidKeySetException;
+use Jose\Component\Core\Exception\InvalidPayloadException;
+use Jose\Component\Core\Exception\InvalidSerializationException;
+use Jose\Component\Core\Exception\InvalidTokenException;
+use Jose\Component\Core\Exception\JoseException;
+use Jose\Component\Core\Exception\LogicException as JoseLogicException;
+use Jose\Component\Core\Exception\MissingDependencyException;
+use Jose\Component\Core\Exception\MissingPayloadException;
+use Jose\Component\Core\Exception\MissingPayloadLogicException;
+use Jose\Component\Core\Exception\MissingPayloadRuntimeException;
+use Jose\Component\Core\Exception\RangeException as JoseRangeException;
+use Jose\Component\Core\Exception\RuntimeException as JoseRuntimeException;
+use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
+use Jose\Component\Core\Exception\UnsupportedCurveException;
+use Jose\Component\Core\Exception\UnsupportedSerializerException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RangeException;
+use ReflectionClass;
+use RuntimeException;
+use Throwable;
+use function count;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final class JoseExceptionTest extends TestCase
+{
+    /**
+     * The SPL parent of each exception is the class that was thrown before version 4.3.0.
+     *
+     * @var array<class-string, class-string>
+     */
+    private const SPL_PARENTS = [
+        DecryptionFailedException::class => RuntimeException::class,
+        EncryptionFailedException::class => RuntimeException::class,
+        JoseInvalidArgumentException::class => InvalidArgumentException::class,
+        InvalidHeaderParameterException::class => InvalidArgumentException::class,
+        InvalidKeyException::class => InvalidArgumentException::class,
+        InvalidKeySetException::class => InvalidArgumentException::class,
+        InvalidPayloadException::class => InvalidArgumentException::class,
+        InvalidSerializationException::class => InvalidArgumentException::class,
+        InvalidTokenException::class => RuntimeException::class,
+        JoseLogicException::class => LogicException::class,
+        MissingDependencyException::class => RuntimeException::class,
+        MissingPayloadLogicException::class => LogicException::class,
+        MissingPayloadRuntimeException::class => RuntimeException::class,
+        JoseRangeException::class => RangeException::class,
+        JoseRuntimeException::class => RuntimeException::class,
+        UnsupportedAlgorithmException::class => InvalidArgumentException::class,
+        UnsupportedCurveException::class => InvalidArgumentException::class,
+        UnsupportedSerializerException::class => InvalidArgumentException::class,
+    ];
+
+    #[Test]
+    public function everyExceptionOfTheLibraryImplementsTheMarkerInterface(): void
+    {
+        $classes = self::exceptionClasses();
+        static::assertGreaterThan(0, count($classes));
+        foreach ($classes as $class) {
+            static::assertTrue(
+                is_a($class, JoseException::class, true),
+                sprintf('%s does not implement %s.', $class, JoseException::class)
+            );
+        }
+    }
+
+    /**
+     * The SPL parent of each exception is the class that was thrown before version 4.3.0. Changing it would
+     * silently break the catch blocks written for the previous versions.
+     */
+    #[Test]
+    #[DataProvider('splParents')]
+    public function theExceptionsKeepTheSplParentThrownByThePreviousVersions(string $class, string $parent): void
+    {
+        static::assertTrue(is_a($class, $parent, true), sprintf('%s does not extend %s.', $class, $parent));
+    }
+
+    #[Test]
+    public function anUnsupportedAlgorithmIsReported(): void
+    {
+        $manager = new AlgorithmManager([]);
+
+        $throwable = self::capture(static fn () => $manager->get('HS256'));
+
+        static::assertInstanceOf(UnsupportedAlgorithmException::class, $throwable);
+        static::assertInstanceOf(InvalidArgumentException::class, $throwable);
+    }
+
+    #[Test]
+    public function anInvalidKeyIsReported(): void
+    {
+        $throwable = self::capture(static fn () => new JWK([
+            'foo' => 'bar',
+        ]));
+
+        static::assertInstanceOf(InvalidKeyException::class, $throwable);
+        static::assertInstanceOf(InvalidArgumentException::class, $throwable);
+    }
+
+    #[Test]
+    public function anInvalidKeySetIsReported(): void
+    {
+        $throwable = self::capture(static fn () => JWKSet::createFromKeyData([]));
+
+        static::assertInstanceOf(InvalidKeySetException::class, $throwable);
+        static::assertInstanceOf(InvalidArgumentException::class, $throwable);
+    }
+
+    #[Test]
+    public function aMalformedBase64UrlStringIsReported(): void
+    {
+        $throwable = self::capture(static fn () => Base64UrlSafe::decode('a', true));
+
+        static::assertInstanceOf(JoseException::class, $throwable);
+        static::assertInstanceOf(RangeException::class, $throwable);
+    }
+
+    /**
+     * The JWS and the JWE builders report the missing payload with the same interface, even though they kept
+     * the two distinct SPL parents they used before version 4.3.0.
+     */
+    #[Test]
+    public function aMissingPayloadIsReportedTheSameWayByBothBuilders(): void
+    {
+        $fromJws = self::capture(static fn () => (new JWSBuilder(new AlgorithmManager([])))->build());
+        $fromJwe = self::capture(static fn () => (new JWEBuilder(new AlgorithmManager([])))->build());
+
+        static::assertInstanceOf(MissingPayloadException::class, $fromJws);
+        static::assertInstanceOf(MissingPayloadException::class, $fromJwe);
+
+        static::assertInstanceOf(MissingPayloadRuntimeException::class, $fromJws);
+        static::assertInstanceOf(RuntimeException::class, $fromJws);
+        static::assertInstanceOf(MissingPayloadLogicException::class, $fromJwe);
+        static::assertInstanceOf(LogicException::class, $fromJwe);
+    }
+
+    #[Test]
+    public function anUnsupportedSerializationIsReportedWithItsCause(): void
+    {
+        $manager = new JWSSerializerManager([new CompactSerializer()]);
+
+        $throwable = self::capture(static fn () => $manager->unserialize('Hello world!'));
+
+        static::assertInstanceOf(InvalidSerializationException::class, $throwable);
+        static::assertInstanceOf(JoseException::class, $throwable->getPrevious());
+    }
+
+    #[Test]
+    public function theHeaderCheckerFailuresBelongToTheHierarchy(): void
+    {
+        $checker = new AlgorithmChecker(['HS256']);
+
+        $throwable = self::capture(static fn () => $checker->checkHeader('none'));
+
+        static::assertInstanceOf(InvalidHeaderException::class, $throwable);
+        static::assertInstanceOf(JoseException::class, $throwable);
+    }
+
+    /**
+     * @return iterable<array{0: class-string, 1: class-string}>
+     */
+    public static function splParents(): iterable
+    {
+        foreach (self::SPL_PARENTS as $class => $parent) {
+            yield $class => [$class, $parent];
+        }
+    }
+
+    #[Test]
+    public function theSplParentOfEveryExceptionIsUnderContract(): void
+    {
+        $concrete = array_filter(
+            self::exceptionClasses(),
+            static fn (string $class): bool => ! (new ReflectionClass($class))->isInterface()
+        );
+
+        static::assertSame([], array_diff($concrete, array_keys(self::SPL_PARENTS)));
+    }
+
+    /**
+     * @return array<class-string>
+     */
+    private static function exceptionClasses(): array
+    {
+        $classes = [];
+        foreach (glob(__DIR__ . '/../../../src/Library/Core/Exception/*.php') ?: [] as $file) {
+            $class = 'Jose\Component\Core\Exception\\' . basename($file, '.php');
+            if ($class !== JoseException::class) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+
+    private static function capture(callable $callable): Throwable
+    {
+        try {
+            $callable();
+        } catch (Throwable $throwable) {
+            return $throwable;
+        }
+
+        static::fail('No exception thrown.');
+    }
+}


### PR DESCRIPTION
Target branch: 4.3.x
Resolves issue # #686

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [ ] Deprecations

The library had no exception hierarchy of its own: depending on the code path it threw
`InvalidArgumentException`, `RuntimeException`, `LogicException`, `RangeException` or even a bare
`\Exception`, so a user had to catch `\Throwable` and read the message.

Every exception thrown by `src/Library` and `src/Experimental` now implements
`Jose\Component\Core\Exception\JoseException`:

```php
try {
    $jws = $jwsLoader->loadAndVerifyWithKeySet($token, $jwkset, $signature);
} catch (JoseException $e) {
    // one catch for the whole library, with the real cause in $e->getPrevious()
}
```

### No BC break

Each new exception extends the SPL class that was thrown at that place until now, so every existing
`catch` keeps matching. A test asserts that contract class by class, and fails as soon as a new
exception is added to the namespace without declaring its SPL parent there.

### The classes

`Jose\Component\Core\Exception` holds four base classes mirroring the SPL ones
(`InvalidArgumentException`, `LogicException`, `RuntimeException`, `RangeException`) and the named
exceptions used for the failures that a caller usually wants to tell apart:

| Exception | SPL parent | Reported failure |
| --- | --- | --- |
| `UnsupportedAlgorithmException` | `InvalidArgumentException` | unknown or unregistered algorithm |
| `UnsupportedCurveException` | `InvalidArgumentException` | unknown or unsupported curve |
| `UnsupportedSerializerException` | `InvalidArgumentException` | unknown serializer name |
| `InvalidKeyException` | `InvalidArgumentException` | unusable, malformed or missing key |
| `InvalidKeySetException` | `InvalidArgumentException` | unusable or malformed key set |
| `InvalidHeaderParameterException` | `InvalidArgumentException` | missing or invalid JOSE header parameter |
| `InvalidPayloadException` | `InvalidArgumentException` | payload not encoded as expected or inconsistent with the header |
| `InvalidSerializationException` | `InvalidArgumentException` | input is not the expected serialization |
| `InvalidTokenException` | `RuntimeException` | token cannot be loaded, verified or decrypted |
| `MissingDependencyException` | `RuntimeException` | required extension or Composer package not installed |
| `EncryptionFailedException` / `DecryptionFailedException` | `RuntimeException` | content or CEK operation failed |
| `MissingPayloadLogicException` / `MissingPayloadRuntimeException` | `LogicException` / `RuntimeException` | no payload set on a builder |

`Jose\Component\Checker\ClaimExceptionInterface` now extends `JoseException`, and
`InvalidHeaderException` and `MissingMandatoryHeaderParameterException` implement it, so the checker
failures belong to the hierarchy too.

### The inconsistencies listed in the issue

- *token cannot be loaded*: `JWSLoader` threw a bare `\Exception` and `JWELoader` a
  `RuntimeException`. Both now throw `InvalidTokenException`, which extends `RuntimeException` and is
  therefore still caught by the two previous types.
- *payload not set*: `JWSBuilder` threw a `RuntimeException` and `JWEBuilder` a `LogicException`.
  Those two SPL parents cannot be merged in 4.3 without breaking one of the two catch blocks, so the
  common type is the `MissingPayloadException` **interface**, implemented by the two classes that keep
  their respective parent. `catch (MissingPayloadException $e)` handles both builders today, and the
  two classes can be merged into one in 5.0.0.

`JWEBuilder` still reports a wrong key with a `RuntimeException` where the rest of the library uses an
`InvalidArgumentException`; aligning it is a 5.0.0 change for the same reason.

### QA

ECS, Rector, PHPStan (level max) and deptrac are green, and the 918 tests pass.
