### PR TITLE
feat(core): return result objects instead of by-reference output parameters

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -3823,48 +3823,6 @@ parameters:
 			path: ../src/Bundle/Services/ClaimCheckerManagerFactory.php
 
 		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypterInterface::decryptUsingKeySet() invoked with 6 parameters, 3-5 required.'
-			identifier: arguments.count
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingJWEDecrypter.php
-
-		-
-			rawMessage: 'Parameter #3 $JWK of class Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingJWEDecrypter.php
-
-		-
-			rawMessage: 'Parameter #4 $recipient of class Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent constructor expects int, int|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingJWELoader.php
-
-		-
-			rawMessage: 'Parameter #4 $signature of class Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent constructor expects int, int|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingJWSLoader.php
-
-		-
-			rawMessage: 'Method Jose\Component\Signature\JWSVerifierInterface::verifyWithKeySet() invoked with 6 parameters, 3-5 required.'
-			identifier: arguments.count
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingJWSVerifier.php
-
-		-
-			rawMessage: 'Parameter #5 $JWK of class Jose\Bundle\JoseFramework\Event\JWSVerificationSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingJWSVerifier.php
-
-		-
-			rawMessage: 'Parameter #5 $signature of class Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent constructor expects int, int|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/EventDispatchingNestedTokenLoader.php
-
-		-
 			rawMessage: Class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager extends @final class Jose\Component\Checker\HeaderCheckerManager.
 			identifier: class.extendsFinalByPhpDoc
 			count: 1
@@ -3943,12 +3901,6 @@ parameters:
 			path: ../src/Bundle/Services/JWEDecrypter.php
 
 		-
-			rawMessage: 'Parameter #3 $JWK of class Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/JWEDecrypter.php
-
-		-
 			rawMessage: '''
 				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWEDecrypter:
 				since 4.3.0, use EventDispatchingJWEDecrypter instead. The class extends a service of
@@ -3993,12 +3945,6 @@ parameters:
 		-
 			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWELoader extends @final class Jose\Component\Encryption\JWELoader.
 			identifier: class.extendsFinalByPhpDoc
-			count: 1
-			path: ../src/Bundle/Services/JWELoader.php
-
-		-
-			rawMessage: 'Parameter #4 $recipient of class Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent constructor expects int, int|null given.'
-			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWELoader.php
 
@@ -4075,12 +4021,6 @@ parameters:
 			path: ../src/Bundle/Services/JWSLoader.php
 
 		-
-			rawMessage: 'Parameter #4 $signature of class Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent constructor expects int, int|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Bundle/Services/JWSLoader.php
-
-		-
 			rawMessage: '''
 				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWSLoader:
 				since 4.3.0, use EventDispatchingJWSLoader instead. The class extends a service of
@@ -4143,12 +4083,6 @@ parameters:
 		-
 			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWSVerifier extends @final class Jose\Component\Signature\JWSVerifier.
 			identifier: class.extendsFinalByPhpDoc
-			count: 1
-			path: ../src/Bundle/Services/JWSVerifier.php
-
-		-
-			rawMessage: 'Parameter #5 $JWK of class Jose\Bundle\JoseFramework\Event\JWSVerificationSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
-			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWSVerifier.php
 
@@ -4281,12 +4215,6 @@ parameters:
 		-
 			rawMessage: Class Jose\Bundle\JoseFramework\Services\NestedTokenLoader extends @final class Jose\Component\NestedToken\NestedTokenLoader.
 			identifier: class.extendsFinalByPhpDoc
-			count: 1
-			path: ../src/Bundle/Services/NestedTokenLoader.php
-
-		-
-			rawMessage: 'Parameter #5 $signature of class Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent constructor expects int, int|null given.'
-			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/NestedTokenLoader.php
 
@@ -4910,18 +4838,6 @@ parameters:
 			path: ../src/Library/Encryption/JWEDecrypter.php
 
 		-
-			rawMessage: 'Parameter #1 $key of static method Jose\Component\Core\Util\KeyChecker::checkKeyAlgorithm() expects Jose\Component\Core\JWK, mixed given.'
-			identifier: argument.type
-			count: 2
-			path: ../src/Library/Encryption/JWEDecrypter.php
-
-		-
-			rawMessage: 'Parameter #1 $key of static method Jose\Component\Core\Util\KeyChecker::checkKeyUsage() expects Jose\Component\Core\JWK, mixed given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Encryption/JWEDecrypter.php
-
-		-
 			rawMessage: 'Parameter #3 $completeHeader of method Jose\Component\Encryption\Algorithm\KeyEncryption\KeyWrapping::unwrapKey() expects array<string, mixed>, array given.'
 			identifier: argument.type
 			count: 1
@@ -4929,12 +4845,6 @@ parameters:
 
 		-
 			rawMessage: 'Parameter #3 $header of method Jose\Component\Encryption\Algorithm\KeyEncryption\KeyEncryption::decryptKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Encryption/JWEDecrypter.php
-
-		-
-			rawMessage: 'Parameter #3 $recipientKey of method Jose\Component\Encryption\JWEDecrypter::decryptCEK() expects Jose\Component\Core\JWK, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Encryption/JWEDecrypter.php
@@ -4950,18 +4860,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/Encryption/JWEDecrypter.php
-
-		-
-			rawMessage: 'Parameter &$successJwk by-ref type of method Jose\Component\Encryption\JWEDecrypter::decryptRecipientKey() expects Jose\Component\Core\JWK|null, mixed given.'
-			identifier: parameterByRef.type
-			count: 1
-			path: ../src/Library/Encryption/JWEDecrypter.php
-
-		-
-			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypterInterface::decryptUsingKeySet() invoked with 6 parameters, 3-5 required.'
-			identifier: arguments.count
-			count: 1
-			path: ../src/Library/Encryption/JWELoader.php
 
 		-
 			rawMessage: 'Method Jose\Component\Encryption\JWELoaderFactory::create() has parameter $encryptionAlgorithms with no value type specified in iterable type array.'
@@ -5366,12 +5264,6 @@ parameters:
 			path: ../src/Library/KeyManagement/KeyConverter/RSAKey.php
 
 		-
-			rawMessage: 'Parameter #2 $recipient of method Jose\Component\NestedToken\NestedTokenLoader::checkContentTypeHeader() expects int, int|null given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/NestedToken/NestedTokenLoader.php
-
-		-
 			rawMessage: 'Parameter #1 $signature of static method Jose\Component\Core\Util\ECSignature::fromAsn1() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
@@ -5400,12 +5292,6 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: ../src/Library/Signature/Algorithm/Util/RSA.php
-
-		-
-			rawMessage: 'Method Jose\Component\Signature\JWSVerifierInterface::verifyWithKeySet() invoked with 6 parameters, 3-5 required.'
-			identifier: arguments.count
-			count: 1
-			path: ../src/Library/Signature/JWSLoader.php
 
 		-
 			rawMessage: 'Parameter #1 $algorithm of method Jose\Component\Core\AlgorithmManager::get() expects string, mixed given.'

--- a/src/Bundle/Services/EventDispatchingJWEDecrypter.php
+++ b/src/Bundle/Services/EventDispatchingJWEDecrypter.php
@@ -9,12 +9,16 @@ use Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\DecryptionResult;
 use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWEDecrypterInterface;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Throwable;
 use function func_get_arg;
 use function func_num_args;
+use function is_callable;
+use function trigger_deprecation;
 
 /**
  * Dispatches an event whenever a recipient is decrypted, without extending the decrypter it decorates.
@@ -39,9 +43,47 @@ final readonly class EventDispatchingJWEDecrypter implements JWEDecrypterInterfa
         return $this->decrypter->getContentEncryptionAlgorithmManager();
     }
 
+    /**
+     * A JWE that already has a payload is reported as decrypted without any key being used. There is nothing to
+     * report in that case, hence no event at all.
+     *
+     * @param (callable(Throwable): void)|null $onError
+     */
     #[Override]
+    public function decrypt(
+        JWE $jwe,
+        JWK|JWKSet $keys,
+        int $recipientIndex,
+        ?JWK $senderKey = null,
+        ?callable $onError = null
+    ): DecryptionResult {
+        $result = $this->decrypter->decrypt($jwe, $keys, $recipientIndex, $senderKey, $onError);
+        $jwkset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
+        $jwk = $result->getKey();
+        if ($jwk !== null) {
+            $this->eventDispatcher->dispatch(
+                new JWEDecryptionSuccessEvent($result->getJwe(), $jwkset, $jwk, $recipientIndex)
+            );
+        } elseif (! $result->isDecrypted()) {
+            $this->eventDispatcher->dispatch(new JWEDecryptionFailureEvent($jwe, $jwkset));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @deprecated since 4.3.0, use "decrypt()" instead. Will be removed in 5.0.0.
+     */
     public function decryptUsingKey(JWE &$jwe, JWK $jwk, int $recipient, ?JWK $senderKey = null): bool
     {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::decryptUsingKey()" is deprecated and will be removed in 5.0.0. Please use "%s::decrypt()" instead: it returns a "%s" object that carries the decrypted JWE instead of replacing the variable of the caller.',
+            self::class,
+            self::class,
+            DecryptionResult::class
+        );
         $jwkset = new JWKSet([$jwk]);
         $successJwk = null;
 
@@ -49,11 +91,14 @@ final readonly class EventDispatchingJWEDecrypter implements JWEDecrypterInterfa
     }
 
     /**
-     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet: it is
-     * read with func_num_args()/func_get_arg(5) and forwarded to the decorated decrypter, otherwise the reason of a
-     * failure would be lost as soon as the decrypter is decorated.
+     * The callable used by the loaders to observe the keys that were discarded is not part of the signature: it is
+     * read with func_num_args()/func_get_arg(5) and forwarded to "decrypt()", otherwise the reason of a failure would
+     * be lost as soon as the decrypter is decorated.
+     *
+     * @param-out JWK|null $jwk
+     *
+     * @deprecated since 4.3.0, use "decrypt()" instead. Will be removed in 5.0.0.
      */
-    #[Override]
     public function decryptUsingKeySet(
         JWE &$jwe,
         JWKSet $jwkset,
@@ -61,21 +106,28 @@ final readonly class EventDispatchingJWEDecrypter implements JWEDecrypterInterfa
         ?JWK &$jwk = null,
         ?JWK $senderKey = null
     ): bool {
-        $success = func_num_args() >= 6 ? $this->decrypter->decryptUsingKeySet(
-            $jwe,
-            $jwkset,
-            $recipient,
-            $jwk,
-            $senderKey,
-            func_get_arg(5)
-        ) : $this->decrypter->decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);
-
-        if ($success) {
-            $this->eventDispatcher->dispatch(new JWEDecryptionSuccessEvent($jwe, $jwkset, $jwk, $recipient));
-        } else {
-            $this->eventDispatcher->dispatch(new JWEDecryptionFailureEvent($jwe, $jwkset));
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::decryptUsingKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::decrypt()" instead: it returns a "%s" object that carries the decrypted JWE and the key instead of replacing the variables of the caller.',
+            self::class,
+            self::class,
+            DecryptionResult::class
+        );
+        $onError = func_num_args() >= 6 ? func_get_arg(5) : null;
+        if (! is_callable($onError)) {
+            $onError = null;
+        }
+        $result = $this->decrypt($jwe, $jwkset, $recipient, $senderKey, $onError);
+        if (! $result->isDecrypted()) {
+            return false;
+        }
+        $jwe = $result->getJwe();
+        $successJwk = $result->getKey();
+        if ($successJwk !== null) {
+            $jwk = $successJwk;
         }
 
-        return $success;
+        return true;
     }
 }

--- a/src/Bundle/Services/EventDispatchingJWELoader.php
+++ b/src/Bundle/Services/EventDispatchingJWELoader.php
@@ -12,10 +12,12 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWEDecrypterInterface;
 use Jose\Component\Encryption\JWELoaderInterface;
+use Jose\Component\Encryption\LoadingResult;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
+use function trigger_deprecation;
 
 /**
  * Dispatches an event whenever a JWE is loaded, without extending the loader it decorates.
@@ -47,25 +49,61 @@ final readonly class EventDispatchingJWELoader implements JWELoaderInterface
     }
 
     #[Override]
-    public function loadAndDecryptWithKey(string $token, JWK $key, ?int &$recipient): JWE
+    public function loadAndDecrypt(string $token, JWK|JWKSet $keys): LoadingResult
     {
-        $keyset = new JWKSet([$key]);
-
-        return $this->loadAndDecryptWithKeySet($token, $keyset, $recipient);
-    }
-
-    #[Override]
-    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
-    {
+        $keyset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
         try {
-            $jwe = $this->loader->loadAndDecryptWithKeySet($token, $keyset, $recipient);
-            $this->eventDispatcher->dispatch(new JWELoadingSuccessEvent($token, $jwe, $keyset, $recipient));
+            $result = $this->loader->loadAndDecrypt($token, $keys);
+            $this->eventDispatcher->dispatch(
+                new JWELoadingSuccessEvent($token, $result->getJwe(), $keyset, $result->getRecipientIndex())
+            );
 
-            return $jwe;
+            return $result;
         } catch (Throwable $throwable) {
             $this->eventDispatcher->dispatch(new JWELoadingFailureEvent($token, $keyset, $throwable));
 
             throw $throwable;
         }
+    }
+
+    /**
+     * @param-out int $recipient
+     *
+     * @deprecated since 4.3.0, use "loadAndDecrypt()" instead. Will be removed in 5.0.0.
+     */
+    public function loadAndDecryptWithKey(string $token, JWK $key, ?int &$recipient): JWE
+    {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndDecryptWithKey()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndDecrypt()" instead: it returns a "%s" object that carries the index of the decrypted recipient instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
+        $keyset = new JWKSet([$key]);
+
+        return $this->loadAndDecryptWithKeySet($token, $keyset, $recipient);
+    }
+
+    /**
+     * @param-out int $recipient
+     *
+     * @deprecated since 4.3.0, use "loadAndDecrypt()" instead. Will be removed in 5.0.0.
+     */
+    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
+    {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndDecryptWithKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndDecrypt()" instead: it returns a "%s" object that carries the index of the decrypted recipient instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
+        $result = $this->loadAndDecrypt($token, $keyset);
+        $recipient = $result->getRecipientIndex();
+
+        return $result->getJwe();
     }
 }

--- a/src/Bundle/Services/EventDispatchingJWSLoader.php
+++ b/src/Bundle/Services/EventDispatchingJWSLoader.php
@@ -12,10 +12,12 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSLoaderInterface;
 use Jose\Component\Signature\JWSVerifierInterface;
+use Jose\Component\Signature\LoadingResult;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
+use function trigger_deprecation;
 
 /**
  * Dispatches an event whenever a JWS is loaded, without extending the loader it decorates.
@@ -47,29 +49,65 @@ final readonly class EventDispatchingJWSLoader implements JWSLoaderInterface
     }
 
     #[Override]
+    public function loadAndVerify(string $token, JWK|JWKSet $keys, ?string $payload = null): LoadingResult
+    {
+        $keyset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
+        try {
+            $result = $this->loader->loadAndVerify($token, $keys, $payload);
+            $this->eventDispatcher->dispatch(
+                new JWSLoadingSuccessEvent($token, $result->getJws(), $keyset, $result->getSignatureIndex())
+            );
+
+            return $result;
+        } catch (Throwable $throwable) {
+            $this->eventDispatcher->dispatch(new JWSLoadingFailureEvent($token, $keyset, $throwable));
+
+            throw $throwable;
+        }
+    }
+
+    /**
+     * @param-out int $signature
+     *
+     * @deprecated since 4.3.0, use "loadAndVerify()" instead. Will be removed in 5.0.0.
+     */
     public function loadAndVerifyWithKey(string $token, JWK $key, ?int &$signature, ?string $payload = null): JWS
     {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndVerifyWithKey()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndVerify()" instead: it returns a "%s" object that carries the index of the verified signature instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
         $keyset = new JWKSet([$key]);
 
         return $this->loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
     }
 
-    #[Override]
+    /**
+     * @param-out int $signature
+     *
+     * @deprecated since 4.3.0, use "loadAndVerify()" instead. Will be removed in 5.0.0.
+     */
     public function loadAndVerifyWithKeySet(
         string $token,
         JWKSet $keyset,
         ?int &$signature,
         ?string $payload = null
     ): JWS {
-        try {
-            $jws = $this->loader->loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
-            $this->eventDispatcher->dispatch(new JWSLoadingSuccessEvent($token, $jws, $keyset, $signature));
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndVerifyWithKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndVerify()" instead: it returns a "%s" object that carries the index of the verified signature instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
+        $result = $this->loadAndVerify($token, $keyset, $payload);
+        $signature = $result->getSignatureIndex();
 
-            return $jws;
-        } catch (Throwable $throwable) {
-            $this->eventDispatcher->dispatch(new JWSLoadingFailureEvent($token, $keyset, $throwable));
-
-            throw $throwable;
-        }
+        return $result->getJws();
     }
 }

--- a/src/Bundle/Services/EventDispatchingJWSVerifier.php
+++ b/src/Bundle/Services/EventDispatchingJWSVerifier.php
@@ -11,10 +11,14 @@ use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSVerifierInterface;
+use Jose\Component\Signature\VerificationResult;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Throwable;
 use function func_get_arg;
 use function func_num_args;
+use function is_callable;
+use function trigger_deprecation;
 
 /**
  * Dispatches an event whenever a signature is verified, without extending the verifier it decorates.
@@ -33,20 +37,47 @@ final readonly class EventDispatchingJWSVerifier implements JWSVerifierInterface
         return $this->verifier->getSignatureAlgorithmManager();
     }
 
+    /**
+     * @param (callable(Throwable): void)|null $onError
+     */
+    #[Override]
+    public function verify(
+        JWS $jws,
+        JWK|JWKSet $keys,
+        int $signatureIndex,
+        ?string $detachedPayload = null,
+        ?callable $onError = null
+    ): VerificationResult {
+        $result = $this->verifier->verify($jws, $keys, $signatureIndex, $detachedPayload, $onError);
+        $jwkset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
+        $jwk = $result->getKey();
+        if ($jwk !== null) {
+            $this->eventDispatcher->dispatch(
+                new JWSVerificationSuccessEvent($jws, $jwkset, $signatureIndex, $detachedPayload, $jwk)
+            );
+        } else {
+            $this->eventDispatcher->dispatch(new JWSVerificationFailureEvent($jws, $jwkset, $detachedPayload));
+        }
+
+        return $result;
+    }
+
     #[Override]
     public function verifyWithKey(JWS $jws, JWK $jwk, int $signature, ?string $detachedPayload = null): bool
     {
-        $jwkset = new JWKSet([$jwk]);
-
-        return $this->verifyWithKeySet($jws, $jwkset, $signature, $detachedPayload);
+        return $this->verify($jws, $jwk, $signature, $detachedPayload)
+            ->isVerified();
     }
 
     /**
-     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet: it is
-     * read with func_num_args()/func_get_arg(5) and forwarded to the decorated verifier, otherwise the reason of a
-     * failure would be lost as soon as the verifier is decorated.
+     * The callable used by the loaders to observe the keys that were discarded is not part of the signature: it is
+     * read with func_num_args()/func_get_arg(5) and forwarded to "verify()", otherwise the reason of a failure would
+     * be lost as soon as the verifier is decorated.
+     *
+     * @param-out JWK|null $jwk
+     *
+     * @deprecated since 4.3.0, use "verify()" instead. Will be removed in 5.0.0.
      */
-    #[Override]
     public function verifyWithKeySet(
         JWS $jws,
         JWKSet $jwkset,
@@ -54,27 +85,23 @@ final readonly class EventDispatchingJWSVerifier implements JWSVerifierInterface
         ?string $detachedPayload = null,
         ?JWK &$jwk = null
     ): bool {
-        $success = func_num_args() >= 6 ? $this->verifier->verifyWithKeySet(
-            $jws,
-            $jwkset,
-            $signatureIndex,
-            $detachedPayload,
-            $jwk,
-            func_get_arg(5)
-        ) : $this->verifier->verifyWithKeySet($jws, $jwkset, $signatureIndex, $detachedPayload, $jwk);
-
-        if ($success) {
-            $this->eventDispatcher->dispatch(new JWSVerificationSuccessEvent(
-                $jws,
-                $jwkset,
-                $signatureIndex,
-                $detachedPayload,
-                $jwk
-            ));
-        } else {
-            $this->eventDispatcher->dispatch(new JWSVerificationFailureEvent($jws, $jwkset, $detachedPayload));
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::verifyWithKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::verify()" instead: it returns a "%s" object that carries the key instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            VerificationResult::class
+        );
+        $onError = func_num_args() >= 6 ? func_get_arg(5) : null;
+        if (! is_callable($onError)) {
+            $onError = null;
+        }
+        $result = $this->verify($jws, $jwkset, $signatureIndex, $detachedPayload, $onError);
+        if ($result->isVerified()) {
+            $jwk = $result->getKey();
         }
 
-        return $success;
+        return $result->isVerified();
     }
 }

--- a/src/Bundle/Services/EventDispatchingNestedTokenLoader.php
+++ b/src/Bundle/Services/EventDispatchingNestedTokenLoader.php
@@ -9,9 +9,12 @@ use Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\NestedToken\NestedTokenLoaderInterface;
 use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\LoadingResult;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
+use function func_num_args;
+use function trigger_deprecation;
 
 /**
  * Dispatches an event whenever a nested token is loaded, without extending the loader it decorates.
@@ -25,19 +28,19 @@ final readonly class EventDispatchingNestedTokenLoader implements NestedTokenLoa
     }
 
     #[Override]
-    public function load(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet, ?int &$signature = null): JWS
+    public function loadAndVerify(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet): LoadingResult
     {
         try {
-            $jws = $this->loader->load($token, $encryptionKeySet, $signatureKeySet, $signature);
+            $result = $this->loader->loadAndVerify($token, $encryptionKeySet, $signatureKeySet);
             $this->eventDispatcher->dispatch(new NestedTokenLoadingSuccessEvent(
                 $token,
-                $jws,
+                $result->getJws(),
                 $signatureKeySet,
                 $encryptionKeySet,
-                $signature
+                $result->getSignatureIndex()
             ));
 
-            return $jws;
+            return $result;
         } catch (Throwable $throwable) {
             $this->eventDispatcher->dispatch(new NestedTokenLoadingFailureEvent(
                 $token,
@@ -48,5 +51,27 @@ final readonly class EventDispatchingNestedTokenLoader implements NestedTokenLoa
 
             throw $throwable;
         }
+    }
+
+    /**
+     * @param-out int $signature
+     */
+    #[Override]
+    public function load(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet, ?int &$signature = null): JWS
+    {
+        if (func_num_args() >= 4) {
+            trigger_deprecation(
+                'web-token/jwt-framework',
+                '4.3.0',
+                'Passing the "$signature" argument to "%s::load()" is deprecated and the argument will be removed in 5.0.0. Please use "%s::loadAndVerify()" instead: it returns a "%s" object that carries the index of the verified signature instead of writing it into a variable of the caller.',
+                self::class,
+                self::class,
+                LoadingResult::class
+            );
+        }
+        $result = $this->loadAndVerify($token, $encryptionKeySet, $signatureKeySet);
+        $signature = $result->getSignatureIndex();
+
+        return $result->getJws();
     }
 }

--- a/src/Bundle/Services/JWEDecrypter.php
+++ b/src/Bundle/Services/JWEDecrypter.php
@@ -9,12 +9,12 @@ use Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\DecryptionResult;
 use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWEDecrypter as BaseJWEDecrypter;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use function func_get_arg;
-use function func_num_args;
+use Throwable;
 
 /**
  * @deprecated since 4.3.0, use EventDispatchingJWEDecrypter instead. The class extends a service of
@@ -30,32 +30,33 @@ final class JWEDecrypter extends BaseJWEDecrypter
     }
 
     /**
-     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet:
-     * it is read with func_num_args()/func_get_arg(5) and forwarded to the parent, otherwise the reason of a
-     * failure would be lost as soon as this service is used in place of the decrypter of the library.
+     * The deprecated methods of the parent class are implemented on top of this one: the events are dispatched
+     * whichever method the application calls.
+     *
+     * A JWE that already has a payload is reported as decrypted without any key being used. There is nothing to
+     * report in that case, hence no event at all.
+     *
+     * @param (callable(Throwable): void)|null $onError
      */
     #[Override]
-    public function decryptUsingKeySet(
-        JWE &$jwe,
-        JWKSet $jwkset,
-        int $recipient,
-        ?JWK &$jwk = null,
-        ?JWK $senderKey = null
-    ): bool {
-        $success = func_num_args() >= 6 ? parent::decryptUsingKeySet(
-            $jwe,
-            $jwkset,
-            $recipient,
-            $jwk,
-            $senderKey,
-            func_get_arg(5)
-        ) : parent::decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);
-        if ($success) {
-            $this->eventDispatcher->dispatch(new JWEDecryptionSuccessEvent($jwe, $jwkset, $jwk, $recipient));
-        } else {
+    public function decrypt(
+        JWE $jwe,
+        JWK|JWKSet $keys,
+        int $recipientIndex,
+        ?JWK $senderKey = null,
+        ?callable $onError = null
+    ): DecryptionResult {
+        $result = parent::decrypt($jwe, $keys, $recipientIndex, $senderKey, $onError);
+        $jwkset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
+        $jwk = $result->getKey();
+        if ($jwk !== null) {
+            $this->eventDispatcher->dispatch(
+                new JWEDecryptionSuccessEvent($result->getJwe(), $jwkset, $jwk, $recipientIndex)
+            );
+        } elseif (! $result->isDecrypted()) {
             $this->eventDispatcher->dispatch(new JWEDecryptionFailureEvent($jwe, $jwkset));
         }
 
-        return $success;
+        return $result;
     }
 }

--- a/src/Bundle/Services/JWELoader.php
+++ b/src/Bundle/Services/JWELoader.php
@@ -7,10 +7,11 @@ namespace Jose\Bundle\JoseFramework\Services;
 use Jose\Bundle\JoseFramework\Event\JWELoadingFailureEvent;
 use Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent;
 use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWEDecrypterInterface;
 use Jose\Component\Encryption\JWELoader as BaseJWELoader;
+use Jose\Component\Encryption\LoadingResult;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -31,14 +32,21 @@ final class JWELoader extends BaseJWELoader
         parent::__construct($serializerManager, $jweDecrypter, $headerCheckerManager);
     }
 
+    /**
+     * The deprecated methods of the parent class are implemented on top of this one: the events are dispatched
+     * whichever method the application calls.
+     */
     #[Override]
-    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
+    public function loadAndDecrypt(string $token, JWK|JWKSet $keys): LoadingResult
     {
+        $keyset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
         try {
-            $jwe = parent::loadAndDecryptWithKeySet($token, $keyset, $recipient);
-            $this->eventDispatcher->dispatch(new JWELoadingSuccessEvent($token, $jwe, $keyset, $recipient));
+            $result = parent::loadAndDecrypt($token, $keys);
+            $this->eventDispatcher->dispatch(
+                new JWELoadingSuccessEvent($token, $result->getJwe(), $keyset, $result->getRecipientIndex())
+            );
 
-            return $jwe;
+            return $result;
         } catch (Throwable $throwable) {
             $this->eventDispatcher->dispatch(new JWELoadingFailureEvent($token, $keyset, $throwable));
 

--- a/src/Bundle/Services/JWSLoader.php
+++ b/src/Bundle/Services/JWSLoader.php
@@ -7,10 +7,11 @@ namespace Jose\Bundle\JoseFramework\Services;
 use Jose\Bundle\JoseFramework\Event\JWSLoadingFailureEvent;
 use Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent;
 use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSLoader as BaseJWSLoader;
 use Jose\Component\Signature\JWSVerifierInterface;
+use Jose\Component\Signature\LoadingResult;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -31,18 +32,21 @@ final class JWSLoader extends BaseJWSLoader
         parent::__construct($serializerManager, $jwsVerifier, $headerCheckerManager);
     }
 
+    /**
+     * The deprecated methods of the parent class are implemented on top of this one: the events are dispatched
+     * whichever method the application calls.
+     */
     #[Override]
-    public function loadAndVerifyWithKeySet(
-        string $token,
-        JWKSet $keyset,
-        ?int &$signature,
-        ?string $payload = null
-    ): JWS {
+    public function loadAndVerify(string $token, JWK|JWKSet $keys, ?string $payload = null): LoadingResult
+    {
+        $keyset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
         try {
-            $jws = parent::loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
-            $this->eventDispatcher->dispatch(new JWSLoadingSuccessEvent($token, $jws, $keyset, $signature));
+            $result = parent::loadAndVerify($token, $keys, $payload);
+            $this->eventDispatcher->dispatch(
+                new JWSLoadingSuccessEvent($token, $result->getJws(), $keyset, $result->getSignatureIndex())
+            );
 
-            return $jws;
+            return $result;
         } catch (Throwable $throwable) {
             $this->eventDispatcher->dispatch(new JWSLoadingFailureEvent($token, $keyset, $throwable));
 

--- a/src/Bundle/Services/JWSVerifier.php
+++ b/src/Bundle/Services/JWSVerifier.php
@@ -11,10 +11,10 @@ use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSVerifier as BaseJWSVerifier;
+use Jose\Component\Signature\VerificationResult;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use function func_get_arg;
-use function func_num_args;
+use Throwable;
 
 /**
  * @deprecated since 4.3.0, use EventDispatchingJWSVerifier instead. The class extends a service of
@@ -30,27 +30,23 @@ final class JWSVerifier extends BaseJWSVerifier
     }
 
     /**
-     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet:
-     * it is read with func_num_args()/func_get_arg(5) and forwarded to the parent, otherwise the reason of a
-     * failure would be lost as soon as this service is used in place of the verifier of the library.
+     * The deprecated methods of the parent class are implemented on top of this one: the events are dispatched
+     * whichever method the application calls.
+     *
+     * @param (callable(Throwable): void)|null $onError
      */
     #[Override]
-    public function verifyWithKeySet(
+    public function verify(
         JWS $jws,
-        JWKSet $jwkset,
+        JWK|JWKSet $keys,
         int $signatureIndex,
         ?string $detachedPayload = null,
-        ?JWK &$jwk = null
-    ): bool {
-        $success = func_num_args() >= 6 ? parent::verifyWithKeySet(
-            $jws,
-            $jwkset,
-            $signatureIndex,
-            $detachedPayload,
-            $jwk,
-            func_get_arg(5)
-        ) : parent::verifyWithKeySet($jws, $jwkset, $signatureIndex, $detachedPayload, $jwk);
-        if ($success) {
+        ?callable $onError = null
+    ): VerificationResult {
+        $result = parent::verify($jws, $keys, $signatureIndex, $detachedPayload, $onError);
+        $jwkset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
+        $jwk = $result->getKey();
+        if ($jwk !== null) {
             $this->eventDispatcher->dispatch(new JWSVerificationSuccessEvent(
                 $jws,
                 $jwkset,
@@ -62,6 +58,6 @@ final class JWSVerifier extends BaseJWSVerifier
             $this->eventDispatcher->dispatch(new JWSVerificationFailureEvent($jws, $jwkset, $detachedPayload));
         }
 
-        return $success;
+        return $result;
     }
 }

--- a/src/Bundle/Services/NestedTokenLoader.php
+++ b/src/Bundle/Services/NestedTokenLoader.php
@@ -9,8 +9,8 @@ use Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Encryption\JWELoaderInterface;
 use Jose\Component\NestedToken\NestedTokenLoader as BaseNestedTokenLoader;
-use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSLoaderInterface;
+use Jose\Component\Signature\LoadingResult;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
@@ -29,20 +29,24 @@ final class NestedTokenLoader extends BaseNestedTokenLoader
         parent::__construct($jweLoader, $jwsLoader);
     }
 
+    /**
+     * The "load()" method of the parent class is implemented on top of this one: the events are dispatched whichever
+     * method the application calls.
+     */
     #[Override]
-    public function load(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet, ?int &$signature = null): JWS
+    public function loadAndVerify(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet): LoadingResult
     {
         try {
-            $jws = parent::load($token, $encryptionKeySet, $signatureKeySet, $signature);
+            $result = parent::loadAndVerify($token, $encryptionKeySet, $signatureKeySet);
             $this->eventDispatcher->dispatch(new NestedTokenLoadingSuccessEvent(
                 $token,
-                $jws,
+                $result->getJws(),
                 $signatureKeySet,
                 $encryptionKeySet,
-                $signature
+                $result->getSignatureIndex()
             ));
 
-            return $jws;
+            return $result;
         } catch (Throwable $throwable) {
             $this->eventDispatcher->dispatch(new NestedTokenLoadingFailureEvent(
                 $token,

--- a/src/Library/Encryption/Algorithm/ContentEncryptionAlgorithm.php
+++ b/src/Library/Encryption/Algorithm/ContentEncryptionAlgorithm.php
@@ -12,6 +12,11 @@ interface ContentEncryptionAlgorithm extends Algorithm
      * This method encrypts the data using the given CEK, IV, AAD and protected header. The variable $tag is populated
      * on success.
      *
+     * BC NOTE: in 5.0, this method will return an "EncryptedContent" object - the ciphertext and the tag - and the
+     * "?string &$tag" output parameter will be removed. The change cannot be made now without breaking every
+     * implementation of this interface. Implementations are encouraged to prepare for it: the object is already
+     * available as Jose\Component\Encryption\Algorithm\EncryptedContent.
+     *
      * @param string $data The data to encrypt
      * @param string $cek The content encryption key
      * @param string $iv The Initialization Vector

--- a/src/Library/Encryption/Algorithm/EncryptedContent.php
+++ b/src/Library/Encryption/Algorithm/EncryptedContent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption\Algorithm;
+
+/**
+ * The ciphertext produced by a content encryption algorithm, together with the authentication tag when the
+ * algorithm computes one.
+ *
+ * It is the return type announced for ContentEncryptionAlgorithm::encryptContent() in 5.0.0, where it replaces
+ * the "?string &$tag" output parameter. It is not used by the interface yet: adding it now would break every
+ * third-party implementation of the interface.
+ */
+final readonly class EncryptedContent
+{
+    public function __construct(
+        private string $ciphertext,
+        private ?string $tag = null
+    ) {
+    }
+
+    /**
+     * The encrypted content.
+     */
+    public function getCiphertext(): string
+    {
+        return $this->ciphertext;
+    }
+
+    /**
+     * The authentication tag, or null when the algorithm does not compute one.
+     */
+    public function getTag(): ?string
+    {
+        return $this->tag;
+    }
+}

--- a/src/Library/Encryption/Algorithm/KeyEncryption/KeyAgreement.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/KeyAgreement.php
@@ -14,6 +14,12 @@ interface KeyAgreement extends KeyEncryptionAlgorithm
      *
      * @param array<string, mixed> $completeHeader
      * @param array<string, mixed> $additionalHeaderValues
+     *
+     * BC NOTE: in 5.0, this method will return a "WrappedKey" object - the agreement key and the header parameters
+     * to add to the token - and the "array &$additionalHeaderValues" output parameter will be removed. The change
+     * cannot be made now without breaking every implementation of this interface. Implementations are encouraged to
+     * prepare for it: the object is already available as
+     * Jose\Component\Encryption\Algorithm\KeyEncryption\WrappedKey.
      */
     public function getAgreementKey(
         int $encryptionKeyLength,

--- a/src/Library/Encryption/Algorithm/KeyEncryption/KeyEncryption.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/KeyEncryption.php
@@ -16,6 +16,12 @@ interface KeyEncryption extends KeyEncryptionAlgorithm
      * @param string $cek The CEK to encrypt
      * @param array<string, mixed> $completeHeader The complete header of the JWT
      * @param array<string, mixed> $additionalHeader Additional header
+     *
+     * BC NOTE: in 5.0, this method will return a "WrappedKey" object - the encrypted CEK and the header parameters
+     * to add to the token - and the "array &$additionalHeader" output parameter will be removed. The change cannot
+     * be made now without breaking every implementation of this interface. Implementations are encouraged to
+     * prepare for it: the object is already available as
+     * Jose\Component\Encryption\Algorithm\KeyEncryption\WrappedKey.
      */
     public function encryptKey(JWK $key, string $cek, array $completeHeader, array &$additionalHeader): string;
 

--- a/src/Library/Encryption/Algorithm/KeyEncryption/KeyWrapping.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/KeyWrapping.php
@@ -16,6 +16,12 @@ interface KeyWrapping extends KeyEncryptionAlgorithm
      * @param string $cek The CEK to encrypt
      * @param array<string, mixed> $completeHeader The complete header of the JWT
      * @param array<string, mixed> $additionalHeader The complete header of the JWT
+     *
+     * BC NOTE: in 5.0, this method will return a "WrappedKey" object - the wrapped CEK and the header parameters to
+     * add to the token - and the "array &$additionalHeader" output parameter will be removed. The change cannot be
+     * made now without breaking every implementation of this interface. Implementations are encouraged to prepare
+     * for it: the object is already available as
+     * Jose\Component\Encryption\Algorithm\KeyEncryption\WrappedKey.
      */
     public function wrapKey(JWK $key, string $cek, array $completeHeader, array &$additionalHeader): string;
 

--- a/src/Library/Encryption/Algorithm/KeyEncryption/WrappedKey.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/WrappedKey.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
+
+/**
+ * The key produced by a key management algorithm, together with the header parameters the algorithm needs to add
+ * to the token so that the recipient is able to compute the key back.
+ *
+ * It is the return type announced for KeyEncryption::encryptKey(), KeyWrapping::wrapKey() and
+ * KeyAgreement::getAgreementKey() in 5.0.0, where it replaces the "array &$additionalHeader" output parameter. It
+ * is not used by those interfaces yet: adding it now would break every third-party implementation of them.
+ */
+final readonly class WrappedKey
+{
+    /**
+     * @param array<string, mixed> $additionalHeader
+     */
+    public function __construct(
+        private string $key,
+        private array $additionalHeader = []
+    ) {
+    }
+
+    /**
+     * The encrypted or wrapped CEK, or the agreement key when the algorithm is a key agreement algorithm.
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * The header parameters to add to the token, such as "epk", "iv", "tag" or "p2s".
+     *
+     * @return array<string, mixed>
+     */
+    public function getAdditionalHeader(): array
+    {
+        return $this->additionalHeader;
+    }
+}

--- a/src/Library/Encryption/DecryptionResult.php
+++ b/src/Library/Encryption/DecryptionResult.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption;
+
+use Jose\Component\Core\JWK;
+
+/**
+ * The result of the decryption of one recipient of a JWE.
+ *
+ * It replaces the "JWE &$jwe" and "?JWK &$jwk" output parameters of JWEDecrypter::decryptUsingKeySet(): the
+ * decrypted JWE and the key that decrypted it are carried by the result instead of being written into variables of
+ * the caller.
+ */
+final readonly class DecryptionResult
+{
+    private function __construct(
+        private bool $decrypted,
+        private JWE $jwe,
+        private int $recipientIndex,
+        private ?JWK $key
+    ) {
+    }
+
+    /**
+     * The recipient has been decrypted. The key is null when the JWE was already decrypted and nothing had to be
+     * done.
+     */
+    public static function success(JWE $jwe, int $recipientIndex, ?JWK $key): self
+    {
+        return new self(true, $jwe, $recipientIndex, $key);
+    }
+
+    /**
+     * No key of the key set was able to decrypt the recipient. The JWE is returned unchanged.
+     */
+    public static function failure(JWE $jwe, int $recipientIndex): self
+    {
+        return new self(false, $jwe, $recipientIndex, null);
+    }
+
+    /**
+     * Returns true if the recipient has been decrypted, otherwise false.
+     */
+    public function isDecrypted(): bool
+    {
+        return $this->decrypted;
+    }
+
+    /**
+     * The decrypted JWE, or the JWE given to the decrypter when the decryption failed. JWE objects are immutable:
+     * this is not the object that has been given to the decrypter, but a copy of it with the payload set.
+     */
+    public function getJwe(): JWE
+    {
+        return $this->jwe;
+    }
+
+    /**
+     * The index of the recipient that has been decrypted, as given to the decrypter.
+     */
+    public function getRecipientIndex(): int
+    {
+        return $this->recipientIndex;
+    }
+
+    /**
+     * The key that decrypted the recipient, or null when the decryption failed or when the JWE was already
+     * decrypted.
+     */
+    public function getKey(): ?JWK
+    {
+        return $this->key;
+    }
+}

--- a/src/Library/Encryption/JWEDecrypter.php
+++ b/src/Library/Encryption/JWEDecrypter.php
@@ -29,6 +29,7 @@ use function is_callable;
 use function is_string;
 use function sprintf;
 use function strlen;
+use function trigger_deprecation;
 
 /**
  * @final The class will be final in 5.0.0: implement JWEDecrypterInterface and decorate the service instead of
@@ -69,11 +70,21 @@ class JWEDecrypter implements JWEDecrypterInterface
      *
      * @param JWE $jwe A JWE object to decrypt
      * @param JWK $jwk The key used to decrypt the input
-     * @param int $recipient The recipient used to decrypt the token
+     * @param int $recipient The index of the recipient to decrypt
      * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
+     *
+     * @deprecated since 4.3.0, use "decrypt()" instead. Will be removed in 5.0.0.
      */
     public function decryptUsingKey(JWE &$jwe, JWK $jwk, int $recipient, ?JWK $senderKey = null): bool
     {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::decryptUsingKey()" is deprecated and will be removed in 5.0.0. Please use "%s::decrypt()" instead: it returns a "%s" object that carries the decrypted JWE instead of replacing the variable of the caller.',
+            self::class,
+            self::class,
+            DecryptionResult::class
+        );
         $jwkset = new JWKSet([$jwk]);
         $successJwk = null;
 
@@ -83,16 +94,17 @@ class JWEDecrypter implements JWEDecrypterInterface
     /**
      * This method will try to decrypt the given JWE and recipient using a JWKSet.
      *
-     * A key that cannot be used, or that does not decrypt the recipient, does not abort the decryption: the next key of
-     * the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
-     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of the
-     * signature yet (it will be in 5.0.0) and is read with func_num_args()/func_get_arg(5), so that classes extending
+     * A callable is accepted as an additional argument to observe the failures met while trying the keys. That argument
+     * is not part of the signature and is read with func_num_args()/func_get_arg(5), so that the objects decorating
      * this one remain compatible.
      *
      * @param JWE $jwe A JWE object to decrypt
      * @param JWKSet $jwkset The key set used to decrypt the input
-     * @param JWK $jwk The key used to decrypt the token in case of success
-     * @param int $recipient The recipient used to decrypt the token in case of success
+     * @param int $recipient The index of the recipient to decrypt
+     * @param JWK|null $jwk The key used to decrypt the token in case of success
+     * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
+     *
+     * @deprecated since 4.3.0, use "decrypt()" instead. Will be removed in 5.0.0.
      */
     public function decryptUsingKeySet(
         JWE &$jwe,
@@ -101,28 +113,66 @@ class JWEDecrypter implements JWEDecrypterInterface
         ?JWK &$jwk = null,
         ?JWK $senderKey = null
     ): bool {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::decryptUsingKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::decrypt()" instead: it returns a "%s" object that carries the decrypted JWE and the key instead of replacing the variables of the caller.',
+            self::class,
+            self::class,
+            DecryptionResult::class
+        );
         $onError = func_num_args() >= 6 ? func_get_arg(5) : null;
         if (! is_callable($onError)) {
             $onError = null;
         }
+        $result = $this->decrypt($jwe, $jwkset, $recipient, $senderKey, $onError);
+        if (! $result->isDecrypted()) {
+            return false;
+        }
+        $jwe = $result->getJwe();
+        $successJwk = $result->getKey();
+        if ($successJwk !== null) {
+            $jwk = $successJwk;
+        }
+
+        return true;
+    }
+
+    /**
+     * This method will try to decrypt the given recipient of the given JWE using a key or a key set. The decrypted JWE
+     * and the key that decrypted it are carried by the returned result: JWE objects are immutable, so the JWE given to
+     * this method is left untouched.
+     *
+     * A key that cannot be used, or that does not decrypt the recipient, does not abort the decryption: the next key of
+     * the key set is tried and the reason of the failure is otherwise lost. The optional callable is called with every
+     * discarded Throwable, so that those failures can be observed.
+     *
+     * @param JWE $jwe A JWE object to decrypt
+     * @param JWK|JWKSet $keys The recipient will be decrypted using that key or the keys in that key set
+     * @param int $recipientIndex The index of the recipient to decrypt
+     * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
+     * @param (callable(Throwable): void)|null $onError Called with every failure met while trying the keys
+     */
+    public function decrypt(
+        JWE $jwe,
+        JWK|JWKSet $keys,
+        int $recipientIndex,
+        ?JWK $senderKey = null,
+        ?callable $onError = null
+    ): DecryptionResult {
+        $jwkset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
         if ($jwkset->count() === 0) {
             throw new InvalidKeySetException('No key in the key set.');
         }
         if ($jwe->getPayload() !== null) {
-            return true;
+            return DecryptionResult::success($jwe, $recipientIndex, null);
         }
         if ($jwe->countRecipients() === 0) {
             throw new InvalidArgumentException('The JWE does not contain any recipient.');
         }
 
-        $plaintext = $this->decryptRecipientKey($jwe, $jwkset, $recipient, $jwk, $senderKey, $onError);
-        if ($plaintext !== null) {
-            $jwe = $jwe->withPayload($plaintext);
-
-            return true;
-        }
-
-        return false;
+        return $this->decryptRecipientKey($jwe, $jwkset, $recipientIndex, $senderKey, $onError)
+            ?? DecryptionResult::failure($jwe, $recipientIndex);
     }
 
     /**
@@ -134,16 +184,15 @@ class JWEDecrypter implements JWEDecrypterInterface
      * The shared unprotected header is never a valid source for "alg" and "enc": it is not covered by the
      * AAD and, unlike the per-recipient header, nothing requires those parameters to be located there.
      *
-     * @param callable(Throwable): void|null $onError
+     * @param (callable(Throwable): void)|null $onError
      */
     private function decryptRecipientKey(
         JWE $jwe,
         JWKSet $jwkset,
         int $i,
-        ?JWK &$successJwk = null,
         ?JWK $senderKey = null,
         ?callable $onError = null
-    ): ?string {
+    ): ?DecryptionResult {
         $recipient = $jwe->getRecipient($i);
         $sharedProtectedHeader = $jwe->getSharedProtectedHeader();
         $sharedHeader = $jwe->getSharedHeader();
@@ -162,7 +211,7 @@ class JWEDecrypter implements JWEDecrypterInterface
 
         $this->checkIvSize($jwe->getIV(), $content_encryption_algorithm->getIVSize());
 
-        foreach ($jwkset as $recipientKey) {
+        foreach ($jwkset->all() as $recipientKey) {
             try {
                 KeyChecker::checkKeyUsage($recipientKey, 'decryption');
                 if ($key_encryption_algorithm->name() !== 'dir') {
@@ -180,9 +229,8 @@ class JWEDecrypter implements JWEDecrypterInterface
                 );
                 $this->checkCekSize($cek, $key_encryption_algorithm, $content_encryption_algorithm);
                 $payload = $this->decryptPayload($jwe, $cek, $content_encryption_algorithm);
-                $successJwk = $recipientKey;
 
-                return $payload;
+                return DecryptionResult::success($jwe->withPayload($payload), $i, $recipientKey);
             } catch (Throwable $throwable) {
                 if ($onError !== null) {
                     $onError($throwable);

--- a/src/Library/Encryption/JWEDecrypterInterface.php
+++ b/src/Library/Encryption/JWEDecrypterInterface.php
@@ -7,12 +7,17 @@ namespace Jose\Component\Encryption;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Throwable;
 
 /**
  * Decrypts a recipient of a JWE.
  *
  * The interface is implemented by JWEDecrypter and by every object that decorates it. Decoration is the supported way
  * of plugging behaviour into the decrypter: JWEDecrypter is annotated as final and will be final in 5.0.0.
+ *
+ * The interface only declares the methods that will survive 5.0.0. "decryptUsingKey()" and "decryptUsingKeySet()",
+ * deprecated since 4.3.0 because they replace variables of the caller, are still available on JWEDecrypter and on
+ * the objects of this package that decorate it, but they are not part of the contract.
  */
 interface JWEDecrypterInterface
 {
@@ -27,29 +32,23 @@ interface JWEDecrypterInterface
     public function getContentEncryptionAlgorithmManager(): AlgorithmManager;
 
     /**
-     * Decrypts the given recipient of the JWE using the given key.
-     *
-     * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
-     */
-    public function decryptUsingKey(JWE &$jwe, JWK $jwk, int $recipient, ?JWK $senderKey = null): bool;
-
-    /**
-     * Decrypts the given recipient of the JWE using the given key set.
+     * Decrypts the given recipient of the JWE using a key or a key set. The decrypted JWE and the key that decrypted
+     * it are carried by the returned result: JWE objects are immutable, so the JWE given to this method is left
+     * untouched.
      *
      * A key that cannot be used, or that does not decrypt the recipient, does not abort the decryption: the next key
-     * of the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
-     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of
-     * the signature yet - it will be in 5.0.0 - and is read with func_num_args()/func_get_arg(5). An implementation
-     * that does not read it still behaves correctly, it only loses the reason of the failures.
+     * of the key set is tried and the reason of the failure is otherwise lost. The optional callable is called with
+     * every discarded Throwable, so that those failures can be observed.
      *
-     * @param JWK|null $jwk The key used to decrypt the token in case of success
+     * @param JWK|JWKSet $keys The recipient will be decrypted using that key or the keys in that key set
      * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
+     * @param (callable(Throwable): void)|null $onError Called with every failure met while trying the keys
      */
-    public function decryptUsingKeySet(
-        JWE &$jwe,
-        JWKSet $jwkset,
-        int $recipient,
-        ?JWK &$jwk = null,
-        ?JWK $senderKey = null
-    ): bool;
+    public function decrypt(
+        JWE $jwe,
+        JWK|JWKSet $keys,
+        int $recipientIndex,
+        ?JWK $senderKey = null,
+        ?callable $onError = null
+    ): DecryptionResult;
 }

--- a/src/Library/Encryption/JWELoader.php
+++ b/src/Library/Encryption/JWELoader.php
@@ -11,6 +11,7 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Throwable;
+use function trigger_deprecation;
 
 /**
  * @final The class will be final in 5.0.0: implement JWELoaderInterface and decorate the service instead of
@@ -55,9 +56,21 @@ class JWELoader implements JWELoaderInterface
     /**
      * This method will try to load and decrypt the given token using a JWK. If succeeded, the methods will populate the
      * $recipient variable and returns the JWE.
+     *
+     * @param-out int $recipient
+     *
+     * @deprecated since 4.3.0, use "loadAndDecrypt()" instead. Will be removed in 5.0.0.
      */
     public function loadAndDecryptWithKey(string $token, JWK $key, ?int &$recipient): JWE
     {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndDecryptWithKey()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndDecrypt()" instead: it returns a "%s" object that carries the index of the decrypted recipient instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
         $keyset = new JWKSet([$key]);
 
         return $this->loadAndDecryptWithKeySet($token, $keyset, $recipient);
@@ -67,21 +80,48 @@ class JWELoader implements JWELoaderInterface
      * This method will try to load and decrypt the given token using a JWKSet. If succeeded, the methods will populate
      * the $recipient variable and returns the JWE.
      *
+     * @param-out int $recipient
+     *
+     * @deprecated since 4.3.0, use "loadAndDecrypt()" instead. Will be removed in 5.0.0.
+     */
+    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
+    {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndDecryptWithKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndDecrypt()" instead: it returns a "%s" object that carries the index of the decrypted recipient instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
+        $result = $this->loadAndDecrypt($token, $keyset);
+        $recipient = $result->getRecipientIndex();
+
+        return $result->getJwe();
+    }
+
+    /**
+     * This method will try to load and decrypt the given token using a key or a key set. The decrypted JWE, the index
+     * of the decrypted recipient and the key that decrypted it are carried by the returned result, otherwise an
+     * exception is thrown.
+     *
      * The failure semantics are unchanged, but the last error met along the way - a serialization failure, a rejected
      * header or a key that could not decrypt the recipient - is chained as the previous exception, so that the reason
      * of the failure remains available to the caller.
+     *
+     * @param string $token A string that represents a JWE
+     * @param JWK|JWKSet $keys The recipient will be decrypted using that key or the keys in that key set
      */
-    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
+    public function loadAndDecrypt(string $token, JWK|JWKSet $keys): LoadingResult
     {
         $lastError = null;
         try {
             $jwe = $this->serializerManager->unserialize($token);
             $nbRecipients = $jwe->countRecipients();
             for ($i = 0; $i < $nbRecipients; ++$i) {
-                if ($this->processRecipient($jwe, $keyset, $i, $lastError)) {
-                    $recipient = $i;
-
-                    return $jwe;
+                $result = $this->processRecipient($jwe, $keys, $i, $lastError);
+                if ($result !== null && $result->isDecrypted()) {
+                    return new LoadingResult($result->getJwe(), $i, $result->getKey());
                 }
             }
         } catch (Throwable $throwable) {
@@ -91,19 +131,21 @@ class JWELoader implements JWELoaderInterface
         throw new InvalidTokenException('Unable to load and decrypt the token.', 0, $lastError);
     }
 
-    private function processRecipient(JWE &$jwe, JWKSet $keyset, int $recipient, ?Throwable &$lastError): bool
-    {
+    private function processRecipient(
+        JWE $jwe,
+        JWK|JWKSet $keys,
+        int $recipient,
+        ?Throwable &$lastError
+    ): ?DecryptionResult {
         try {
             if ($this->headerCheckerManager !== null) {
                 $this->headerCheckerManager->check($jwe, $recipient);
             }
-            $jwk = null;
 
-            return $this->jweDecrypter->decryptUsingKeySet(
+            return $this->jweDecrypter->decrypt(
                 $jwe,
-                $keyset,
+                $keys,
                 $recipient,
-                $jwk,
                 null,
                 static function (Throwable $throwable) use (&$lastError): void {
                     $lastError = $throwable;
@@ -112,7 +154,7 @@ class JWELoader implements JWELoaderInterface
         } catch (Throwable $throwable) {
             $lastError = $throwable;
 
-            return false;
+            return null;
         }
     }
 }

--- a/src/Library/Encryption/JWELoaderInterface.php
+++ b/src/Library/Encryption/JWELoaderInterface.php
@@ -14,6 +14,11 @@ use Jose\Component\Encryption\Serializer\JWESerializerManager;
  *
  * The interface is implemented by JWELoader and by every object that decorates it. Decoration is the supported way of
  * plugging behaviour into the loader: JWELoader is annotated as final and will be final in 5.0.0.
+ *
+ * The interface only declares the methods that will survive 5.0.0. "loadAndDecryptWithKey()" and
+ * "loadAndDecryptWithKeySet()", deprecated since 4.3.0 because they write the index of the decrypted recipient into
+ * a variable of the caller, are still available on JWELoader and on the objects of this package that decorate it,
+ * but they are not part of the contract.
  */
 interface JWELoaderInterface
 {
@@ -33,14 +38,10 @@ interface JWELoaderInterface
     public function getSerializerManager(): JWESerializerManager;
 
     /**
-     * Loads and decrypts the token using the given key. It returns a JWE and populates the $recipient variable in case
-     * of success, otherwise an exception is thrown.
+     * Loads and decrypts the token using the given key or key set. The decrypted JWE, the index of the decrypted
+     * recipient and the key that decrypted it are carried by the returned result, otherwise an exception is thrown.
+     *
+     * @param JWK|JWKSet $keys The recipient will be decrypted using that key or the keys in that key set
      */
-    public function loadAndDecryptWithKey(string $token, JWK $key, ?int &$recipient): JWE;
-
-    /**
-     * Loads and decrypts the token using the given key set. It returns a JWE and populates the $recipient variable in
-     * case of success, otherwise an exception is thrown.
-     */
-    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE;
+    public function loadAndDecrypt(string $token, JWK|JWKSet $keys): LoadingResult;
 }

--- a/src/Library/Encryption/LoadingResult.php
+++ b/src/Library/Encryption/LoadingResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption;
+
+use Jose\Component\Core\JWK;
+
+/**
+ * The result of the loading and the decryption of a token by the JWELoader.
+ *
+ * It replaces the "?int &$recipient" output parameter of JWELoader::loadAndDecryptWithKeySet(): the index of the
+ * decrypted recipient is carried by the result instead of being written into a variable of the caller.
+ */
+final readonly class LoadingResult
+{
+    public function __construct(
+        private JWE $jwe,
+        private int $recipientIndex,
+        private ?JWK $key
+    ) {
+    }
+
+    /**
+     * The loaded and decrypted JWE.
+     */
+    public function getJwe(): JWE
+    {
+        return $this->jwe;
+    }
+
+    /**
+     * The index of the recipient that has been decrypted.
+     */
+    public function getRecipientIndex(): int
+    {
+        return $this->recipientIndex;
+    }
+
+    /**
+     * The key that decrypted the recipient. It is null when the decrypter reported a JWE that was already
+     * decrypted and hence used no key at all.
+     */
+    public function getKey(): ?JWK
+    {
+        return $this->key;
+    }
+}

--- a/src/Library/Encryption/Serializer/JWESerializerManager.php
+++ b/src/Library/Encryption/Serializer/JWESerializerManager.php
@@ -8,7 +8,9 @@ use InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidSerializationException;
 use Jose\Component\Core\Exception\UnsupportedSerializerException;
 use Jose\Component\Encryption\JWE;
+use function func_num_args;
 use function sprintf;
+use function trigger_deprecation;
 
 /**
  * The set of serializers is fixed at construction time: a manager shared as a service cannot be silently extended by
@@ -62,17 +64,45 @@ final readonly class JWESerializerManager
      * exception, so that the actual reason of the failure remains available to the caller.
      *
      * @param string $input A string that represents a JWE
-     * @param string|null $name the name of the serializer if the input is unserialized
+     * @param string|null $name the name of the serializer if the input is unserialized. Passing that argument is
+     *                          deprecated since 4.3.0 and it will be removed in 5.0.0: use "unserializeToken()"
+     *                          instead.
+     *
+     * @param-out string $name
      */
     public function unserialize(string $input, ?string &$name = null): JWE
+    {
+        if (func_num_args() >= 2) {
+            trigger_deprecation(
+                'web-token/jwt-framework',
+                '4.3.0',
+                'Passing the "$name" argument to "%s::unserialize()" is deprecated and the argument will be removed in 5.0.0. Please use "%s::unserializeToken()" instead: it returns a "%s" object that carries the name of the serializer instead of writing it into a variable of the caller.',
+                self::class,
+                self::class,
+                UnserializationResult::class
+            );
+        }
+        $result = $this->unserializeToken($input);
+        $name = $result->getSerializerName();
+
+        return $result->getJwe();
+    }
+
+    /**
+     * Loads data and returns the JWE object it represents, together with the name of the serializer that was able to
+     * convert it.
+     *
+     * When no serializer is able to convert the input, the exception thrown by the last one is chained as the previous
+     * exception, so that the actual reason of the failure remains available to the caller.
+     *
+     * @param string $input A string that represents a JWE
+     */
+    public function unserializeToken(string $input): UnserializationResult
     {
         $lastError = null;
         foreach ($this->serializers as $serializer) {
             try {
-                $jws = $serializer->unserialize($input);
-                $name = $serializer->name();
-
-                return $jws;
+                return new UnserializationResult($serializer->unserialize($input), $serializer->name());
             } catch (InvalidArgumentException $invalidArgumentException) {
                 $lastError = $invalidArgumentException;
 

--- a/src/Library/Encryption/Serializer/UnserializationResult.php
+++ b/src/Library/Encryption/Serializer/UnserializationResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption\Serializer;
+
+use Jose\Component\Encryption\JWE;
+
+/**
+ * The result of the conversion of a string into a JWE by the JWESerializerManager.
+ *
+ * It replaces the "?string &$name" output parameter of JWESerializerManager::unserialize(): the name of the
+ * serializer that converted the input is carried by the result instead of being written into a variable of the
+ * caller.
+ */
+final readonly class UnserializationResult
+{
+    public function __construct(
+        private JWE $jwe,
+        private string $serializerName
+    ) {
+    }
+
+    /**
+     * The JWE the input has been converted into.
+     */
+    public function getJwe(): JWE
+    {
+        return $this->jwe;
+    }
+
+    /**
+     * The name of the serializer that converted the input.
+     */
+    public function getSerializerName(): string
+    {
+        return $this->serializerName;
+    }
+}

--- a/src/Library/NestedToken/NestedTokenLoader.php
+++ b/src/Library/NestedToken/NestedTokenLoader.php
@@ -13,7 +13,10 @@ use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWELoaderInterface;
 use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSLoaderInterface;
+use Jose\Component\Signature\LoadingResult;
+use function func_num_args;
 use function is_string;
+use function trigger_deprecation;
 
 /**
  * @final The class will be final in 5.0.0: implement NestedTokenLoaderInterface and decorate the service instead of
@@ -31,17 +34,45 @@ class NestedTokenLoader implements NestedTokenLoaderInterface
     /**
      * This method will try to load, decrypt and verify the token. In case of failure, an exception is thrown, otherwise
      * returns the JWS and populates the $signature variable.
+     *
+     * @param int|null $signature the index of the verified signature. Passing that argument is deprecated since 4.3.0
+     *                            and it will be removed in 5.0.0: use "loadAndVerify()" instead.
+     *
+     * @param-out int $signature
      */
     public function load(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet, ?int &$signature = null): JWS
     {
-        $recipient = null;
-        $jwe = $this->jweLoader->loadAndDecryptWithKeySet($token, $encryptionKeySet, $recipient);
-        $this->checkContentTypeHeader($jwe, $recipient);
-        if ($jwe->getPayload() === null) {
+        if (func_num_args() >= 4) {
+            trigger_deprecation(
+                'web-token/jwt-framework',
+                '4.3.0',
+                'Passing the "$signature" argument to "%s::load()" is deprecated and the argument will be removed in 5.0.0. Please use "%s::loadAndVerify()" instead: it returns a "%s" object that carries the index of the verified signature instead of writing it into a variable of the caller.',
+                self::class,
+                self::class,
+                LoadingResult::class
+            );
+        }
+        $result = $this->loadAndVerify($token, $encryptionKeySet, $signatureKeySet);
+        $signature = $result->getSignatureIndex();
+
+        return $result->getJws();
+    }
+
+    /**
+     * This method will try to load, decrypt and verify the token. In case of failure, an exception is thrown, otherwise
+     * the JWS, the index of the verified signature and the key that verified it are carried by the returned result.
+     */
+    public function loadAndVerify(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet): LoadingResult
+    {
+        $jweResult = $this->jweLoader->loadAndDecrypt($token, $encryptionKeySet);
+        $jwe = $jweResult->getJwe();
+        $this->checkContentTypeHeader($jwe, $jweResult->getRecipientIndex());
+        $payload = $jwe->getPayload();
+        if ($payload === null) {
             throw new InvalidPayloadException('The token has no payload.');
         }
 
-        return $this->jwsLoader->loadAndVerifyWithKeySet($jwe->getPayload(), $signatureKeySet, $signature);
+        return $this->jwsLoader->loadAndVerify($payload, $signatureKeySet);
     }
 
     private function checkContentTypeHeader(JWE $jwe, int $recipient): void

--- a/src/Library/NestedToken/NestedTokenLoaderInterface.php
+++ b/src/Library/NestedToken/NestedTokenLoaderInterface.php
@@ -6,6 +6,7 @@ namespace Jose\Component\NestedToken;
 
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\LoadingResult;
 
 /**
  * Loads a nested token: a JWS serialized as the payload of a JWE.
@@ -16,8 +17,19 @@ use Jose\Component\Signature\JWS;
 interface NestedTokenLoaderInterface
 {
     /**
+     * Loads, decrypts and verifies the token. In case of failure, an exception is thrown, otherwise the JWS, the index
+     * of the verified signature and the key that verified it are carried by the returned result.
+     */
+    public function loadAndVerify(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet): LoadingResult;
+
+    /**
      * Loads, decrypts and verifies the token. In case of failure, an exception is thrown, otherwise the JWS is returned
      * and the $signature variable is populated.
+     *
+     * @param int|null $signature the index of the verified signature. Passing that argument is deprecated since 4.3.0
+     *                            and it will be removed in 5.0.0: use "loadAndVerify()" instead.
+     *
+     * @param-out int $signature
      */
     public function load(
         string $token,

--- a/src/Library/Signature/JWSLoader.php
+++ b/src/Library/Signature/JWSLoader.php
@@ -11,6 +11,7 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Throwable;
+use function trigger_deprecation;
 
 /**
  * @final The class will be final in 5.0.0: implement JWSLoaderInterface and decorate the service instead of
@@ -55,9 +56,21 @@ class JWSLoader implements JWSLoaderInterface
     /**
      * This method will try to load and verify the token using the given key. It returns a JWS and will populate the
      * $signature variable in case of success, otherwise an exception is thrown.
+     *
+     * @param-out int $signature
+     *
+     * @deprecated since 4.3.0, use "loadAndVerify()" instead. Will be removed in 5.0.0.
      */
     public function loadAndVerifyWithKey(string $token, JWK $key, ?int &$signature, ?string $payload = null): JWS
     {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndVerifyWithKey()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndVerify()" instead: it returns a "%s" object that carries the index of the verified signature instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
         $keyset = new JWKSet([$key]);
 
         return $this->loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
@@ -67,9 +80,9 @@ class JWSLoader implements JWSLoaderInterface
      * This method will try to load and verify the token using the given key set. It returns a JWS and will populate the
      * $signature variable in case of success, otherwise an exception is thrown.
      *
-     * The failure semantics are unchanged, but the last error met along the way - a serialization failure, a rejected
-     * header or a key that could not verify the signature - is chained as the previous exception, so that the reason of
-     * the failure remains available to the caller.
+     * @param-out int $signature
+     *
+     * @deprecated since 4.3.0, use "loadAndVerify()" instead. Will be removed in 5.0.0.
      */
     public function loadAndVerifyWithKeySet(
         string $token,
@@ -77,15 +90,44 @@ class JWSLoader implements JWSLoaderInterface
         ?int &$signature,
         ?string $payload = null
     ): JWS {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::loadAndVerifyWithKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::loadAndVerify()" instead: it returns a "%s" object that carries the index of the verified signature instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            LoadingResult::class
+        );
+        $result = $this->loadAndVerify($token, $keyset, $payload);
+        $signature = $result->getSignatureIndex();
+
+        return $result->getJws();
+    }
+
+    /**
+     * This method will try to load and verify the token using the given key or key set. The JWS, the index of the
+     * verified signature and the key that verified it are carried by the returned result, otherwise an exception is
+     * thrown.
+     *
+     * The failure semantics are unchanged, but the last error met along the way - a serialization failure, a rejected
+     * header or a key that could not verify the signature - is chained as the previous exception, so that the reason of
+     * the failure remains available to the caller.
+     *
+     * @param string $token A string that represents a JWS
+     * @param JWK|JWKSet $keys The signature will be verified using that key or the keys in that key set
+     * @param string|null $payload If not null, the value must be the detached payload encoded in Base64 URL safe
+     */
+    public function loadAndVerify(string $token, JWK|JWKSet $keys, ?string $payload = null): LoadingResult
+    {
         $lastError = null;
         try {
             $jws = $this->serializerManager->unserialize($token);
             $nbSignatures = $jws->countSignatures();
             for ($i = 0; $i < $nbSignatures; ++$i) {
-                if ($this->processSignature($jws, $keyset, $i, $payload, $lastError)) {
-                    $signature = $i;
-
-                    return $jws;
+                $result = $this->processSignature($jws, $keys, $i, $payload, $lastError);
+                $key = $result?->getKey();
+                if ($key !== null) {
+                    return new LoadingResult($jws, $i, $key);
                 }
             }
         } catch (Throwable $throwable) {
@@ -97,23 +139,21 @@ class JWSLoader implements JWSLoaderInterface
 
     private function processSignature(
         JWS $jws,
-        JWKSet $keyset,
+        JWK|JWKSet $keys,
         int $signature,
         ?string $payload,
         ?Throwable &$lastError
-    ): bool {
+    ): ?VerificationResult {
         try {
             if ($this->headerCheckerManager !== null) {
                 $this->headerCheckerManager->check($jws, $signature);
             }
-            $jwk = null;
 
-            return $this->jwsVerifier->verifyWithKeySet(
+            return $this->jwsVerifier->verify(
                 $jws,
-                $keyset,
+                $keys,
                 $signature,
                 $payload,
-                $jwk,
                 static function (Throwable $throwable) use (&$lastError): void {
                     $lastError = $throwable;
                 }
@@ -121,7 +161,7 @@ class JWSLoader implements JWSLoaderInterface
         } catch (Throwable $throwable) {
             $lastError = $throwable;
 
-            return false;
+            return null;
         }
     }
 }

--- a/src/Library/Signature/JWSLoaderInterface.php
+++ b/src/Library/Signature/JWSLoaderInterface.php
@@ -14,6 +14,11 @@ use Jose\Component\Signature\Serializer\JWSSerializerManager;
  *
  * The interface is implemented by JWSLoader and by every object that decorates it. Decoration is the supported way of
  * plugging behaviour into the loader: JWSLoader is annotated as final and will be final in 5.0.0.
+ *
+ * The interface only declares the methods that will survive 5.0.0. "loadAndVerifyWithKey()" and
+ * "loadAndVerifyWithKeySet()", deprecated since 4.3.0 because they write the index of the verified signature into a
+ * variable of the caller, are still available on JWSLoader and on the objects of this package that decorate it, but
+ * they are not part of the contract.
  */
 interface JWSLoaderInterface
 {
@@ -33,19 +38,11 @@ interface JWSLoaderInterface
     public function getSerializerManager(): JWSSerializerManager;
 
     /**
-     * Loads and verifies the token using the given key. It returns a JWS and populates the $signature variable in case
-     * of success, otherwise an exception is thrown.
+     * Loads and verifies the token using the given key or key set. The JWS, the index of the verified signature and
+     * the key that verified it are carried by the returned result, otherwise an exception is thrown.
+     *
+     * @param JWK|JWKSet $keys The signature will be verified using that key or the keys in that key set
+     * @param string|null $payload If not null, the value must be the detached payload encoded in Base64 URL safe
      */
-    public function loadAndVerifyWithKey(string $token, JWK $key, ?int &$signature, ?string $payload = null): JWS;
-
-    /**
-     * Loads and verifies the token using the given key set. It returns a JWS and populates the $signature variable in
-     * case of success, otherwise an exception is thrown.
-     */
-    public function loadAndVerifyWithKeySet(
-        string $token,
-        JWKSet $keyset,
-        ?int &$signature,
-        ?string $payload = null
-    ): JWS;
+    public function loadAndVerify(string $token, JWK|JWKSet $keys, ?string $payload = null): LoadingResult;
 }

--- a/src/Library/Signature/JWSVerifier.php
+++ b/src/Library/Signature/JWSVerifier.php
@@ -22,6 +22,7 @@ use Throwable;
 use function func_num_args;
 use function is_callable;
 use function sprintf;
+use function trigger_deprecation;
 
 /**
  * @final The class will be final in 5.0.0: implement JWSVerifierInterface and decorate the service instead of
@@ -51,27 +52,60 @@ class JWSVerifier implements JWSVerifierInterface
      */
     public function verifyWithKey(JWS $jws, JWK $jwk, int $signature, ?string $detachedPayload = null): bool
     {
-        $jwkset = new JWKSet([$jwk]);
+        return $this->verify($jws, $jwk, $signature, $detachedPayload)
+            ->isVerified();
+    }
 
-        return $this->verifyWithKeySet($jws, $jwkset, $signature, $detachedPayload);
+    /**
+     * This method will try to verify the JWS object using the given key or key set and for the given signature. The
+     * key that verified the signature is carried by the returned result.
+     *
+     * A key that cannot be used, or that does not verify the signature, does not abort the verification: the next key
+     * of the key set is tried and the reason of the failure is otherwise lost. The optional callable is called with
+     * every discarded Throwable, so that those failures can be observed.
+     *
+     * @param JWS $jws A JWS object
+     * @param JWK|JWKSet $keys The signature will be verified using that key or the keys in that key set
+     * @param int $signatureIndex The index of the signature to verify
+     * @param string|null $detachedPayload If not null, the value must be the detached payload encoded in Base64 URL safe. If the input contains a payload, throws an exception.
+     * @param (callable(Throwable): void)|null $onError Called with every failure met while trying the keys
+     */
+    public function verify(
+        JWS $jws,
+        JWK|JWKSet $keys,
+        int $signatureIndex,
+        ?string $detachedPayload = null,
+        ?callable $onError = null
+    ): VerificationResult {
+        $jwkset = $keys instanceof JWK ? new JWKSet([$keys]) : $keys;
+        if ($jwkset->count() === 0) {
+            throw new InvalidKeySetException('There is no key in the key set.');
+        }
+        if ($jws->countSignatures() === 0) {
+            throw new InvalidArgumentException('The JWS does not contain any signature.');
+        }
+        $this->checkPayload($jws, $detachedPayload);
+
+        return $this->verifySignature($jws, $jwkset, $signatureIndex, $detachedPayload, $onError);
     }
 
     /**
      * This method will try to verify the JWS object using the given key set and for the given signature. It returns
      * true if the signature is verified, otherwise false.
      *
-     * A key that cannot be used, or that does not verify the signature, does not abort the verification: the next key
-     * of the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
-     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of the
-     * signature yet (it will be in 5.0.0) and is read with func_num_args()/func_get_arg(5), so that classes extending
+     * A callable is accepted as an additional argument to observe the failures met while trying the keys. That argument
+     * is not part of the signature and is read with func_num_args()/func_get_arg(5), so that the objects decorating
      * this one remain compatible.
      *
      * @param JWS $jws A JWS object
      * @param JWKSet $jwkset The signature will be verified using keys in the key set
-     * @param JWK $jwk The key used to verify the signature in case of success
+     * @param int $signatureIndex The index of the signature to verify
      * @param string|null $detachedPayload If not null, the value must be the detached payload encoded in Base64 URL safe. If the input contains a payload, throws an exception.
+     * @param JWK|null $jwk The key used to verify the signature in case of success
      *
      * @return bool true if the verification of the signature succeeded, else false
+     *
+     * @deprecated since 4.3.0, use "verify()" instead. Will be removed in 5.0.0.
      */
     public function verifyWithKeySet(
         JWS $jws,
@@ -80,33 +114,37 @@ class JWSVerifier implements JWSVerifierInterface
         ?string $detachedPayload = null,
         ?JWK &$jwk = null
     ): bool {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::verifyWithKeySet()" is deprecated and will be removed in 5.0.0. Please use "%s::verify()" instead: it returns a "%s" object that carries the key instead of writing it into a variable of the caller.',
+            self::class,
+            self::class,
+            VerificationResult::class
+        );
         $onError = func_num_args() >= 6 ? func_get_arg(5) : null;
         if (! is_callable($onError)) {
             $onError = null;
         }
-        if ($jwkset->count() === 0) {
-            throw new InvalidKeySetException('There is no key in the key set.');
+        $result = $this->verify($jws, $jwkset, $signatureIndex, $detachedPayload, $onError);
+        if ($result->isVerified()) {
+            $jwk = $result->getKey();
         }
-        if ($jws->countSignatures() === 0) {
-            throw new InvalidArgumentException('The JWS does not contain any signature.');
-        }
-        $this->checkPayload($jws, $detachedPayload);
-        $signature = $jws->getSignature($signatureIndex);
 
-        return $this->verifySignature($jws, $jwkset, $signature, $detachedPayload, $jwk, $onError);
+        return $result->isVerified();
     }
 
     /**
-     * @param callable(Throwable): void|null $onError
+     * @param (callable(Throwable): void)|null $onError
      */
     private function verifySignature(
         JWS $jws,
         JWKSet $jwkset,
-        Signature $signature,
+        int $signatureIndex,
         ?string $detachedPayload = null,
-        ?JWK &$successJwk = null,
         ?callable $onError = null
-    ): bool {
+    ): VerificationResult {
+        $signature = $jws->getSignature($signatureIndex);
         $input = $this->getInputToVerify($jws, $signature, $detachedPayload);
         $algorithm = $this->getAlgorithm($signature);
         foreach ($jwkset->all() as $jwk) {
@@ -114,9 +152,7 @@ class JWSVerifier implements JWSVerifierInterface
                 KeyChecker::checkKeyUsage($jwk, 'verification');
                 KeyChecker::checkKeyAlgorithm($jwk, $algorithm->name());
                 if ($algorithm->verify($jwk, $input, $signature->getSignature()) === true) {
-                    $successJwk = $jwk;
-
-                    return true;
+                    return VerificationResult::success($signatureIndex, $jwk);
                 }
             } catch (Throwable $throwable) {
                 if ($onError !== null) {
@@ -127,7 +163,7 @@ class JWSVerifier implements JWSVerifierInterface
             }
         }
 
-        return false;
+        return VerificationResult::failure($signatureIndex);
     }
 
     private function getInputToVerify(JWS $jws, Signature $signature, ?string $detachedPayload): string

--- a/src/Library/Signature/JWSVerifierInterface.php
+++ b/src/Library/Signature/JWSVerifierInterface.php
@@ -7,12 +7,17 @@ namespace Jose\Component\Signature;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Throwable;
 
 /**
  * Verifies the signatures of a JWS.
  *
  * The interface is implemented by JWSVerifier and by every object that decorates it. Decoration is the supported way
  * of plugging behaviour into the verifier: JWSVerifier is annotated as final and will be final in 5.0.0.
+ *
+ * The interface only declares the methods that will survive 5.0.0. "verifyWithKeySet()", deprecated since 4.3.0
+ * because it writes the key it used into a variable of the caller, is still available on JWSVerifier and on the
+ * objects of this package that decorate it, but it is not part of the contract.
  */
 interface JWSVerifierInterface
 {
@@ -29,24 +34,22 @@ interface JWSVerifierInterface
     public function verifyWithKey(JWS $jws, JWK $jwk, int $signature, ?string $detachedPayload = null): bool;
 
     /**
-     * Verifies the given signature of the JWS object using the given key set.
+     * Verifies the given signature of the JWS object using the given key or key set. The key that verified the
+     * signature is carried by the returned result.
      *
      * A key that cannot be used, or that does not verify the signature, does not abort the verification: the next key
-     * of the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
-     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of
-     * the signature yet - it will be in 5.0.0 - and is read with func_num_args()/func_get_arg(5). An implementation
-     * that does not read it still behaves correctly, it only loses the reason of the failures.
+     * of the key set is tried and the reason of the failure is otherwise lost. The optional callable is called with
+     * every discarded Throwable, so that those failures can be observed.
      *
+     * @param JWK|JWKSet $keys The signature will be verified using that key or the keys in that key set
      * @param string|null $detachedPayload If not null, the value must be the detached payload encoded in Base64 URL safe. If the input contains a payload, throws an exception.
-     * @param JWK|null $jwk The key used to verify the signature in case of success
-     *
-     * @return bool true if the verification of the signature succeeded, else false
+     * @param (callable(Throwable): void)|null $onError Called with every failure met while trying the keys
      */
-    public function verifyWithKeySet(
+    public function verify(
         JWS $jws,
-        JWKSet $jwkset,
+        JWK|JWKSet $keys,
         int $signatureIndex,
         ?string $detachedPayload = null,
-        ?JWK &$jwk = null
-    ): bool;
+        ?callable $onError = null
+    ): VerificationResult;
 }

--- a/src/Library/Signature/LoadingResult.php
+++ b/src/Library/Signature/LoadingResult.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Signature;
+
+use Jose\Component\Core\JWK;
+
+/**
+ * The result of the loading and the verification of a token by the JWSLoader.
+ *
+ * It replaces the "?int &$signature" output parameter of JWSLoader::loadAndVerifyWithKeySet(): the index of the
+ * verified signature is carried by the result instead of being written into a variable of the caller.
+ */
+final readonly class LoadingResult
+{
+    public function __construct(
+        private JWS $jws,
+        private int $signatureIndex,
+        private JWK $key
+    ) {
+    }
+
+    /**
+     * The loaded JWS.
+     */
+    public function getJws(): JWS
+    {
+        return $this->jws;
+    }
+
+    /**
+     * The index of the signature that has been verified.
+     */
+    public function getSignatureIndex(): int
+    {
+        return $this->signatureIndex;
+    }
+
+    /**
+     * The key that verified the signature.
+     */
+    public function getKey(): JWK
+    {
+        return $this->key;
+    }
+}

--- a/src/Library/Signature/Serializer/JWSSerializerManager.php
+++ b/src/Library/Signature/Serializer/JWSSerializerManager.php
@@ -8,7 +8,9 @@ use InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidSerializationException;
 use Jose\Component\Core\Exception\UnsupportedSerializerException;
 use Jose\Component\Signature\JWS;
+use function func_num_args;
 use function sprintf;
+use function trigger_deprecation;
 
 /**
  * The set of serializers is fixed at construction time: a manager shared as a service cannot be silently extended by
@@ -60,17 +62,45 @@ final readonly class JWSSerializerManager
      * exception, so that the actual reason of the failure remains available to the caller.
      *
      * @param string $input A string that represents a JWS
-     * @param string|null $name the name of the serializer if the input is unserialized
+     * @param string|null $name the name of the serializer if the input is unserialized. Passing that argument is
+     *                          deprecated since 4.3.0 and it will be removed in 5.0.0: use "unserializeToken()"
+     *                          instead.
+     *
+     * @param-out string $name
      */
     public function unserialize(string $input, ?string &$name = null): JWS
+    {
+        if (func_num_args() >= 2) {
+            trigger_deprecation(
+                'web-token/jwt-framework',
+                '4.3.0',
+                'Passing the "$name" argument to "%s::unserialize()" is deprecated and the argument will be removed in 5.0.0. Please use "%s::unserializeToken()" instead: it returns a "%s" object that carries the name of the serializer instead of writing it into a variable of the caller.',
+                self::class,
+                self::class,
+                UnserializationResult::class
+            );
+        }
+        $result = $this->unserializeToken($input);
+        $name = $result->getSerializerName();
+
+        return $result->getJws();
+    }
+
+    /**
+     * Loads data and returns the JWS object it represents, together with the name of the serializer that was able to
+     * convert it.
+     *
+     * When no serializer is able to convert the input, the exception thrown by the last one is chained as the previous
+     * exception, so that the actual reason of the failure remains available to the caller.
+     *
+     * @param string $input A string that represents a JWS
+     */
+    public function unserializeToken(string $input): UnserializationResult
     {
         $lastError = null;
         foreach ($this->serializers as $serializer) {
             try {
-                $jws = $serializer->unserialize($input);
-                $name = $serializer->name();
-
-                return $jws;
+                return new UnserializationResult($serializer->unserialize($input), $serializer->name());
             } catch (InvalidArgumentException $invalidArgumentException) {
                 $lastError = $invalidArgumentException;
 

--- a/src/Library/Signature/Serializer/UnserializationResult.php
+++ b/src/Library/Signature/Serializer/UnserializationResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Signature\Serializer;
+
+use Jose\Component\Signature\JWS;
+
+/**
+ * The result of the conversion of a string into a JWS by the JWSSerializerManager.
+ *
+ * It replaces the "?string &$name" output parameter of JWSSerializerManager::unserialize(): the name of the
+ * serializer that converted the input is carried by the result instead of being written into a variable of the
+ * caller.
+ */
+final readonly class UnserializationResult
+{
+    public function __construct(
+        private JWS $jws,
+        private string $serializerName
+    ) {
+    }
+
+    /**
+     * The JWS the input has been converted into.
+     */
+    public function getJws(): JWS
+    {
+        return $this->jws;
+    }
+
+    /**
+     * The name of the serializer that converted the input.
+     */
+    public function getSerializerName(): string
+    {
+        return $this->serializerName;
+    }
+}

--- a/src/Library/Signature/VerificationResult.php
+++ b/src/Library/Signature/VerificationResult.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Signature;
+
+use Jose\Component\Core\JWK;
+
+/**
+ * The result of the verification of one signature of a JWS.
+ *
+ * It replaces the "?JWK &$jwk" output parameter of JWSVerifier::verifyWithKeySet(): the key that verified the
+ * signature is carried by the result instead of being written into a variable of the caller.
+ */
+final readonly class VerificationResult
+{
+    private function __construct(
+        private bool $verified,
+        private int $signatureIndex,
+        private ?JWK $key
+    ) {
+    }
+
+    /**
+     * The signature has been verified with the given key.
+     */
+    public static function success(int $signatureIndex, JWK $key): self
+    {
+        return new self(true, $signatureIndex, $key);
+    }
+
+    /**
+     * No key of the key set was able to verify the signature.
+     */
+    public static function failure(int $signatureIndex): self
+    {
+        return new self(false, $signatureIndex, null);
+    }
+
+    /**
+     * Returns true if the signature has been verified, otherwise false.
+     */
+    public function isVerified(): bool
+    {
+        return $this->verified;
+    }
+
+    /**
+     * The index of the signature that has been verified, as given to the verifier.
+     */
+    public function getSignatureIndex(): int
+    {
+        return $this->signatureIndex;
+    }
+
+    /**
+     * The key that verified the signature, or null when the verification failed.
+     */
+    public function getKey(): ?JWK
+    {
+        return $this->key;
+    }
+}

--- a/tests/Component/Encryption/RSA15ExpectedCekSizeTest.php
+++ b/tests/Component/Encryption/RSA15ExpectedCekSizeTest.php
@@ -116,9 +116,9 @@ final class RSA15ExpectedCekSizeTest extends TestCase
         $decrypter = new JWEDecrypter($algorithmManager);
 
         $deprecations = $this->collectDeprecations(static function () use ($decrypter, $jwe, $jwk): void {
-            $jweToDecrypt = $jwe;
-            static::assertTrue($decrypter->decryptUsingKey($jweToDecrypt, $jwk, 0));
-            static::assertSame('Live long and prosper.', $jweToDecrypt->getPayload());
+            $result = $decrypter->decrypt($jwe, $jwk, 0);
+            static::assertTrue($result->isDecrypted());
+            static::assertSame('Live long and prosper.', $result->getJwe()->getPayload());
         });
 
         static::assertSame([], $deprecations);
@@ -137,8 +137,9 @@ final class RSA15ExpectedCekSizeTest extends TestCase
         $jwe = (new CompactSerializer())->unserialize($token);
         $decrypter = new JWEDecrypter($algorithmManager);
 
-        static::assertTrue($decrypter->decryptUsingKey($jwe, $jwk, 0));
-        static::assertSame('Live long and prosper.', $jwe->getPayload());
+        $result = $decrypter->decrypt($jwe, $jwk, 0);
+        static::assertTrue($result->isDecrypted());
+        static::assertSame('Live long and prosper.', $result->getJwe()->getPayload());
         static::assertSame(4, $algorithm->receivedArgumentCount);
     }
 

--- a/tests/Component/Encryption/ResultObjectsTest.php
+++ b/tests/Component/Encryption/ResultObjectsTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Encryption;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWELoader;
+use Jose\Component\KeyManagement\JWKFactory;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Throwable;
+use function count;
+use const E_USER_DEPRECATED;
+
+/**
+ * The methods that used to populate variables of the caller are deprecated and replaced with methods that return a
+ * result object. The deprecated methods are implemented on top of the new ones and keep their exact behaviour.
+ *
+ * @internal
+ */
+final class ResultObjectsTest extends EncryptionTestCase
+{
+    private ?JWK $key = null;
+
+    private ?JWK $wrongKey = null;
+
+    #[Test]
+    public function theDecrypterReturnsTheDecryptedTokenAndTheKey(): void
+    {
+        $jwe = $this->createJWE();
+        $result = $this->getDecrypter()
+            ->decrypt($jwe, $this->getKeySet(), 0);
+
+        static::assertTrue($result->isDecrypted());
+        static::assertSame(0, $result->getRecipientIndex());
+        static::assertSame('Live long and prosper.', $result->getJwe()->getPayload());
+        static::assertSame($this->getKey()->all(), $result->getKey()?->all());
+    }
+
+    #[Test]
+    public function theDecrypterLeavesTheGivenTokenUntouched(): void
+    {
+        $jwe = $this->createJWE();
+        $this->getDecrypter()
+            ->decrypt($jwe, $this->getKeySet(), 0);
+
+        static::assertNull($jwe->getPayload());
+    }
+
+    #[Test]
+    public function theDecrypterAcceptsASingleKey(): void
+    {
+        $result = $this->getDecrypter()
+            ->decrypt($this->createJWE(), $this->getKey(), 0);
+
+        static::assertTrue($result->isDecrypted());
+        static::assertSame('Live long and prosper.', $result->getJwe()->getPayload());
+    }
+
+    #[Test]
+    public function theDecrypterReportsAFailureWithoutAnyKey(): void
+    {
+        $jwe = $this->createJWE();
+        $errors = [];
+        $result = $this->getDecrypter()
+            ->decrypt($jwe, new JWKSet([$this->getWrongKey()]), 0, null, static function (
+                Throwable $throwable
+            ) use (&$errors): void {
+                $errors[] = $throwable->getMessage();
+            });
+
+        static::assertFalse($result->isDecrypted());
+        static::assertNull($result->getKey());
+        static::assertNull($result->getJwe()->getPayload());
+        static::assertGreaterThan(0, count($errors));
+    }
+
+    #[Test]
+    public function theLoaderReturnsTheIndexOfTheDecryptedRecipient(): void
+    {
+        $result = $this->getLoader()
+            ->loadAndDecrypt($this->createToken(), $this->getKeySet());
+
+        static::assertSame('Live long and prosper.', $result->getJwe()->getPayload());
+        static::assertSame(0, $result->getRecipientIndex());
+        static::assertSame($this->getKey()->all(), $result->getKey()?->all());
+    }
+
+    #[Test]
+    public function theLoaderAcceptsASingleKey(): void
+    {
+        $result = $this->getLoader()
+            ->loadAndDecrypt($this->createToken(), $this->getKey());
+
+        static::assertSame('Live long and prosper.', $result->getJwe()->getPayload());
+    }
+
+    #[Test]
+    public function theSerializerManagerReturnsTheNameOfTheSerializer(): void
+    {
+        $result = $this->getJWESerializerManager()
+            ->unserializeToken($this->createToken());
+
+        static::assertSame('jwe_compact', $result->getSerializerName());
+        static::assertSame(1, $result->getJwe()->countRecipients());
+    }
+
+    #[Test]
+    public function theDeprecatedDecrypterMethodsStillReplaceTheGivenToken(): void
+    {
+        $withKey = $this->createJWE();
+        $withKeySet = $this->createJWE();
+        $jwk = null;
+        $deprecations = $this->collectDeprecations(function () use (&$withKey, &$withKeySet, &$jwk): void {
+            static::assertTrue($this->getDecrypter()->decryptUsingKey($withKey, $this->getKey(), 0));
+            static::assertTrue(
+                $this->getDecrypter()
+                    ->decryptUsingKeySet($withKeySet, $this->getKeySet(), 0, $jwk)
+            );
+        });
+
+        static::assertSame('Live long and prosper.', $withKey->getPayload());
+        static::assertSame('Live long and prosper.', $withKeySet->getPayload());
+        static::assertInstanceOf(JWK::class, $jwk);
+        static::assertSame($this->getKey()->all(), $jwk->all());
+        static::assertCount(3, $deprecations);
+        static::assertStringContainsString('::decryptUsingKey()" is deprecated', $deprecations[0]);
+        static::assertStringContainsString('::decryptUsingKeySet()" is deprecated', $deprecations[1]);
+        static::assertStringContainsString('::decryptUsingKeySet()" is deprecated', $deprecations[2]);
+    }
+
+    /**
+     * "decryptUsingKey()" delegated to "decryptUsingKeySet()" before 4.3.0. It still does, so that an object
+     * extending the decrypter and overriding the key set method keeps intercepting both.
+     */
+    #[Test]
+    public function theDeprecatedKeyMethodStillGoesThroughItsKeySetCounterpart(): void
+    {
+        $algorithmManager = $this->getAlgorithmManagerFactory()
+            ->create(['A256KW', 'A256GCM']);
+        $decrypter = new class($algorithmManager) extends JWEDecrypter {
+            public bool $keySetMethodWasCalled = false;
+
+            #[Override]
+            public function decryptUsingKeySet(
+                JWE &$jwe,
+                JWKSet $jwkset,
+                int $recipient,
+                ?JWK &$jwk = null,
+                ?JWK $senderKey = null
+            ): bool {
+                $this->keySetMethodWasCalled = true;
+
+                return parent::decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);
+            }
+        };
+
+        $jwe = $this->createJWE();
+        static::assertTrue($decrypter->decryptUsingKey($jwe, $this->getKey(), 0));
+        static::assertTrue($decrypter->keySetMethodWasCalled);
+    }
+
+    #[Test]
+    public function theDeprecatedLoaderMethodsStillPopulateTheRecipientIndex(): void
+    {
+        $token = $this->createToken();
+        $withKey = null;
+        $withKeySet = null;
+        $deprecations = $this->collectDeprecations(function () use ($token, &$withKey, &$withKeySet): void {
+            $this->getLoader()
+                ->loadAndDecryptWithKey($token, $this->getKey(), $withKey);
+            $this->getLoader()
+                ->loadAndDecryptWithKeySet($token, $this->getKeySet(), $withKeySet);
+        });
+
+        static::assertSame(0, $withKey);
+        static::assertSame(0, $withKeySet);
+        static::assertCount(3, $deprecations);
+        static::assertStringContainsString('::loadAndDecryptWithKey()" is deprecated', $deprecations[0]);
+        static::assertStringContainsString('::loadAndDecryptWithKeySet()" is deprecated', $deprecations[1]);
+        static::assertStringContainsString('::loadAndDecryptWithKeySet()" is deprecated', $deprecations[2]);
+    }
+
+    #[Test]
+    public function onlyThePassedSerializerNameArgumentIsDeprecated(): void
+    {
+        $token = $this->createToken();
+        $name = null;
+        $deprecations = $this->collectDeprecations(function () use ($token, &$name): void {
+            $this->getJWESerializerManager()
+                ->unserialize($token);
+            $this->getJWESerializerManager()
+                ->unserialize($token, $name);
+        });
+
+        static::assertSame('jwe_compact', $name);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Passing the "$name" argument', $deprecations[0]);
+    }
+
+    private function getDecrypter(): JWEDecrypter
+    {
+        return $this->getJWEDecrypterFactory()
+            ->create(['A256KW', 'A256GCM']);
+    }
+
+    private function getLoader(): JWELoader
+    {
+        return $this->getJWELoaderFactory()
+            ->create(['jwe_compact'], ['A256KW', 'A256GCM']);
+    }
+
+    private function getKey(): JWK
+    {
+        if ($this->key === null) {
+            $this->key = JWKFactory::createOctKey(256, [
+                'alg' => 'A256KW',
+                'use' => 'enc',
+            ]);
+        }
+
+        return $this->key;
+    }
+
+    private function getWrongKey(): JWK
+    {
+        if ($this->wrongKey === null) {
+            $this->wrongKey = JWKFactory::createOctKey(256, [
+                'alg' => 'A256KW',
+                'use' => 'enc',
+            ]);
+        }
+
+        return $this->wrongKey;
+    }
+
+    private function getKeySet(): JWKSet
+    {
+        return new JWKSet([$this->getWrongKey(), $this->getKey()]);
+    }
+
+    private function createJWE(): JWE
+    {
+        return $this->getJWEBuilderFactory()
+            ->create(['A256KW', 'A256GCM'])
+            ->create()
+            ->withPayload('Live long and prosper.')
+            ->withSharedProtectedHeader([
+                'alg' => 'A256KW',
+                'enc' => 'A256GCM',
+            ])
+            ->addRecipient($this->getKey())
+            ->build();
+    }
+
+    private function createToken(): string
+    {
+        return $this->getJWESerializerManager()
+            ->serialize('jwe_compact', $this->createJWE(), 0);
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}

--- a/tests/Component/NestedToken/ResultObjectsTest.php
+++ b/tests/Component/NestedToken/ResultObjectsTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\NestedToken;
+
+use Jose\Component\Core\AlgorithmManagerFactory;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\NestedToken\NestedTokenBuilderFactory;
+use Jose\Component\NestedToken\NestedTokenLoader;
+use Jose\Component\NestedToken\NestedTokenLoaderFactory;
+use Jose\Component\Signature\Algorithm\HS256;
+use Jose\Component\Signature\JWSBuilderFactory;
+use Jose\Component\Signature\JWSLoaderFactory;
+use Jose\Component\Signature\JWSVerifierFactory;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManagerFactory;
+use PHPUnit\Framework\Attributes\Test;
+use const E_USER_DEPRECATED;
+
+/**
+ * The "$signature" output parameter of the nested token loader is deprecated and replaced with a result object. The
+ * "load()" method is implemented on top of the new one and keeps its exact behaviour.
+ *
+ * @internal
+ */
+final class ResultObjectsTest extends NestedTokenTestCase
+{
+    private ?JWK $encryptionKey = null;
+
+    private ?JWK $signatureKey = null;
+
+    #[Test]
+    public function theLoaderReturnsTheIndexOfTheVerifiedSignature(): void
+    {
+        $result = $this->getNestedTokenLoader()
+            ->loadAndVerify(
+                $this->createToken(),
+                new JWKSet([$this->getEncryptionKey()]),
+                new JWKSet([$this->getSignatureKey()])
+            );
+
+        static::assertSame('Live long and prosper.', $result->getJws()->getPayload());
+        static::assertSame(0, $result->getSignatureIndex());
+        static::assertSame($this->getSignatureKey()->all(), $result->getKey()->all());
+    }
+
+    #[Test]
+    public function onlyThePassedSignatureArgumentIsDeprecated(): void
+    {
+        $token = $this->createToken();
+        $encryptionKeySet = new JWKSet([$this->getEncryptionKey()]);
+        $signatureKeySet = new JWKSet([$this->getSignatureKey()]);
+        $signature = null;
+        $deprecations = $this->collectDeprecations(function () use (
+            $token,
+            $encryptionKeySet,
+            $signatureKeySet,
+            &$signature
+        ): void {
+            $this->getNestedTokenLoader()
+                ->load($token, $encryptionKeySet, $signatureKeySet);
+            $this->getNestedTokenLoader()
+                ->load($token, $encryptionKeySet, $signatureKeySet, $signature);
+        });
+
+        static::assertSame(0, $signature);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Passing the "$signature" argument', $deprecations[0]);
+    }
+
+    private function getNestedTokenLoader(): NestedTokenLoader
+    {
+        $loaderFactory = new NestedTokenLoaderFactory(
+            $this->getJWELoaderFactory(),
+            new JWSLoaderFactory(
+                $this->getJWSSerializerManagerFactory(),
+                new JWSVerifierFactory($this->getSignatureAlgorithmManagerFactory()),
+                null
+            )
+        );
+
+        return $loaderFactory->create(['jwe_compact'], ['A256KW', 'A256GCM'], [], ['jws_compact'], ['HS256'], []);
+    }
+
+    private function getSignatureAlgorithmManagerFactory(): AlgorithmManagerFactory
+    {
+        return new AlgorithmManagerFactory([new HS256()]);
+    }
+
+    private function getJWSSerializerManagerFactory(): JWSSerializerManagerFactory
+    {
+        $factory = new JWSSerializerManagerFactory();
+        $factory->add(new CompactSerializer());
+
+        return $factory;
+    }
+
+    private function getEncryptionKey(): JWK
+    {
+        if ($this->encryptionKey === null) {
+            $this->encryptionKey = JWKFactory::createOctKey(256, [
+                'alg' => 'A256KW',
+                'use' => 'enc',
+            ]);
+        }
+
+        return $this->encryptionKey;
+    }
+
+    private function getSignatureKey(): JWK
+    {
+        if ($this->signatureKey === null) {
+            $this->signatureKey = JWKFactory::createOctKey(512, [
+                'alg' => 'HS256',
+                'use' => 'sig',
+            ]);
+        }
+
+        return $this->signatureKey;
+    }
+
+    private function createToken(): string
+    {
+        $builderFactory = new NestedTokenBuilderFactory(
+            $this->getJWEBuilderFactory(),
+            $this->getJWESerializerManagerFactory(),
+            new JWSBuilderFactory($this->getSignatureAlgorithmManagerFactory()),
+            $this->getJWSSerializerManagerFactory()
+        );
+        $builder = $builderFactory->create(['jwe_compact'], ['A256KW', 'A256GCM'], ['jws_compact'], ['HS256']);
+
+        return $builder->create(
+            'Live long and prosper.',
+            [
+                [
+                    'key' => $this->getSignatureKey(),
+                    'protected_header' => [
+                        'alg' => 'HS256',
+                    ],
+                ],
+            ],
+            'jws_compact',
+            [
+                'alg' => 'A256KW',
+                'enc' => 'A256GCM',
+            ],
+            [],
+            [
+                [
+                    'key' => $this->getEncryptionKey(),
+                ],
+            ],
+            'jwe_compact'
+        );
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}

--- a/tests/Component/Signature/ResultObjectsTest.php
+++ b/tests/Component/Signature/ResultObjectsTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Signature;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSVerifier;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Throwable;
+use function count;
+use const E_USER_DEPRECATED;
+
+/**
+ * The methods that used to populate variables of the caller are deprecated and replaced with methods that return a
+ * result object. The deprecated methods are implemented on top of the new ones and keep their exact behaviour.
+ *
+ * @internal
+ */
+final class ResultObjectsTest extends SignatureTestCase
+{
+    #[Test]
+    public function theVerifierReturnsTheKeyThatVerifiedTheSignature(): void
+    {
+        $jws = $this->createJWS();
+        $result = $this->getVerifier()
+            ->verify($jws, $this->getKeySet(), 0);
+
+        static::assertTrue($result->isVerified());
+        static::assertSame(0, $result->getSignatureIndex());
+        static::assertSame($this->getKey()->all(), $result->getKey()?->all());
+    }
+
+    #[Test]
+    public function theVerifierAcceptsASingleKey(): void
+    {
+        $jws = $this->createJWS();
+        $result = $this->getVerifier()
+            ->verify($jws, $this->getKey(), 0);
+
+        static::assertTrue($result->isVerified());
+        static::assertSame($this->getKey()->all(), $result->getKey()?->all());
+    }
+
+    #[Test]
+    public function theVerifierReportsAFailureWithoutAnyKey(): void
+    {
+        $jws = $this->createJWS();
+        $result = $this->getVerifier()
+            ->verify($jws, new JWKSet([$this->getWrongKey()]), 0);
+
+        static::assertFalse($result->isVerified());
+        static::assertNull($result->getKey());
+        static::assertSame(0, $result->getSignatureIndex());
+    }
+
+    #[Test]
+    public function theVerifierReportsEveryDiscardedFailure(): void
+    {
+        $jws = $this->createJWS();
+        $errors = [];
+        $result = $this->getVerifier()
+            ->verify($jws, new JWKSet([$this->getWrongKey()]), 0, null, static function (
+                Throwable $throwable
+            ) use (&$errors): void {
+                $errors[] = $throwable->getMessage();
+            });
+
+        static::assertFalse($result->isVerified());
+        static::assertGreaterThan(0, count($errors));
+    }
+
+    #[Test]
+    public function theLoaderReturnsTheIndexOfTheVerifiedSignature(): void
+    {
+        $result = $this->getLoader()
+            ->loadAndVerify($this->createToken(), $this->getKeySet());
+
+        static::assertSame('Live long and prosper.', $result->getJws()->getPayload());
+        static::assertSame(0, $result->getSignatureIndex());
+        static::assertSame($this->getKey()->all(), $result->getKey()->all());
+    }
+
+    #[Test]
+    public function theLoaderAcceptsASingleKey(): void
+    {
+        $result = $this->getLoader()
+            ->loadAndVerify($this->createToken(), $this->getKey());
+
+        static::assertSame('Live long and prosper.', $result->getJws()->getPayload());
+    }
+
+    #[Test]
+    public function theSerializerManagerReturnsTheNameOfTheSerializer(): void
+    {
+        $result = $this->getJWSSerializerManager()
+            ->unserializeToken($this->createToken());
+
+        static::assertSame('jws_compact', $result->getSerializerName());
+        static::assertSame('Live long and prosper.', $result->getJws()->getPayload());
+    }
+
+    #[Test]
+    public function theDeprecatedVerifierMethodStillPopulatesTheKey(): void
+    {
+        $jws = $this->createJWS();
+        $jwk = null;
+        $verified = false;
+        $deprecations = $this->collectDeprecations(function () use ($jws, &$jwk, &$verified): void {
+            $verified = $this->getVerifier()
+                ->verifyWithKeySet($jws, $this->getKeySet(), 0, null, $jwk);
+        });
+
+        static::assertTrue($verified);
+        static::assertInstanceOf(JWK::class, $jwk);
+        static::assertSame($this->getKey()->all(), $jwk->all());
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('::verifyWithKeySet()" is deprecated', $deprecations[0]);
+    }
+
+    #[Test]
+    public function theVerificationWithASingleKeyIsNotDeprecated(): void
+    {
+        $jws = $this->createJWS();
+        $verified = false;
+        $deprecations = $this->collectDeprecations(function () use ($jws, &$verified): void {
+            $verified = $this->getVerifier()
+                ->verifyWithKey($jws, $this->getKey(), 0);
+        });
+
+        static::assertTrue($verified);
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function theDeprecatedLoaderMethodsStillPopulateTheSignatureIndex(): void
+    {
+        $token = $this->createToken();
+        $withKey = null;
+        $withKeySet = null;
+        $deprecations = $this->collectDeprecations(function () use ($token, &$withKey, &$withKeySet): void {
+            $this->getLoader()
+                ->loadAndVerifyWithKey($token, $this->getKey(), $withKey);
+            $this->getLoader()
+                ->loadAndVerifyWithKeySet($token, $this->getKeySet(), $withKeySet);
+        });
+
+        static::assertSame(0, $withKey);
+        static::assertSame(0, $withKeySet);
+        static::assertCount(3, $deprecations);
+        static::assertStringContainsString('::loadAndVerifyWithKey()" is deprecated', $deprecations[0]);
+        static::assertStringContainsString('::loadAndVerifyWithKeySet()" is deprecated', $deprecations[1]);
+        static::assertStringContainsString('::loadAndVerifyWithKeySet()" is deprecated', $deprecations[2]);
+    }
+
+    /**
+     * "loadAndVerifyWithKey()" delegated to "loadAndVerifyWithKeySet()" before 4.3.0. It still does, so that an
+     * object extending the loader and overriding the key set method keeps intercepting both.
+     */
+    #[Test]
+    public function theDeprecatedKeyMethodStillGoesThroughItsKeySetCounterpart(): void
+    {
+        $verifier = $this->getJWSVerifierFactory()
+            ->create(['HS256']);
+        $loader = new class($this->getJWSSerializerManager(), $verifier, null) extends JWSLoader {
+            public bool $keySetMethodWasCalled = false;
+
+            #[Override]
+            public function loadAndVerifyWithKeySet(
+                string $token,
+                JWKSet $keyset,
+                ?int &$signature,
+                ?string $payload = null
+            ): JWS {
+                $this->keySetMethodWasCalled = true;
+
+                return parent::loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
+            }
+        };
+
+        $index = null;
+        $loader->loadAndVerifyWithKey($this->createToken(), $this->getKey(), $index);
+
+        static::assertSame(0, $index);
+        static::assertTrue($loader->keySetMethodWasCalled);
+    }
+
+    #[Test]
+    public function onlyThePassedSerializerNameArgumentIsDeprecated(): void
+    {
+        $token = $this->createToken();
+        $name = null;
+        $deprecations = $this->collectDeprecations(function () use ($token, &$name): void {
+            $this->getJWSSerializerManager()
+                ->unserialize($token);
+            $this->getJWSSerializerManager()
+                ->unserialize($token, $name);
+        });
+
+        static::assertSame('jws_compact', $name);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Passing the "$name" argument', $deprecations[0]);
+    }
+
+    private function getVerifier(): JWSVerifier
+    {
+        return $this->getJWSVerifierFactory()
+            ->create(['HS256']);
+    }
+
+    private function getLoader(): JWSLoader
+    {
+        return $this->getJWSLoaderFactory()
+            ->create(['jws_compact'], ['HS256']);
+    }
+
+    private function getKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+    }
+
+    private function getWrongKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+        ]);
+    }
+
+    private function getKeySet(): JWKSet
+    {
+        return new JWKSet([$this->getWrongKey(), $this->getKey()]);
+    }
+
+    private function createJWS(): JWS
+    {
+        return $this->getJWSBuilderFactory()
+            ->create(['HS256'])
+            ->create()
+            ->withPayload('Live long and prosper.')
+            ->addSignature($this->getKey(), [
+                'alg' => 'HS256',
+            ])
+            ->build();
+    }
+
+    private function createToken(): string
+    {
+        return $this->getJWSSerializerManager()
+            ->serialize('jws_compact', $this->createJWS(), 0);
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}


### PR DESCRIPTION
Closes #685. Rebased on `4.3.x` after #709 (service interfaces), #707 (exception hierarchy) and #710.

## What changes

Readonly result objects replace the by-reference output parameters listed in the issue. The new methods sit next to the old ones, and the old ones are implemented on top of them, so nothing breaks.

| Before | After |
|---|---|
| `JWSVerifier::verifyWithKeySet($jws, $jwkset, 0, null, $jwk)` | `verify($jws, $keys, 0)` → `VerificationResult` |
| `JWEDecrypter::decryptUsingKey/KeySet($jwe, …)` | `decrypt($jwe, $keys, 0)` → `DecryptionResult` |
| `JWSLoader::loadAndVerifyWithKey/KeySet($token, …, $signature)` | `loadAndVerify($token, $keys)` → `LoadingResult` |
| `JWELoader::loadAndDecryptWithKey/KeySet($token, …, $recipient)` | `loadAndDecrypt($token, $keys)` → `LoadingResult` |
| `JWSSerializerManager::unserialize($input, $name)` | `unserializeToken($input)` → `UnserializationResult` |
| `JWESerializerManager::unserialize($input, $name)` | `unserializeToken($input)` → `UnserializationResult` |
| `NestedTokenLoader::load($token, …, $signature)` | `loadAndVerify($token, …)` → `LoadingResult` |

```php
$result = $jwsVerifier->verify($jws, $jwkset, 0);
if ($result->isVerified()) {
    $key = $result->getKey();
}

$result = $jweDecrypter->decrypt($jwe, $jwkset, 0);
if ($result->isDecrypted()) {
    $jwe = $result->getJwe();   // the JWE given to the decrypter is left untouched
}
```

Two other things the new methods gain:

- they accept a `JWK` as well as a `JWKSet`, so the `…WithKey()` / `…WithKeySet()` pairs collapse into one method;
- the callable that observes the keys discarded along the way — added in #698 behind `func_get_arg()` because a signature cannot change in a minor — is a declared argument of `verify()` and `decrypt()`.

The `$signature` / `$signatureIndex` docblock mismatch of `verifyWithKeySet()` is fixed on the docblock side: renaming the parameter would break callers already using named arguments.

## Backward compatibility

Audited against **4.2.1**, the last tag.

- **No signature changed.** A diff of every public and protected signature of the touched classes between `4.2.1` and this branch reports additions only. (The `getJwsVerifier()` / `getHeaderCheckerManager()` return types widen to the new interfaces, but that comes from #709, not from here.)
- **The bundle services keep every method they had.** They no longer *override* `verifyWithKeySet()`, `loadAndVerifyWithKeySet()`, `decryptUsingKeySet()`, `loadAndDecryptWithKeySet()` and `load()` — they override the new method instead — but the methods are inherited and reflection confirms identical signatures, parameter names, by-ref markers and defaults. Behaviour is preserved because the inherited method delegates to the overridden one, so the events are still dispatched.
- **The internal delegation is preserved.** `decryptUsingKey()` still routes through `decryptUsingKeySet()`, `loadAndVerifyWithKey()` through `loadAndVerifyWithKeySet()`, and `loadAndDecryptWithKey()` through `loadAndDecryptWithKeySet()`, exactly as in 4.2.1 — so an object that extends a service and overrides the key set method keeps intercepting both. Two tests pin that guarantee. The cost is that calling one of the `…WithKey()` methods emits the two deprecations of the chain.
- **One exception, deliberate:** `JWSVerifier::verifyWithKey()` now calls `verify()` instead of `verifyWithKeySet()`. It is the only method of the family that is *not* deprecated, so routing it through a deprecated one would emit a deprecation for supported code, for every caller. The consequence is narrow: a class that extends `JWSVerifier` and overrides only `verifyWithKeySet()` no longer intercepts `verifyWithKey()` — a pattern #709 already deprecates in the same release, via `InheritanceChecker`. Say the word and I flip it.
- **The interfaces are not published yet** (latest tag is 4.2.1), so slimming them breaks nothing.

## The interfaces of #709 carry the new API only

`JWSVerifierInterface`, `JWEDecrypterInterface`, `JWSLoaderInterface` and `JWELoaderInterface` gain the new method and **drop** the by-reference ones. Those interfaces ship in the same version as the deprecation, so there is no reason for them to be born carrying an API that is already on its way out.

The deprecated methods stay where the code that uses them actually is: on `JWSVerifier`, `JWEDecrypter`, `JWSLoader`, `JWELoader` and on the `EventDispatching*` decorators, so migrating from a deprecated bundle service to its decorator stays a drop-in move. They are simply not part of the contract an implementation has to honour, and the library itself never calls them through an interface.

`NestedTokenLoaderInterface` keeps `load()`: only its `$signature` argument is deprecated, not the method.

## Deprecations

`verifyWithKeySet()`, `decryptUsingKey()`, `decryptUsingKeySet()`, `loadAndVerifyWithKey()`, `loadAndVerifyWithKeySet()`, `loadAndDecryptWithKey()` and `loadAndDecryptWithKeySet()` trigger a deprecation and will be removed in 5.0.0. Their output parameter is required, so the methods cannot survive without it.

`JWSSerializerManager::unserialize()`, `JWESerializerManager::unserialize()` and `NestedTokenLoader::load()` keep working as they are: their output parameter is optional, so only *passing* it is deprecated, and only the argument goes away in 5.0.0. Calling `unserialize($input)` or `load($token, $encryptionKeySet, $signatureKeySet)` triggers nothing.

## Algorithm interfaces

As in #654, changing `encryptContent()`, `encryptKey()`, `wrapKey()` and `getAgreementKey()` cannot be done additively without breaking every third-party implementation. 4.3.0 only documents the signature they will have in 5.0.0 and ships the objects they will return: `EncryptedContent` (ciphertext + tag) and `WrappedKey` (key + additional header parameters).

## Bundle

Both families of services implement the new methods:

- the `EventDispatching*` decorators dispatch from the new method and implement the deprecated ones on top of it, so an event is dispatched exactly once whichever API the application uses;
- the deprecated inheritance-based services do the same, so they stay behaviourally identical to what they were.

## Two decisions worth a look

- **`decrypt()` does not throw on failure.** The issue's example has it throwing, but `decryptUsingKeySet()` already throws for an empty key set or a JWE without recipients, and those must keep propagating. A dedicated exception would be needed to tell "no key worked" apart from them; `isDecrypted()` keeps the old semantics, mirrors `isVerified()` and makes the deprecated method a two-line wrapper.
- **`NestedTokenLoader` is included** although it is not in the issue's table — its `load()` has the same `?int &$signature` idiom.

## Checks

- `phpunit`: 1039 tests green, including 25 new ones covering the result objects, the deprecations, the preserved delegation and the unchanged behaviour of the deprecated methods.
- `ecs`, `rector --dry-run`: clean on the touched files.
- `phpstan`: the output is identical to the one on a pristine `4.3.x` — no new error and no newly unmatched baseline entry. Nineteen baseline entries are dropped: the by-ref, `int|null` and `arguments.count` types they described are gone, `JWEDecrypter` now iterates `JWKSet::all()` instead of the `@internal` iterator, and the deprecated loader methods declare `@param-out int`.