### PR TITLE
feat(core): introduce interfaces for the main services

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -7,6 +7,46 @@ parameters:
 			path: ../src/Bundle/DataCollector/CheckerCollector.php
 
 		-
+			rawMessage: '''
+				Parameter $claimCheckerManager of method Jose\Bundle\JoseFramework\DataCollector\CheckerCollector::addClaimCheckerManager() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager:
+				since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: ../src/Bundle/DataCollector/CheckerCollector.php
+
+		-
+			rawMessage: '''
+				Parameter $headerCheckerManager of method Jose\Bundle\JoseFramework\DataCollector\CheckerCollector::addHeaderCheckerManager() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager:
+				since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: ../src/Bundle/DataCollector/CheckerCollector.php
+
+		-
+			rawMessage: '''
+				Property $claimCheckerManagers references deprecated class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager in its type:
+				since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: ../src/Bundle/DataCollector/CheckerCollector.php
+
+		-
+			rawMessage: '''
+				Property $headerCheckerManagers references deprecated class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager in its type:
+				since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: ../src/Bundle/DataCollector/CheckerCollector.php
+
+		-
 			rawMessage: 'Parameter #1 $data of method Jose\Bundle\JoseFramework\DataCollector\JWECollector::collectSupportedJWESerializations() expects array<string, array<string, mixed>>, array<string, mixed> given.'
 			identifier: argument.type
 			count: 1
@@ -247,6 +287,16 @@ parameters:
 			path: ../src/Bundle/DependencyInjection/Source/Checker/CheckerSource.php
 
 		-
+			rawMessage: '''
+				Access to constant on deprecated class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager:
+				since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 2
+			path: ../src/Bundle/DependencyInjection/Source/Checker/ClaimChecker.php
+
+		-
 			rawMessage: 'Argument of an invalid type mixed supplied for foreach, only iterables are supported.'
 			identifier: foreach.nonIterable
 			count: 2
@@ -255,7 +305,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'ClaimCheckerManager' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Checker/ClaimChecker.php
 
 		-
@@ -403,6 +453,16 @@ parameters:
 			path: ../src/Bundle/DependencyInjection/Source/Checker/ClaimChecker.php
 
 		-
+			rawMessage: '''
+				Access to constant on deprecated class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager:
+				since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 2
+			path: ../src/Bundle/DependencyInjection/Source/Checker/HeaderChecker.php
+
+		-
 			rawMessage: 'Argument of an invalid type mixed supplied for foreach, only iterables are supported.'
 			identifier: foreach.nonIterable
 			count: 2
@@ -411,7 +471,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'HeaderCheckerManager' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Checker/HeaderChecker.php
 
 		-
@@ -771,7 +831,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'JweBuilder' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Encryption/JWEBuilder.php
 
 		-
@@ -831,7 +891,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'JweDecrypter' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Encryption/JWEDecrypter.php
 
 		-
@@ -891,7 +951,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'JweLoader' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Encryption/JWELoader.php
 
 		-
@@ -2379,7 +2439,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'NestedTokenBuilder' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
 
 		-
@@ -2559,7 +2619,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'NestedTokenLoader' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
 
 		-
@@ -2853,7 +2913,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'JwsBuilder' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Signature/JWSBuilder.php
 
 		-
@@ -2913,7 +2973,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'JwsLoader' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Signature/JWSLoader.php
 
 		-
@@ -3249,7 +3309,7 @@ parameters:
 		-
 			rawMessage: Binary operation "." between mixed and 'JwsVerifier' results in an error.
 			identifier: binaryOp.invalid
-			count: 1
+			count: 2
 			path: ../src/Bundle/DependencyInjection/Source/Signature/JWSVerifier.php
 
 		-
@@ -3727,22 +3787,186 @@ parameters:
 			path: ../src/Bundle/Serializer/JWSSerializer.php
 
 		-
-			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\ClaimCheckerManager::check() has parameter $claims with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager extends @final class Jose\Component\Checker\ClaimCheckerManager.
+			identifier: class.extendsFinalByPhpDoc
 			count: 1
 			path: ../src/Bundle/Services/ClaimCheckerManager.php
 
 		-
-			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\ClaimCheckerManager::check() return type has no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager:
+				since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
 			count: 1
-			path: ../src/Bundle/Services/ClaimCheckerManager.php
+			path: ../src/Bundle/Services/ClaimCheckerManagerFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager:
+				since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/ClaimCheckerManagerFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\ClaimCheckerManagerFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\ClaimCheckerManager:
+				since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/ClaimCheckerManagerFactory.php
+
+		-
+			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypterInterface::decryptUsingKeySet() invoked with 6 parameters, 3-5 required.'
+			identifier: arguments.count
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingJWEDecrypter.php
+
+		-
+			rawMessage: 'Parameter #3 $JWK of class Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingJWEDecrypter.php
+
+		-
+			rawMessage: 'Parameter #4 $recipient of class Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent constructor expects int, int|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingJWELoader.php
+
+		-
+			rawMessage: 'Parameter #4 $signature of class Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent constructor expects int, int|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingJWSLoader.php
+
+		-
+			rawMessage: 'Method Jose\Component\Signature\JWSVerifierInterface::verifyWithKeySet() invoked with 6 parameters, 3-5 required.'
+			identifier: arguments.count
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingJWSVerifier.php
+
+		-
+			rawMessage: 'Parameter #5 $JWK of class Jose\Bundle\JoseFramework\Event\JWSVerificationSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingJWSVerifier.php
+
+		-
+			rawMessage: 'Parameter #5 $signature of class Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent constructor expects int, int|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Bundle/Services/EventDispatchingNestedTokenLoader.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager extends @final class Jose\Component\Checker\HeaderCheckerManager.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/HeaderCheckerManager.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager:
+				since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/HeaderCheckerManagerFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager:
+				since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/HeaderCheckerManagerFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\HeaderCheckerManagerFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\HeaderCheckerManager:
+				since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/HeaderCheckerManagerFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWEBuilder extends @final class Jose\Component\Encryption\JWEBuilder.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/JWEBuilder.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWEBuilder:
+				since 4.3.0, use EventDispatchingJWEBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWEBuilderFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\JWEBuilder:
+				since 4.3.0, use EventDispatchingJWEBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWEBuilderFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\JWEBuilderFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\JWEBuilder:
+				since 4.3.0, use EventDispatchingJWEBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWEBuilderFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWEDecrypter extends @final class Jose\Component\Encryption\JWEDecrypter.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/JWEDecrypter.php
 
 		-
 			rawMessage: 'Parameter #3 $JWK of class Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWEDecrypter.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWEDecrypter:
+				since 4.3.0, use EventDispatchingJWEDecrypter instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWEDecrypterFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\JWEDecrypter:
+				since 4.3.0, use EventDispatchingJWEDecrypter instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWEDecrypterFactory.php
 
 		-
 			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\JWEDecrypterFactory::create() has parameter $encryptionAlgorithms with no value type specified in iterable type array.'
@@ -3757,16 +3981,124 @@ parameters:
 			path: ../src/Bundle/Services/JWEDecrypterFactory.php
 
 		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\JWEDecrypterFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\JWEDecrypter:
+				since 4.3.0, use EventDispatchingJWEDecrypter instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWEDecrypterFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWELoader extends @final class Jose\Component\Encryption\JWELoader.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/JWELoader.php
+
+		-
 			rawMessage: 'Parameter #4 $recipient of class Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent constructor expects int, int|null given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWELoader.php
 
 		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWELoader:
+				since 4.3.0, use EventDispatchingJWELoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWELoaderFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\JWELoader:
+				since 4.3.0, use EventDispatchingJWELoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWELoaderFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\JWELoaderFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\JWELoader:
+				since 4.3.0, use EventDispatchingJWELoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWELoaderFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWSBuilder extends @final class Jose\Component\Signature\JWSBuilder.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/JWSBuilder.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWSBuilder:
+				since 4.3.0, use EventDispatchingJWSBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSBuilderFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\JWSBuilder:
+				since 4.3.0, use EventDispatchingJWSBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSBuilderFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\JWSBuilderFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\JWSBuilder:
+				since 4.3.0, use EventDispatchingJWSBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSBuilderFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWSLoader extends @final class Jose\Component\Signature\JWSLoader.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/JWSLoader.php
+
+		-
 			rawMessage: 'Parameter #4 $signature of class Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent constructor expects int, int|null given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWSLoader.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWSLoader:
+				since 4.3.0, use EventDispatchingJWSLoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSLoaderFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\JWSLoader:
+				since 4.3.0, use EventDispatchingJWSLoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSLoaderFactory.php
 
 		-
 			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\JWSLoaderFactory::create() has parameter $algorithms with no value type specified in iterable type array.'
@@ -3799,10 +4131,46 @@ parameters:
 			path: ../src/Bundle/Services/JWSLoaderFactory.php
 
 		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\JWSLoaderFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\JWSLoader:
+				since 4.3.0, use EventDispatchingJWSLoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSLoaderFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\JWSVerifier extends @final class Jose\Component\Signature\JWSVerifier.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/JWSVerifier.php
+
+		-
 			rawMessage: 'Parameter #5 $JWK of class Jose\Bundle\JoseFramework\Event\JWSVerificationSuccessEvent constructor expects Jose\Component\Core\JWK, Jose\Component\Core\JWK|null given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWSVerifier.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\JWSVerifier:
+				since 4.3.0, use EventDispatchingJWSVerifier instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSVerifierFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\JWSVerifier:
+				since 4.3.0, use EventDispatchingJWSVerifier instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSVerifierFactory.php
 
 		-
 			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\JWSVerifierFactory::create() has parameter $algorithms with no value type specified in iterable type array.'
@@ -3815,6 +4183,42 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/JWSVerifierFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\JWSVerifierFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\JWSVerifier:
+				since 4.3.0, use EventDispatchingJWSVerifier instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/JWSVerifierFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\NestedTokenBuilder extends @final class Jose\Component\NestedToken\NestedTokenBuilder.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenBuilder.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\NestedTokenBuilder:
+				since 4.3.0, use EventDispatchingNestedTokenBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenBuilderFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\NestedTokenBuilder:
+				since 4.3.0, use EventDispatchingNestedTokenBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenBuilderFactory.php
 
 		-
 			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\NestedTokenBuilderFactory::create() has parameter $encryptionAlgorithms with no value type specified in iterable type array.'
@@ -3865,10 +4269,46 @@ parameters:
 			path: ../src/Bundle/Services/NestedTokenBuilderFactory.php
 
 		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\NestedTokenBuilderFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\NestedTokenBuilder:
+				since 4.3.0, use EventDispatchingNestedTokenBuilder instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenBuilderFactory.php
+
+		-
+			rawMessage: Class Jose\Bundle\JoseFramework\Services\NestedTokenLoader extends @final class Jose\Component\NestedToken\NestedTokenLoader.
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenLoader.php
+
+		-
 			rawMessage: 'Parameter #5 $signature of class Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent constructor expects int, int|null given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Bundle/Services/NestedTokenLoader.php
+
+		-
+			rawMessage: '''
+				Call to method __construct() of deprecated class Jose\Bundle\JoseFramework\Services\NestedTokenLoader:
+				since 4.3.0, use EventDispatchingNestedTokenLoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenLoaderFactory.php
+
+		-
+			rawMessage: '''
+				Instantiation of deprecated class Jose\Bundle\JoseFramework\Services\NestedTokenLoader:
+				since 4.3.0, use EventDispatchingNestedTokenLoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenLoaderFactory.php
 
 		-
 			rawMessage: 'Method Jose\Bundle\JoseFramework\Services\NestedTokenLoaderFactory::create() has parameter $encryptionAlgorithms with no value type specified in iterable type array.'
@@ -3925,6 +4365,16 @@ parameters:
 			path: ../src/Bundle/Services/NestedTokenLoaderFactory.php
 
 		-
+			rawMessage: '''
+				Return type of method Jose\Bundle\JoseFramework\Services\NestedTokenLoaderFactory::create() has typehint with deprecated class Jose\Bundle\JoseFramework\Services\NestedTokenLoader:
+				since 4.3.0, use EventDispatchingNestedTokenLoader instead. The class extends a service of
+				the library that will be final in 5.0.0.
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: ../src/Bundle/Services/NestedTokenLoaderFactory.php
+
+		-
 			rawMessage: 'Call to function is_string() with null will always evaluate to false.'
 			identifier: function.impossibleType
 			count: 1
@@ -3935,18 +4385,6 @@ parameters:
 			identifier: throw.notThrowable
 			count: 3
 			path: ../src/Library/Checker/AudienceChecker.php
-
-		-
-			rawMessage: 'Method Jose\Component\Checker\ClaimCheckerManager::check() has parameter $claims with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Checker/ClaimCheckerManager.php
-
-		-
-			rawMessage: 'Method Jose\Component\Checker\ClaimCheckerManager::check() return type has no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Checker/ClaimCheckerManager.php
 
 		-
 			rawMessage: 'Method Jose\Component\Checker\ClaimCheckerManager::checkMandatoryClaims() has parameter $claims with no value type specified in iterable type array.'
@@ -4555,6 +4993,12 @@ parameters:
 			path: ../src/Library/Encryption/JWEDecrypter.php
 
 		-
+			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypterInterface::decryptUsingKeySet() invoked with 6 parameters, 3-5 required.'
+			identifier: arguments.count
+			count: 1
+			path: ../src/Library/Encryption/JWELoader.php
+
+		-
 			rawMessage: 'Method Jose\Component\Encryption\JWELoaderFactory::create() has parameter $encryptionAlgorithms with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -5021,6 +5465,12 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: ../src/Library/Signature/Algorithm/Util/RSA.php
+
+		-
+			rawMessage: 'Method Jose\Component\Signature\JWSVerifierInterface::verifyWithKeySet() invoked with 6 parameters, 3-5 required.'
+			identifier: arguments.count
+			count: 1
+			path: ../src/Library/Signature/JWSLoader.php
 
 		-
 			rawMessage: 'Parameter #1 $algorithm of method Jose\Component\Core\AlgorithmManager::get() expects string, mixed given.'

--- a/src/Bundle/DependencyInjection/Source/Checker/ClaimChecker.php
+++ b/src/Bundle/DependencyInjection/Source/Checker/ClaimChecker.php
@@ -7,6 +7,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Checker;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\ClaimCheckerManager;
 use Jose\Bundle\JoseFramework\Services\ClaimCheckerManagerFactory;
+use Jose\Component\Checker\ClaimCheckerManagerInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -40,6 +41,11 @@ final readonly class ClaimChecker implements Source
             $container->registerAliasForArgument(
                 $service_id,
                 ClaimCheckerManager::class,
+                $name . 'ClaimCheckerManager'
+            );
+            $container->registerAliasForArgument(
+                $service_id,
+                ClaimCheckerManagerInterface::class,
                 $name . 'ClaimCheckerManager'
             );
         }

--- a/src/Bundle/DependencyInjection/Source/Checker/HeaderChecker.php
+++ b/src/Bundle/DependencyInjection/Source/Checker/HeaderChecker.php
@@ -7,6 +7,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Checker;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\HeaderCheckerManager;
 use Jose\Bundle\JoseFramework\Services\HeaderCheckerManagerFactory;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -40,6 +41,11 @@ final readonly class HeaderChecker implements Source
             $container->registerAliasForArgument(
                 $service_id,
                 HeaderCheckerManager::class,
+                $name . 'HeaderCheckerManager'
+            );
+            $container->registerAliasForArgument(
+                $service_id,
+                HeaderCheckerManagerInterface::class,
                 $name . 'HeaderCheckerManager'
             );
         }

--- a/src/Bundle/DependencyInjection/Source/Encryption/JWEBuilder.php
+++ b/src/Bundle/DependencyInjection/Source/Encryption/JWEBuilder.php
@@ -6,6 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Encryption;
 
 use Jose\Bundle\JoseFramework\Services\JWEBuilderFactory;
 use Jose\Component\Encryption\JWEBuilder as JWEBuilderService;
+use Jose\Component\Encryption\JWEBuilderInterface;
 use Override;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -36,6 +37,7 @@ final readonly class JWEBuilder extends AbstractEncryptionSource
             }
             $container->setDefinition($service_id, $definition);
             $container->registerAliasForArgument($service_id, JWEBuilderService::class, $name . 'JweBuilder');
+            $container->registerAliasForArgument($service_id, JWEBuilderInterface::class, $name . 'JweBuilder');
         }
     }
 }

--- a/src/Bundle/DependencyInjection/Source/Encryption/JWEDecrypter.php
+++ b/src/Bundle/DependencyInjection/Source/Encryption/JWEDecrypter.php
@@ -6,6 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Encryption;
 
 use Jose\Bundle\JoseFramework\Services\JWEDecrypterFactory;
 use Jose\Component\Encryption\JWEDecrypter as JWEDecrypterService;
+use Jose\Component\Encryption\JWEDecrypterInterface;
 use Override;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -36,6 +37,7 @@ final readonly class JWEDecrypter extends AbstractEncryptionSource
             }
             $container->setDefinition($service_id, $definition);
             $container->registerAliasForArgument($service_id, JWEDecrypterService::class, $name . 'JweDecrypter');
+            $container->registerAliasForArgument($service_id, JWEDecrypterInterface::class, $name . 'JweDecrypter');
         }
     }
 }

--- a/src/Bundle/DependencyInjection/Source/Encryption/JWELoader.php
+++ b/src/Bundle/DependencyInjection/Source/Encryption/JWELoader.php
@@ -7,6 +7,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Encryption;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\JWELoaderFactory;
 use Jose\Component\Encryption\JWELoader as JWELoaderService;
+use Jose\Component\Encryption\JWELoaderInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,6 +44,7 @@ final readonly class JWELoader implements Source
 
             $container->setDefinition($service_id, $definition);
             $container->registerAliasForArgument($service_id, JWELoaderService::class, $name . 'JweLoader');
+            $container->registerAliasForArgument($service_id, JWELoaderInterface::class, $name . 'JweLoader');
         }
     }
 

--- a/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
+++ b/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenBuilder.php
@@ -7,6 +7,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\NestedToken;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\NestedTokenBuilderFactory;
 use Jose\Component\NestedToken\NestedTokenBuilder as NestedTokenBuilderService;
+use Jose\Component\NestedToken\NestedTokenBuilderInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -45,6 +46,11 @@ final readonly class NestedTokenBuilder implements Source
             $container->registerAliasForArgument(
                 $service_id,
                 NestedTokenBuilderService::class,
+                $name . 'NestedTokenBuilder'
+            );
+            $container->registerAliasForArgument(
+                $service_id,
+                NestedTokenBuilderInterface::class,
                 $name . 'NestedTokenBuilder'
             );
         }

--- a/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
+++ b/src/Bundle/DependencyInjection/Source/NestedToken/NestedTokenLoader.php
@@ -7,6 +7,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\NestedToken;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\NestedTokenLoaderFactory;
 use Jose\Component\NestedToken\NestedTokenLoader as NestedTokenLoaderService;
+use Jose\Component\NestedToken\NestedTokenLoaderInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -47,6 +48,11 @@ final readonly class NestedTokenLoader implements Source
             $container->registerAliasForArgument(
                 $service_id,
                 NestedTokenLoaderService::class,
+                $name . 'NestedTokenLoader'
+            );
+            $container->registerAliasForArgument(
+                $service_id,
+                NestedTokenLoaderInterface::class,
                 $name . 'NestedTokenLoader'
             );
         }

--- a/src/Bundle/DependencyInjection/Source/Signature/JWSBuilder.php
+++ b/src/Bundle/DependencyInjection/Source/Signature/JWSBuilder.php
@@ -6,6 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Signature;
 
 use Jose\Bundle\JoseFramework\Services\JWSBuilderFactory;
 use Jose\Component\Signature\JWSBuilder as JWSBuilderService;
+use Jose\Component\Signature\JWSBuilderInterface;
 use Override;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -36,6 +37,7 @@ final readonly class JWSBuilder extends AbstractSignatureSource
             }
             $container->setDefinition($service_id, $definition);
             $container->registerAliasForArgument($service_id, JWSBuilderService::class, $name . 'JwsBuilder');
+            $container->registerAliasForArgument($service_id, JWSBuilderInterface::class, $name . 'JwsBuilder');
         }
     }
 }

--- a/src/Bundle/DependencyInjection/Source/Signature/JWSLoader.php
+++ b/src/Bundle/DependencyInjection/Source/Signature/JWSLoader.php
@@ -7,6 +7,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Signature;
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\Source;
 use Jose\Bundle\JoseFramework\Services\JWSLoaderFactory;
 use Jose\Component\Signature\JWSLoader as JWSLoaderService;
+use Jose\Component\Signature\JWSLoaderInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,6 +44,7 @@ final readonly class JWSLoader implements Source
 
             $container->setDefinition($service_id, $definition);
             $container->registerAliasForArgument($service_id, JWSLoaderService::class, $name . 'JwsLoader');
+            $container->registerAliasForArgument($service_id, JWSLoaderInterface::class, $name . 'JwsLoader');
         }
     }
 

--- a/src/Bundle/DependencyInjection/Source/Signature/JWSVerifier.php
+++ b/src/Bundle/DependencyInjection/Source/Signature/JWSVerifier.php
@@ -6,6 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\Signature;
 
 use Jose\Bundle\JoseFramework\Services\JWSVerifierFactory;
 use Jose\Component\Signature\JWSVerifier as JWSVerifierService;
+use Jose\Component\Signature\JWSVerifierInterface;
 use Override;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -36,6 +37,7 @@ final readonly class JWSVerifier extends AbstractSignatureSource
             }
             $container->setDefinition($service_id, $definition);
             $container->registerAliasForArgument($service_id, JWSVerifierService::class, $name . 'JwsVerifier');
+            $container->registerAliasForArgument($service_id, JWSVerifierInterface::class, $name . 'JwsVerifier');
         }
     }
 }

--- a/src/Bundle/Services/EventDispatchingClaimCheckerManager.php
+++ b/src/Bundle/Services/EventDispatchingClaimCheckerManager.php
@@ -6,29 +6,33 @@ namespace Jose\Bundle\JoseFramework\Services;
 
 use Jose\Bundle\JoseFramework\Event\ClaimCheckedFailureEvent;
 use Jose\Bundle\JoseFramework\Event\ClaimCheckedSuccessEvent;
-use Jose\Component\Checker\ClaimCheckerManager as BaseClaimCheckerManager;
+use Jose\Component\Checker\ClaimCheckerManagerInterface;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
 /**
- * @deprecated since 4.3.0, use EventDispatchingClaimCheckerManager instead. The class extends a service of
- * the library that will be final in 5.0.0.
+ * Dispatches an event whenever claims are checked, without extending the manager it decorates.
  */
-final class ClaimCheckerManager extends BaseClaimCheckerManager
+final readonly class EventDispatchingClaimCheckerManager implements ClaimCheckerManagerInterface
 {
     public function __construct(
-        $checkers,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private ClaimCheckerManagerInterface $manager,
+        private EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($checkers);
+    }
+
+    #[Override]
+    public function getCheckers(): array
+    {
+        return $this->manager->getCheckers();
     }
 
     #[Override]
     public function check(array $claims, array $mandatoryClaims = []): array
     {
         try {
-            $checkedClaims = BaseClaimCheckerManager::check($claims, $mandatoryClaims);
+            $checkedClaims = $this->manager->check($claims, $mandatoryClaims);
             $this->eventDispatcher->dispatch(
                 new ClaimCheckedSuccessEvent($claims, $mandatoryClaims, $checkedClaims)
             );

--- a/src/Bundle/Services/EventDispatchingHeaderCheckerManager.php
+++ b/src/Bundle/Services/EventDispatchingHeaderCheckerManager.php
@@ -6,31 +6,34 @@ namespace Jose\Bundle\JoseFramework\Services;
 
 use Jose\Bundle\JoseFramework\Event\HeaderCheckedFailureEvent;
 use Jose\Bundle\JoseFramework\Event\HeaderCheckedSuccessEvent;
-use Jose\Component\Checker\HeaderCheckerManager as BaseHeaderCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
 use Jose\Component\Core\JWT;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
 /**
- * @deprecated since 4.3.0, use EventDispatchingHeaderCheckerManager instead. The class extends a service of
- * the library that will be final in 5.0.0.
+ * Dispatches an event whenever header parameters are checked, without extending the manager it decorates.
  */
-final class HeaderCheckerManager extends BaseHeaderCheckerManager
+final readonly class EventDispatchingHeaderCheckerManager implements HeaderCheckerManagerInterface
 {
     public function __construct(
-        array $checkers,
-        array $tokenTypes,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private HeaderCheckerManagerInterface $manager,
+        private EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($checkers, $tokenTypes);
+    }
+
+    #[Override]
+    public function getCheckers(): array
+    {
+        return $this->manager->getCheckers();
     }
 
     #[Override]
     public function check(JWT $jwt, int $index, array $mandatoryHeaderParameters = []): void
     {
         try {
-            BaseHeaderCheckerManager::check($jwt, $index, $mandatoryHeaderParameters);
+            $this->manager->check($jwt, $index, $mandatoryHeaderParameters);
             $this->eventDispatcher->dispatch(
                 new HeaderCheckedSuccessEvent($jwt, $index, $mandatoryHeaderParameters)
             );

--- a/src/Bundle/Services/EventDispatchingJWEBuilder.php
+++ b/src/Bundle/Services/EventDispatchingJWEBuilder.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWEBuiltFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWEBuiltSuccessEvent;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEBuilderInterface;
+use Override;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Throwable;
+
+/**
+ * Dispatches an event whenever a JWE is built, without extending the builder it decorates.
+ *
+ * The decorator keeps the arguments it is given so that the failure event can be populated: the state of the decorated
+ * builder is private and, unlike the deprecated JWEBuilder of this namespace, a decorator cannot read it. The
+ * recipients it reports therefore describe the key and the header that were passed, and not the key encryption
+ * algorithm the builder resolved from them.
+ */
+final readonly class EventDispatchingJWEBuilder implements JWEBuilderInterface
+{
+    /**
+     * @param array<array{key: JWK, header: array<string, mixed>}> $recipients
+     * @param array<string, mixed> $sharedProtectedHeader
+     * @param array<string, mixed> $sharedHeader
+     */
+    public function __construct(
+        private JWEBuilderInterface $builder,
+        private EventDispatcherInterface $eventDispatcher,
+        private ?string $payload = null,
+        private array $recipients = [],
+        private array $sharedProtectedHeader = [],
+        private array $sharedHeader = [],
+        private ?string $aad = null
+    ) {
+    }
+
+    #[Override]
+    public function getKeyEncryptionAlgorithmManager(): AlgorithmManager
+    {
+        return $this->builder->getKeyEncryptionAlgorithmManager();
+    }
+
+    #[Override]
+    public function getContentEncryptionAlgorithmManager(): AlgorithmManager
+    {
+        return $this->builder->getContentEncryptionAlgorithmManager();
+    }
+
+    #[Override]
+    public function withPayload(string $payload): self
+    {
+        return new self(
+            $this->builder->withPayload($payload),
+            $this->eventDispatcher,
+            $payload,
+            $this->recipients,
+            $this->sharedProtectedHeader,
+            $this->sharedHeader,
+            $this->aad
+        );
+    }
+
+    #[Override]
+    public function withAAD(?string $aad): self
+    {
+        return new self(
+            $this->builder->withAAD($aad),
+            $this->eventDispatcher,
+            $this->payload,
+            $this->recipients,
+            $this->sharedProtectedHeader,
+            $this->sharedHeader,
+            $aad
+        );
+    }
+
+    #[Override]
+    public function withSharedProtectedHeader(array $sharedProtectedHeader): self
+    {
+        return new self(
+            $this->builder->withSharedProtectedHeader($sharedProtectedHeader),
+            $this->eventDispatcher,
+            $this->payload,
+            $this->recipients,
+            $sharedProtectedHeader,
+            $this->sharedHeader,
+            $this->aad
+        );
+    }
+
+    #[Override]
+    public function withSharedHeader(array $sharedHeader): self
+    {
+        return new self(
+            $this->builder->withSharedHeader($sharedHeader),
+            $this->eventDispatcher,
+            $this->payload,
+            $this->recipients,
+            $this->sharedProtectedHeader,
+            $sharedHeader,
+            $this->aad
+        );
+    }
+
+    #[Override]
+    public function addRecipient(JWK $recipientKey, array $recipientHeader = []): self
+    {
+        return new self(
+            $this->builder->addRecipient($recipientKey, $recipientHeader),
+            $this->eventDispatcher,
+            $this->payload,
+            [...$this->recipients, [
+                'key' => $recipientKey,
+                'header' => $recipientHeader,
+            ]],
+            $this->sharedProtectedHeader,
+            $this->sharedHeader,
+            $this->aad
+        );
+    }
+
+    #[Override]
+    public function withSenderKey(JWK $senderKey): self
+    {
+        return new self(
+            $this->builder->withSenderKey($senderKey),
+            $this->eventDispatcher,
+            $this->payload,
+            $this->recipients,
+            $this->sharedProtectedHeader,
+            $this->sharedHeader,
+            $this->aad
+        );
+    }
+
+    #[Override]
+    public function build(): JWE
+    {
+        try {
+            $jwe = $this->builder->build();
+            $this->eventDispatcher->dispatch(new JWEBuiltSuccessEvent($jwe));
+
+            return $jwe;
+        } catch (Throwable $throwable) {
+            $this->eventDispatcher->dispatch(new JWEBuiltFailureEvent(
+                $this->payload,
+                $this->recipients,
+                $this->sharedProtectedHeader,
+                $this->sharedHeader,
+                $this->aad,
+                $throwable
+            ));
+
+            throw $throwable;
+        }
+    }
+}

--- a/src/Bundle/Services/EventDispatchingJWEDecrypter.php
+++ b/src/Bundle/Services/EventDispatchingJWEDecrypter.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWEDecryptionFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEDecrypterInterface;
+use Override;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use function func_get_arg;
+use function func_num_args;
+
+/**
+ * Dispatches an event whenever a recipient is decrypted, without extending the decrypter it decorates.
+ */
+final readonly class EventDispatchingJWEDecrypter implements JWEDecrypterInterface
+{
+    public function __construct(
+        private JWEDecrypterInterface $decrypter,
+        private EventDispatcherInterface $eventDispatcher
+    ) {
+    }
+
+    #[Override]
+    public function getKeyEncryptionAlgorithmManager(): AlgorithmManager
+    {
+        return $this->decrypter->getKeyEncryptionAlgorithmManager();
+    }
+
+    #[Override]
+    public function getContentEncryptionAlgorithmManager(): AlgorithmManager
+    {
+        return $this->decrypter->getContentEncryptionAlgorithmManager();
+    }
+
+    #[Override]
+    public function decryptUsingKey(JWE &$jwe, JWK $jwk, int $recipient, ?JWK $senderKey = null): bool
+    {
+        $jwkset = new JWKSet([$jwk]);
+        $successJwk = null;
+
+        return $this->decryptUsingKeySet($jwe, $jwkset, $recipient, $successJwk, $senderKey);
+    }
+
+    /**
+     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet: it is
+     * read with func_num_args()/func_get_arg(5) and forwarded to the decorated decrypter, otherwise the reason of a
+     * failure would be lost as soon as the decrypter is decorated.
+     */
+    #[Override]
+    public function decryptUsingKeySet(
+        JWE &$jwe,
+        JWKSet $jwkset,
+        int $recipient,
+        ?JWK &$jwk = null,
+        ?JWK $senderKey = null
+    ): bool {
+        $success = func_num_args() >= 6 ? $this->decrypter->decryptUsingKeySet(
+            $jwe,
+            $jwkset,
+            $recipient,
+            $jwk,
+            $senderKey,
+            func_get_arg(5)
+        ) : $this->decrypter->decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);
+
+        if ($success) {
+            $this->eventDispatcher->dispatch(new JWEDecryptionSuccessEvent($jwe, $jwkset, $jwk, $recipient));
+        } else {
+            $this->eventDispatcher->dispatch(new JWEDecryptionFailureEvent($jwe, $jwkset));
+        }
+
+        return $success;
+    }
+}

--- a/src/Bundle/Services/EventDispatchingJWELoader.php
+++ b/src/Bundle/Services/EventDispatchingJWELoader.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWELoadingFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEDecrypterInterface;
+use Jose\Component\Encryption\JWELoaderInterface;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use Override;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Throwable;
+
+/**
+ * Dispatches an event whenever a JWE is loaded, without extending the loader it decorates.
+ */
+final readonly class EventDispatchingJWELoader implements JWELoaderInterface
+{
+    public function __construct(
+        private JWELoaderInterface $loader,
+        private EventDispatcherInterface $eventDispatcher
+    ) {
+    }
+
+    #[Override]
+    public function getJweDecrypter(): JWEDecrypterInterface
+    {
+        return $this->loader->getJweDecrypter();
+    }
+
+    #[Override]
+    public function getHeaderCheckerManager(): ?HeaderCheckerManagerInterface
+    {
+        return $this->loader->getHeaderCheckerManager();
+    }
+
+    #[Override]
+    public function getSerializerManager(): JWESerializerManager
+    {
+        return $this->loader->getSerializerManager();
+    }
+
+    #[Override]
+    public function loadAndDecryptWithKey(string $token, JWK $key, ?int &$recipient): JWE
+    {
+        $keyset = new JWKSet([$key]);
+
+        return $this->loadAndDecryptWithKeySet($token, $keyset, $recipient);
+    }
+
+    #[Override]
+    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE
+    {
+        try {
+            $jwe = $this->loader->loadAndDecryptWithKeySet($token, $keyset, $recipient);
+            $this->eventDispatcher->dispatch(new JWELoadingSuccessEvent($token, $jwe, $keyset, $recipient));
+
+            return $jwe;
+        } catch (Throwable $throwable) {
+            $this->eventDispatcher->dispatch(new JWELoadingFailureEvent($token, $keyset, $throwable));
+
+            throw $throwable;
+        }
+    }
+}

--- a/src/Bundle/Services/EventDispatchingJWSBuilder.php
+++ b/src/Bundle/Services/EventDispatchingJWSBuilder.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWSBuiltFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWSBuiltSuccessEvent;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSBuilderInterface;
+use Override;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Throwable;
+use function array_key_exists;
+
+/**
+ * Dispatches an event whenever a JWS is built, without extending the builder it decorates.
+ *
+ * The decorator keeps the arguments it is given so that the failure event can be populated: the state of the decorated
+ * builder is private and, unlike the deprecated JWSBuilder of this namespace, a decorator cannot read it. The
+ * signatures it reports therefore describe the key and the headers that were passed, and not the signature algorithm
+ * the builder resolved from them.
+ */
+final readonly class EventDispatchingJWSBuilder implements JWSBuilderInterface
+{
+    /**
+     * @param array<array{signature_key: JWK, protected_header: array<string, mixed>, header: array<string, mixed>}> $signatures
+     */
+    public function __construct(
+        private JWSBuilderInterface $builder,
+        private EventDispatcherInterface $eventDispatcher,
+        private ?string $payload = null,
+        private array $signatures = [],
+        private bool $isPayloadDetached = false,
+        private ?bool $isPayloadEncoded = null
+    ) {
+    }
+
+    #[Override]
+    public function getSignatureAlgorithmManager(): AlgorithmManager
+    {
+        return $this->builder->getSignatureAlgorithmManager();
+    }
+
+    #[Override]
+    public function withPayload(string $payload, bool $isPayloadDetached = false): self
+    {
+        return new self(
+            $this->builder->withPayload($payload, $isPayloadDetached),
+            $this->eventDispatcher,
+            $payload,
+            $this->signatures,
+            $isPayloadDetached,
+            $this->isPayloadEncoded
+        );
+    }
+
+    #[Override]
+    public function withEncodedPayload(string $payload, bool $isPayloadDetached = false): self
+    {
+        return new self(
+            $this->builder->withEncodedPayload($payload, $isPayloadDetached),
+            $this->eventDispatcher,
+            Base64UrlSafe::decodeNoPadding($payload),
+            $this->signatures,
+            $isPayloadDetached,
+            $this->isPayloadEncoded
+        );
+    }
+
+    #[Override]
+    public function addSignature(JWK $signatureKey, array $protectedHeader, array $header = []): self
+    {
+        $builder = $this->builder->addSignature($signatureKey, $protectedHeader, $header);
+
+        return new self(
+            $builder,
+            $this->eventDispatcher,
+            $this->payload,
+            [...$this->signatures, [
+                'signature_key' => $signatureKey,
+                'protected_header' => $protectedHeader,
+                'header' => $header,
+            ]],
+            $this->isPayloadDetached,
+            $this->isPayloadEncoded ?? (! array_key_exists('b64', $protectedHeader) || $protectedHeader['b64'] === true)
+        );
+    }
+
+    #[Override]
+    public function build(): JWS
+    {
+        try {
+            $jws = $this->builder->build();
+            $this->eventDispatcher->dispatch(new JWSBuiltSuccessEvent($jws));
+
+            return $jws;
+        } catch (Throwable $throwable) {
+            $this->eventDispatcher->dispatch(new JWSBuiltFailureEvent(
+                $this->payload,
+                $this->signatures,
+                $this->isPayloadDetached,
+                $this->isPayloadEncoded,
+                $throwable
+            ));
+
+            throw $throwable;
+        }
+    }
+}

--- a/src/Bundle/Services/EventDispatchingJWSLoader.php
+++ b/src/Bundle/Services/EventDispatchingJWSLoader.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWSLoadingFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSLoaderInterface;
+use Jose\Component\Signature\JWSVerifierInterface;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Override;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Throwable;
+
+/**
+ * Dispatches an event whenever a JWS is loaded, without extending the loader it decorates.
+ */
+final readonly class EventDispatchingJWSLoader implements JWSLoaderInterface
+{
+    public function __construct(
+        private JWSLoaderInterface $loader,
+        private EventDispatcherInterface $eventDispatcher
+    ) {
+    }
+
+    #[Override]
+    public function getJwsVerifier(): JWSVerifierInterface
+    {
+        return $this->loader->getJwsVerifier();
+    }
+
+    #[Override]
+    public function getHeaderCheckerManager(): ?HeaderCheckerManagerInterface
+    {
+        return $this->loader->getHeaderCheckerManager();
+    }
+
+    #[Override]
+    public function getSerializerManager(): JWSSerializerManager
+    {
+        return $this->loader->getSerializerManager();
+    }
+
+    #[Override]
+    public function loadAndVerifyWithKey(string $token, JWK $key, ?int &$signature, ?string $payload = null): JWS
+    {
+        $keyset = new JWKSet([$key]);
+
+        return $this->loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
+    }
+
+    #[Override]
+    public function loadAndVerifyWithKeySet(
+        string $token,
+        JWKSet $keyset,
+        ?int &$signature,
+        ?string $payload = null
+    ): JWS {
+        try {
+            $jws = $this->loader->loadAndVerifyWithKeySet($token, $keyset, $signature, $payload);
+            $this->eventDispatcher->dispatch(new JWSLoadingSuccessEvent($token, $jws, $keyset, $signature));
+
+            return $jws;
+        } catch (Throwable $throwable) {
+            $this->eventDispatcher->dispatch(new JWSLoadingFailureEvent($token, $keyset, $throwable));
+
+            throw $throwable;
+        }
+    }
+}

--- a/src/Bundle/Services/EventDispatchingJWSVerifier.php
+++ b/src/Bundle/Services/EventDispatchingJWSVerifier.php
@@ -10,29 +10,41 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWS;
-use Jose\Component\Signature\JWSVerifier as BaseJWSVerifier;
+use Jose\Component\Signature\JWSVerifierInterface;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use function func_get_arg;
 use function func_num_args;
 
 /**
- * @deprecated since 4.3.0, use EventDispatchingJWSVerifier instead. The class extends a service of
- * the library that will be final in 5.0.0.
+ * Dispatches an event whenever a signature is verified, without extending the verifier it decorates.
  */
-final class JWSVerifier extends BaseJWSVerifier
+final readonly class EventDispatchingJWSVerifier implements JWSVerifierInterface
 {
     public function __construct(
-        AlgorithmManager $signatureAlgorithmManager,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private JWSVerifierInterface $verifier,
+        private EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($signatureAlgorithmManager);
+    }
+
+    #[Override]
+    public function getSignatureAlgorithmManager(): AlgorithmManager
+    {
+        return $this->verifier->getSignatureAlgorithmManager();
+    }
+
+    #[Override]
+    public function verifyWithKey(JWS $jws, JWK $jwk, int $signature, ?string $detachedPayload = null): bool
+    {
+        $jwkset = new JWKSet([$jwk]);
+
+        return $this->verifyWithKeySet($jws, $jwkset, $signature, $detachedPayload);
     }
 
     /**
-     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet:
-     * it is read with func_num_args()/func_get_arg(5) and forwarded to the parent, otherwise the reason of a
-     * failure would be lost as soon as this service is used in place of the verifier of the library.
+     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet: it is
+     * read with func_num_args()/func_get_arg(5) and forwarded to the decorated verifier, otherwise the reason of a
+     * failure would be lost as soon as the verifier is decorated.
      */
     #[Override]
     public function verifyWithKeySet(
@@ -42,14 +54,15 @@ final class JWSVerifier extends BaseJWSVerifier
         ?string $detachedPayload = null,
         ?JWK &$jwk = null
     ): bool {
-        $success = func_num_args() >= 6 ? parent::verifyWithKeySet(
+        $success = func_num_args() >= 6 ? $this->verifier->verifyWithKeySet(
             $jws,
             $jwkset,
             $signatureIndex,
             $detachedPayload,
             $jwk,
             func_get_arg(5)
-        ) : parent::verifyWithKeySet($jws, $jwkset, $signatureIndex, $detachedPayload, $jwk);
+        ) : $this->verifier->verifyWithKeySet($jws, $jwkset, $signatureIndex, $detachedPayload, $jwk);
+
         if ($success) {
             $this->eventDispatcher->dispatch(new JWSVerificationSuccessEvent(
                 $jws,

--- a/src/Bundle/Services/EventDispatchingNestedTokenBuilder.php
+++ b/src/Bundle/Services/EventDispatchingNestedTokenBuilder.php
@@ -5,28 +5,19 @@ declare(strict_types=1);
 namespace Jose\Bundle\JoseFramework\Services;
 
 use Jose\Bundle\JoseFramework\Event\NestedTokenIssuedEvent;
-use Jose\Component\Encryption\JWEBuilderInterface;
-use Jose\Component\Encryption\Serializer\JWESerializerManager;
-use Jose\Component\NestedToken\NestedTokenBuilder as BaseNestedTokenBuilder;
-use Jose\Component\Signature\JWSBuilderInterface;
-use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Jose\Component\NestedToken\NestedTokenBuilderInterface;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @deprecated since 4.3.0, use EventDispatchingNestedTokenBuilder instead. The class extends a service of
- * the library that will be final in 5.0.0.
+ * Dispatches an event whenever a nested token is issued, without extending the builder it decorates.
  */
-final class NestedTokenBuilder extends BaseNestedTokenBuilder
+final readonly class EventDispatchingNestedTokenBuilder implements NestedTokenBuilderInterface
 {
     public function __construct(
-        JWEBuilderInterface $jweBuilder,
-        JWESerializerManager $jweSerializerManager,
-        JWSBuilderInterface $jwsBuilder,
-        JWSSerializerManager $jwsSerializerManager,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private NestedTokenBuilderInterface $builder,
+        private EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($jweBuilder, $jweSerializerManager, $jwsBuilder, $jwsSerializerManager);
     }
 
     #[Override]
@@ -40,7 +31,7 @@ final class NestedTokenBuilder extends BaseNestedTokenBuilder
         string $jwe_serialization_mode,
         ?string $aad = null
     ): string {
-        $nestedToken = parent::create(
+        $nestedToken = $this->builder->create(
             $payload,
             $signatures,
             $jws_serialization_mode,

--- a/src/Bundle/Services/EventDispatchingNestedTokenLoader.php
+++ b/src/Bundle/Services/EventDispatchingNestedTokenLoader.php
@@ -7,33 +7,28 @@ namespace Jose\Bundle\JoseFramework\Services;
 use Jose\Bundle\JoseFramework\Event\NestedTokenLoadingFailureEvent;
 use Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\Encryption\JWELoaderInterface;
-use Jose\Component\NestedToken\NestedTokenLoader as BaseNestedTokenLoader;
+use Jose\Component\NestedToken\NestedTokenLoaderInterface;
 use Jose\Component\Signature\JWS;
-use Jose\Component\Signature\JWSLoaderInterface;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
 /**
- * @deprecated since 4.3.0, use EventDispatchingNestedTokenLoader instead. The class extends a service of
- * the library that will be final in 5.0.0.
+ * Dispatches an event whenever a nested token is loaded, without extending the loader it decorates.
  */
-final class NestedTokenLoader extends BaseNestedTokenLoader
+final readonly class EventDispatchingNestedTokenLoader implements NestedTokenLoaderInterface
 {
     public function __construct(
-        JWELoaderInterface $jweLoader,
-        JWSLoaderInterface $jwsLoader,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private NestedTokenLoaderInterface $loader,
+        private EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($jweLoader, $jwsLoader);
     }
 
     #[Override]
     public function load(string $token, JWKSet $encryptionKeySet, JWKSet $signatureKeySet, ?int &$signature = null): JWS
     {
         try {
-            $jws = parent::load($token, $encryptionKeySet, $signatureKeySet, $signature);
+            $jws = $this->loader->load($token, $encryptionKeySet, $signatureKeySet, $signature);
             $this->eventDispatcher->dispatch(new NestedTokenLoadingSuccessEvent(
                 $token,
                 $jws,

--- a/src/Bundle/Services/JWEBuilder.php
+++ b/src/Bundle/Services/JWEBuilder.php
@@ -13,6 +13,10 @@ use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
+/**
+ * @deprecated since 4.3.0, use EventDispatchingJWEBuilder instead. The class extends a service of
+ * the library that will be final in 5.0.0.
+ */
 final class JWEBuilder extends BaseJWEBuilder
 {
     public function __construct(

--- a/src/Bundle/Services/JWEDecrypter.php
+++ b/src/Bundle/Services/JWEDecrypter.php
@@ -13,7 +13,13 @@ use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWEDecrypter as BaseJWEDecrypter;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function func_get_arg;
+use function func_num_args;
 
+/**
+ * @deprecated since 4.3.0, use EventDispatchingJWEDecrypter instead. The class extends a service of
+ * the library that will be final in 5.0.0.
+ */
 final class JWEDecrypter extends BaseJWEDecrypter
 {
     public function __construct(
@@ -23,6 +29,11 @@ final class JWEDecrypter extends BaseJWEDecrypter
         parent::__construct($algorithmManager);
     }
 
+    /**
+     * The callable used by the loaders to observe the keys that were discarded is not part of the signature yet:
+     * it is read with func_num_args()/func_get_arg(5) and forwarded to the parent, otherwise the reason of a
+     * failure would be lost as soon as this service is used in place of the decrypter of the library.
+     */
     #[Override]
     public function decryptUsingKeySet(
         JWE &$jwe,
@@ -31,7 +42,14 @@ final class JWEDecrypter extends BaseJWEDecrypter
         ?JWK &$jwk = null,
         ?JWK $senderKey = null
     ): bool {
-        $success = parent::decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);
+        $success = func_num_args() >= 6 ? parent::decryptUsingKeySet(
+            $jwe,
+            $jwkset,
+            $recipient,
+            $jwk,
+            $senderKey,
+            func_get_arg(5)
+        ) : parent::decryptUsingKeySet($jwe, $jwkset, $recipient, $jwk, $senderKey);
         if ($success) {
             $this->eventDispatcher->dispatch(new JWEDecryptionSuccessEvent($jwe, $jwkset, $jwk, $recipient));
         } else {

--- a/src/Bundle/Services/JWELoader.php
+++ b/src/Bundle/Services/JWELoader.php
@@ -6,22 +6,26 @@ namespace Jose\Bundle\JoseFramework\Services;
 
 use Jose\Bundle\JoseFramework\Event\JWELoadingFailureEvent;
 use Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent;
-use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Encryption\JWE;
-use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWEDecrypterInterface;
 use Jose\Component\Encryption\JWELoader as BaseJWELoader;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
+/**
+ * @deprecated since 4.3.0, use EventDispatchingJWELoader instead. The class extends a service of
+ * the library that will be final in 5.0.0.
+ */
 final class JWELoader extends BaseJWELoader
 {
     public function __construct(
         JWESerializerManager $serializerManager,
-        JWEDecrypter $jweDecrypter,
-        ?HeaderCheckerManager $headerCheckerManager,
+        JWEDecrypterInterface $jweDecrypter,
+        ?HeaderCheckerManagerInterface $headerCheckerManager,
         private readonly EventDispatcherInterface $eventDispatcher
     ) {
         parent::__construct($serializerManager, $jweDecrypter, $headerCheckerManager);

--- a/src/Bundle/Services/JWSBuilder.php
+++ b/src/Bundle/Services/JWSBuilder.php
@@ -13,6 +13,10 @@ use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
+/**
+ * @deprecated since 4.3.0, use EventDispatchingJWSBuilder instead. The class extends a service of
+ * the library that will be final in 5.0.0.
+ */
 final class JWSBuilder extends BaseJWSBuilder
 {
     public function __construct(

--- a/src/Bundle/Services/JWSLoader.php
+++ b/src/Bundle/Services/JWSLoader.php
@@ -6,22 +6,26 @@ namespace Jose\Bundle\JoseFramework\Services;
 
 use Jose\Bundle\JoseFramework\Event\JWSLoadingFailureEvent;
 use Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent;
-use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSLoader as BaseJWSLoader;
-use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\JWSVerifierInterface;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Override;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Throwable;
 
+/**
+ * @deprecated since 4.3.0, use EventDispatchingJWSLoader instead. The class extends a service of
+ * the library that will be final in 5.0.0.
+ */
 final class JWSLoader extends BaseJWSLoader
 {
     public function __construct(
         JWSSerializerManager $serializerManager,
-        JWSVerifier $jwsVerifier,
-        ?HeaderCheckerManager $headerCheckerManager,
+        JWSVerifierInterface $jwsVerifier,
+        ?HeaderCheckerManagerInterface $headerCheckerManager,
         private readonly EventDispatcherInterface $eventDispatcher
     ) {
         parent::__construct($serializerManager, $jwsVerifier, $headerCheckerManager);

--- a/src/Library/Checker/ClaimCheckerManager.php
+++ b/src/Library/Checker/ClaimCheckerManager.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Jose\Component\Checker;
 
+use Jose\Component\Core\Util\InheritanceChecker;
 use function array_key_exists;
 use function count;
 use function sprintf;
 
 /**
  * This class manages claim checkers and performs claim checks.
+ *
+ * @final The class will be final in 5.0.0: implement ClaimCheckerManagerInterface and decorate the service instead of
+ * extending it.
+ *
  * @see \Jose\Tests\Component\Checker\ClaimCheckerManagerTest
  */
-class ClaimCheckerManager
+class ClaimCheckerManager implements ClaimCheckerManagerInterface
 {
     /**
      * @var ClaimChecker[]
@@ -24,6 +29,7 @@ class ClaimCheckerManager
      */
     public function __construct(iterable $checkers)
     {
+        InheritanceChecker::warnIfExtended(static::class, self::class, ClaimCheckerManagerInterface::class);
         foreach ($checkers as $checker) {
             $this->add($checker);
         }

--- a/src/Library/Checker/ClaimCheckerManagerInterface.php
+++ b/src/Library/Checker/ClaimCheckerManagerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Checker;
+
+/**
+ * Checks the claims of a token.
+ *
+ * The interface is implemented by ClaimCheckerManager and by every object that decorates it. Decoration is the
+ * supported way of plugging behaviour into the manager: ClaimCheckerManager is annotated as final and will be final in
+ * 5.0.0.
+ */
+interface ClaimCheckerManagerInterface
+{
+    /**
+     * Returns all the checkers handled by this manager.
+     *
+     * @return ClaimChecker[]
+     */
+    public function getCheckers(): array;
+
+    /**
+     * Checks all the claims passed as argument. All the claims are checked against the claim checkers. If one fails,
+     * an InvalidClaimException is thrown.
+     *
+     * @param array<string, mixed> $claims
+     * @param string[] $mandatoryClaims
+     *
+     * @return array<string, mixed>
+     */
+    public function check(array $claims, array $mandatoryClaims = []): array;
+}

--- a/src/Library/Checker/HeaderCheckerManager.php
+++ b/src/Library/Checker/HeaderCheckerManager.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Checker;
 
 use InvalidArgumentException;
 use Jose\Component\Core\JWT;
+use Jose\Component\Core\Util\InheritanceChecker;
 use function array_key_exists;
 use function count;
 use function is_array;
@@ -17,8 +18,11 @@ use function sprintf;
  *
  * It allows to add header parameter checkers and token type supports.
  * The factory is responsible to create a Header Checker Manager with the header parameter checkers found based
+ *
+ * @final The class will be final in 5.0.0: implement HeaderCheckerManagerInterface and decorate the service instead
+ * of extending it.
  */
-class HeaderCheckerManager
+class HeaderCheckerManager implements HeaderCheckerManagerInterface
 {
     /**
      * @var array<string, HeaderChecker>
@@ -36,6 +40,7 @@ class HeaderCheckerManager
      */
     public function __construct(iterable $checkers, iterable $tokenTypes)
     {
+        InheritanceChecker::warnIfExtended(static::class, self::class, HeaderCheckerManagerInterface::class);
         foreach ($checkers as $checker) {
             $this->add($checker);
         }

--- a/src/Library/Checker/HeaderCheckerManagerInterface.php
+++ b/src/Library/Checker/HeaderCheckerManagerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Checker;
+
+use Jose\Component\Core\JWT;
+
+/**
+ * Checks the header parameters of a token.
+ *
+ * The interface is implemented by HeaderCheckerManager and by every object that decorates it. Decoration is the
+ * supported way of plugging behaviour into the manager: HeaderCheckerManager is annotated as final and will be final
+ * in 5.0.0.
+ */
+interface HeaderCheckerManagerInterface
+{
+    /**
+     * Returns all the checkers handled by this manager.
+     *
+     * @return HeaderChecker[]
+     */
+    public function getCheckers(): array;
+
+    /**
+     * Checks all the header parameters of the given signature or recipient. All the header parameters are checked
+     * against the header parameter checkers. If one fails, an InvalidHeaderException is thrown.
+     *
+     * @param string[] $mandatoryHeaderParameters
+     */
+    public function check(JWT $jwt, int $index, array $mandatoryHeaderParameters = []): void;
+}

--- a/src/Library/Core/Util/InheritanceChecker.php
+++ b/src/Library/Core/Util/InheritanceChecker.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Util;
+
+use function str_starts_with;
+use function trigger_deprecation;
+
+/**
+ * Raises the deprecation notice emitted when one of the services of the library is extended.
+ *
+ * Those services will be final in 5.0.0. The behaviour they used to be extended for is now available through the
+ * interfaces they implement: a decorator implements the same interface, wraps the service and is injected in its
+ * place. The event dispatching services of the bundle are the only subclasses shipped by the project; they are
+ * deprecated as well and replaced by decorators, so they are left out of the notice to keep it actionable.
+ *
+ * @internal
+ */
+final class InheritanceChecker
+{
+    private const DEPRECATED_BUNDLE_SERVICES = 'Jose\\Bundle\\JoseFramework\\Services\\';
+
+    public static function warnIfExtended(string $actualClass, string $finalClass, string $interface): void
+    {
+        if ($actualClass === $finalClass) {
+            return;
+        }
+        if (str_starts_with($actualClass, self::DEPRECATED_BUNDLE_SERVICES)) {
+            return;
+        }
+
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'Extending "%s" is deprecated: the class will be final in 5.0.0. Implement "%s" and decorate the '
+            . 'service instead ("%s" does it).',
+            $finalClass,
+            $interface,
+            $actualClass
+        );
+    }
+}

--- a/src/Library/Encryption/JWEBuilder.php
+++ b/src/Library/Encryption/JWEBuilder.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
@@ -35,8 +36,11 @@ use function trigger_deprecation;
  * complete header of each recipient, which is only known once every shared header is set: they are resolved
  * by build(), together with all the checks that involve more than one recipient. The order of the calls is
  * therefore irrelevant.
+ *
+ * @final The class will be final in 5.0.0: implement JWEBuilderInterface and decorate the service instead of
+ * extending it.
  */
-class JWEBuilder
+class JWEBuilder implements JWEBuilderInterface
 {
     protected ?JWK $senderKey = null;
 
@@ -65,6 +69,7 @@ class JWEBuilder
 
     public function __construct(AlgorithmManager $algorithmManager)
     {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWEBuilderInterface::class);
         $keyEncryptionAlgorithms = [];
         $contentEncryptionAlgorithms = [];
         foreach ($algorithmManager->all() as $algorithm) {

--- a/src/Library/Encryption/JWEBuilderInterface.php
+++ b/src/Library/Encryption/JWEBuilderInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+
+/**
+ * Accumulates the payload, the headers and the recipients of a JWE, then encrypts them.
+ *
+ * The interface is implemented by JWEBuilder and by every object that decorates it. Decoration is the supported way of
+ * plugging behaviour into the builder: JWEBuilder is annotated as final and will be final in 5.0.0.
+ *
+ * The deprecated create() of JWEBuilder is deliberately left out: the builder is immutable, hence there is no state to
+ * reset, and the method is removed in 5.0.0.
+ */
+interface JWEBuilderInterface
+{
+    /**
+     * Returns the key encryption algorithm manager.
+     */
+    public function getKeyEncryptionAlgorithmManager(): AlgorithmManager;
+
+    /**
+     * Returns the content encryption algorithm manager.
+     */
+    public function getContentEncryptionAlgorithmManager(): AlgorithmManager;
+
+    /**
+     * Sets the payload of the JWE to build. This method returns a new builder.
+     */
+    public function withPayload(string $payload): self;
+
+    /**
+     * Sets the Additional Authenticated Data of the JWE to build. This method returns a new builder.
+     */
+    public function withAAD(?string $aad): self;
+
+    /**
+     * Sets the shared protected header of the JWE to build. This method returns a new builder.
+     *
+     * @param array<string, mixed> $sharedProtectedHeader
+     */
+    public function withSharedProtectedHeader(array $sharedProtectedHeader): self;
+
+    /**
+     * Sets the shared header of the JWE to build. This method returns a new builder.
+     *
+     * @param array<string, mixed> $sharedHeader
+     */
+    public function withSharedHeader(array $sharedHeader): self;
+
+    /**
+     * Adds a recipient to the JWE to build. This method returns a new builder.
+     *
+     * @param array<string, mixed> $recipientHeader
+     */
+    public function addRecipient(JWK $recipientKey, array $recipientHeader = []): self;
+
+    /**
+     * Sets the sender key to be used instead of the internal generated key. This method returns a new builder.
+     */
+    public function withSenderKey(JWK $senderKey): self;
+
+    /**
+     * Encrypts the payload and returns the JWE object.
+     */
+    public function build(): JWE;
+}

--- a/src/Library/Encryption/JWEDecrypter.php
+++ b/src/Library/Encryption/JWEDecrypter.php
@@ -9,6 +9,7 @@ use Jose\Component\Core\Algorithm;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Encryption\Algorithm\ContentEncryptionAlgorithm;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\DirectEncryption;
@@ -25,7 +26,11 @@ use function is_string;
 use function sprintf;
 use function strlen;
 
-class JWEDecrypter
+/**
+ * @final The class will be final in 5.0.0: implement JWEDecrypterInterface and decorate the service instead of
+ * extending it.
+ */
+class JWEDecrypter implements JWEDecrypterInterface
 {
     private readonly AlgorithmManager $keyEncryptionAlgorithmManager;
 
@@ -33,6 +38,7 @@ class JWEDecrypter
 
     public function __construct(AlgorithmManager $algorithmManager)
     {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWEDecrypterInterface::class);
         $keyEncryptionAlgorithms = [];
         $contentEncryptionAlgorithms = [];
         foreach ($algorithmManager->all() as $key => $algorithm) {

--- a/src/Library/Encryption/JWEDecrypterInterface.php
+++ b/src/Library/Encryption/JWEDecrypterInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+
+/**
+ * Decrypts a recipient of a JWE.
+ *
+ * The interface is implemented by JWEDecrypter and by every object that decorates it. Decoration is the supported way
+ * of plugging behaviour into the decrypter: JWEDecrypter is annotated as final and will be final in 5.0.0.
+ */
+interface JWEDecrypterInterface
+{
+    /**
+     * Returns the key encryption algorithm manager.
+     */
+    public function getKeyEncryptionAlgorithmManager(): AlgorithmManager;
+
+    /**
+     * Returns the content encryption algorithm manager.
+     */
+    public function getContentEncryptionAlgorithmManager(): AlgorithmManager;
+
+    /**
+     * Decrypts the given recipient of the JWE using the given key.
+     *
+     * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
+     */
+    public function decryptUsingKey(JWE &$jwe, JWK $jwk, int $recipient, ?JWK $senderKey = null): bool;
+
+    /**
+     * Decrypts the given recipient of the JWE using the given key set.
+     *
+     * A key that cannot be used, or that does not decrypt the recipient, does not abort the decryption: the next key
+     * of the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
+     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of
+     * the signature yet - it will be in 5.0.0 - and is read with func_num_args()/func_get_arg(5). An implementation
+     * that does not read it still behaves correctly, it only loses the reason of the failures.
+     *
+     * @param JWK|null $jwk The key used to decrypt the token in case of success
+     * @param JWK|null $senderKey The sender key, when the key management algorithm is a static key agreement
+     */
+    public function decryptUsingKeySet(
+        JWE &$jwe,
+        JWKSet $jwkset,
+        int $recipient,
+        ?JWK &$jwk = null,
+        ?JWK $senderKey = null
+    ): bool;
+}

--- a/src/Library/Encryption/JWELoader.php
+++ b/src/Library/Encryption/JWELoader.php
@@ -4,29 +4,34 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption;
 
-use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use RuntimeException;
 use Throwable;
 
 /**
+ * @final The class will be final in 5.0.0: implement JWELoaderInterface and decorate the service instead of
+ * extending it.
+ *
  * @see \Jose\Tests\Component\Encryption\JWELoaderTest
  */
-class JWELoader
+class JWELoader implements JWELoaderInterface
 {
     public function __construct(
         private readonly JWESerializerManager $serializerManager,
-        private readonly JWEDecrypter $jweDecrypter,
-        private readonly ?HeaderCheckerManager $headerCheckerManager
+        private readonly JWEDecrypterInterface $jweDecrypter,
+        private readonly ?HeaderCheckerManagerInterface $headerCheckerManager
     ) {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWELoaderInterface::class);
     }
 
     /**
      * Returns the JWE Decrypter object.
      */
-    public function getJweDecrypter(): JWEDecrypter
+    public function getJweDecrypter(): JWEDecrypterInterface
     {
         return $this->jweDecrypter;
     }
@@ -34,7 +39,7 @@ class JWELoader
     /**
      * Returns the header checker manager if set.
      */
-    public function getHeaderCheckerManager(): ?HeaderCheckerManager
+    public function getHeaderCheckerManager(): ?HeaderCheckerManagerInterface
     {
         return $this->headerCheckerManager;
     }

--- a/src/Library/Encryption/JWELoaderInterface.php
+++ b/src/Library/Encryption/JWELoaderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Encryption;
+
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+
+/**
+ * Loads a serialized JWE, checks its header and decrypts it.
+ *
+ * The interface is implemented by JWELoader and by every object that decorates it. Decoration is the supported way of
+ * plugging behaviour into the loader: JWELoader is annotated as final and will be final in 5.0.0.
+ */
+interface JWELoaderInterface
+{
+    /**
+     * Returns the decrypter associated to the loader.
+     */
+    public function getJweDecrypter(): JWEDecrypterInterface;
+
+    /**
+     * Returns the header checker manager associated to the loader, if any.
+     */
+    public function getHeaderCheckerManager(): ?HeaderCheckerManagerInterface;
+
+    /**
+     * Returns the serializer manager associated to the loader.
+     */
+    public function getSerializerManager(): JWESerializerManager;
+
+    /**
+     * Loads and decrypts the token using the given key. It returns a JWE and populates the $recipient variable in case
+     * of success, otherwise an exception is thrown.
+     */
+    public function loadAndDecryptWithKey(string $token, JWK $key, ?int &$recipient): JWE;
+
+    /**
+     * Loads and decrypts the token using the given key set. It returns a JWE and populates the $recipient variable in
+     * case of success, otherwise an exception is thrown.
+     */
+    public function loadAndDecryptWithKeySet(string $token, JWKSet $keyset, ?int &$recipient): JWE;
+}

--- a/src/Library/NestedToken/NestedTokenBuilder.php
+++ b/src/Library/NestedToken/NestedTokenBuilder.php
@@ -5,20 +5,26 @@ declare(strict_types=1);
 namespace Jose\Component\NestedToken;
 
 use Jose\Component\Core\JWK;
-use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Core\Util\InheritanceChecker;
+use Jose\Component\Encryption\JWEBuilderInterface;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
-use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSBuilderInterface;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use function array_key_exists;
 
-class NestedTokenBuilder
+/**
+ * @final The class will be final in 5.0.0: implement NestedTokenBuilderInterface and decorate the service instead of
+ * extending it.
+ */
+class NestedTokenBuilder implements NestedTokenBuilderInterface
 {
     public function __construct(
-        private readonly JWEBuilder $jweBuilder,
+        private readonly JWEBuilderInterface $jweBuilder,
         private readonly JWESerializerManager $jweSerializerManager,
-        private readonly JWSBuilder $jwsBuilder,
+        private readonly JWSBuilderInterface $jwsBuilder,
         private readonly JWSSerializerManager $jwsSerializerManager
     ) {
+        InheritanceChecker::warnIfExtended(static::class, self::class, NestedTokenBuilderInterface::class);
     }
 
     /**

--- a/src/Library/NestedToken/NestedTokenBuilderInterface.php
+++ b/src/Library/NestedToken/NestedTokenBuilderInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\NestedToken;
+
+use Jose\Component\Core\JWK;
+
+/**
+ * Builds a nested token: a JWS serialized as the payload of a JWE.
+ *
+ * The interface is implemented by NestedTokenBuilder and by every object that decorates it. Decoration is the
+ * supported way of plugging behaviour into the builder: NestedTokenBuilder is annotated as final and will be final in
+ * 5.0.0.
+ */
+interface NestedTokenBuilderInterface
+{
+    /**
+     * Creates a nested token.
+     *
+     * @param array<array{key: JWK, protected_header?: array<string, mixed>, header?: array<string, mixed>}> $signatures
+     * @param array<string, mixed> $jweSharedProtectedHeader
+     * @param array<string, mixed> $jweSharedHeader
+     * @param array<array{key: JWK, header?: array<string, mixed>}> $recipients
+     */
+    public function create(
+        string $payload,
+        array $signatures,
+        string $jws_serialization_mode,
+        array $jweSharedProtectedHeader,
+        array $jweSharedHeader,
+        array $recipients,
+        string $jwe_serialization_mode,
+        ?string $aad = null
+    ): string;
+}

--- a/src/Library/NestedToken/NestedTokenLoader.php
+++ b/src/Library/NestedToken/NestedTokenLoader.php
@@ -6,18 +6,24 @@ namespace Jose\Component\NestedToken;
 
 use InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Encryption\JWE;
-use Jose\Component\Encryption\JWELoader;
+use Jose\Component\Encryption\JWELoaderInterface;
 use Jose\Component\Signature\JWS;
-use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSLoaderInterface;
 use function is_string;
 
-class NestedTokenLoader
+/**
+ * @final The class will be final in 5.0.0: implement NestedTokenLoaderInterface and decorate the service instead of
+ * extending it.
+ */
+class NestedTokenLoader implements NestedTokenLoaderInterface
 {
     public function __construct(
-        private readonly JWELoader $jweLoader,
-        private readonly JWSLoader $jwsLoader
+        private readonly JWELoaderInterface $jweLoader,
+        private readonly JWSLoaderInterface $jwsLoader
     ) {
+        InheritanceChecker::warnIfExtended(static::class, self::class, NestedTokenLoaderInterface::class);
     }
 
     /**

--- a/src/Library/NestedToken/NestedTokenLoaderInterface.php
+++ b/src/Library/NestedToken/NestedTokenLoaderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\NestedToken;
+
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\JWS;
+
+/**
+ * Loads a nested token: a JWS serialized as the payload of a JWE.
+ *
+ * The interface is implemented by NestedTokenLoader and by every object that decorates it. Decoration is the supported
+ * way of plugging behaviour into the loader: NestedTokenLoader is annotated as final and will be final in 5.0.0.
+ */
+interface NestedTokenLoaderInterface
+{
+    /**
+     * Loads, decrypts and verifies the token. In case of failure, an exception is thrown, otherwise the JWS is returned
+     * and the $signature variable is populated.
+     */
+    public function load(
+        string $token,
+        JWKSet $encryptionKeySet,
+        JWKSet $signatureKeySet,
+        ?int &$signature = null
+    ): JWS;
+}

--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
@@ -30,8 +31,11 @@ use function trigger_deprecation;
  * never modifies the receiver, so that a builder registered as a shared service cannot be poisoned by a
  * previous build. The consistency of the accumulated state is checked by build(), which makes the order of
  * the calls irrelevant.
+ *
+ * @final The class will be final in 5.0.0: implement JWSBuilderInterface and decorate the service instead of
+ * extending it.
  */
-class JWSBuilder
+class JWSBuilder implements JWSBuilderInterface
 {
     protected ?string $payload = null;
 
@@ -61,6 +65,7 @@ class JWSBuilder
     public function __construct(
         private readonly AlgorithmManager $signatureAlgorithmManager
     ) {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWSBuilderInterface::class);
     }
 
     /**

--- a/src/Library/Signature/JWSBuilderInterface.php
+++ b/src/Library/Signature/JWSBuilderInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Signature;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+
+/**
+ * Accumulates the payload and the signatures of a JWS, then computes them.
+ *
+ * The interface is implemented by JWSBuilder and by every object that decorates it. Decoration is the supported way
+ * of plugging behaviour into the builder: JWSBuilder is annotated as final and will be final in 5.0.0.
+ *
+ * The deprecated create() of JWSBuilder is deliberately left out: the builder is immutable, hence there is no state
+ * to reset, and the method is removed in 5.0.0.
+ */
+interface JWSBuilderInterface
+{
+    /**
+     * Returns the algorithm manager associated to the builder.
+     */
+    public function getSignatureAlgorithmManager(): AlgorithmManager;
+
+    /**
+     * Sets the payload. This method returns a new builder.
+     */
+    public function withPayload(string $payload, bool $isPayloadDetached = false): self;
+
+    /**
+     * Sets a payload that is already Base64Url encoded. This method returns a new builder.
+     */
+    public function withEncodedPayload(string $payload, bool $isPayloadDetached = false): self;
+
+    /**
+     * Adds the information needed to compute a signature. This method returns a new builder.
+     *
+     * @param array<string, mixed> $protectedHeader
+     * @param array<string, mixed> $header
+     */
+    public function addSignature(JWK $signatureKey, array $protectedHeader, array $header = []): self;
+
+    /**
+     * Computes all the signatures and returns the JWS object.
+     */
+    public function build(): JWS;
+}

--- a/src/Library/Signature/JWSLoader.php
+++ b/src/Library/Signature/JWSLoader.php
@@ -5,28 +5,33 @@ declare(strict_types=1);
 namespace Jose\Component\Signature;
 
 use Exception;
-use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Throwable;
 
 /**
+ * @final The class will be final in 5.0.0: implement JWSLoaderInterface and decorate the service instead of
+ * extending it.
+ *
  * @see \Jose\Tests\Component\Signature\JWSLoaderTest
  */
-class JWSLoader
+class JWSLoader implements JWSLoaderInterface
 {
     public function __construct(
         private readonly JWSSerializerManager $serializerManager,
-        private readonly JWSVerifier $jwsVerifier,
-        private readonly ?HeaderCheckerManager $headerCheckerManager
+        private readonly JWSVerifierInterface $jwsVerifier,
+        private readonly ?HeaderCheckerManagerInterface $headerCheckerManager
     ) {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWSLoaderInterface::class);
     }
 
     /**
      * Returns the JWSVerifier associated to the JWSLoader.
      */
-    public function getJwsVerifier(): JWSVerifier
+    public function getJwsVerifier(): JWSVerifierInterface
     {
         return $this->jwsVerifier;
     }
@@ -34,7 +39,7 @@ class JWSLoader
     /**
      * Returns the Header Checker Manager associated to the JWSLoader.
      */
-    public function getHeaderCheckerManager(): ?HeaderCheckerManager
+    public function getHeaderCheckerManager(): ?HeaderCheckerManagerInterface
     {
         return $this->headerCheckerManager;
     }

--- a/src/Library/Signature/JWSLoaderInterface.php
+++ b/src/Library/Signature/JWSLoaderInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Signature;
+
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+
+/**
+ * Loads a serialized JWS, checks its header and verifies its signatures.
+ *
+ * The interface is implemented by JWSLoader and by every object that decorates it. Decoration is the supported way of
+ * plugging behaviour into the loader: JWSLoader is annotated as final and will be final in 5.0.0.
+ */
+interface JWSLoaderInterface
+{
+    /**
+     * Returns the verifier associated to the loader.
+     */
+    public function getJwsVerifier(): JWSVerifierInterface;
+
+    /**
+     * Returns the header checker manager associated to the loader, if any.
+     */
+    public function getHeaderCheckerManager(): ?HeaderCheckerManagerInterface;
+
+    /**
+     * Returns the serializer manager associated to the loader.
+     */
+    public function getSerializerManager(): JWSSerializerManager;
+
+    /**
+     * Loads and verifies the token using the given key. It returns a JWS and populates the $signature variable in case
+     * of success, otherwise an exception is thrown.
+     */
+    public function loadAndVerifyWithKey(string $token, JWK $key, ?int &$signature, ?string $payload = null): JWS;
+
+    /**
+     * Loads and verifies the token using the given key set. It returns a JWS and populates the $signature variable in
+     * case of success, otherwise an exception is thrown.
+     */
+    public function loadAndVerifyWithKeySet(
+        string $token,
+        JWKSet $keyset,
+        ?int &$signature,
+        ?string $payload = null
+    ): JWS;
+}

--- a/src/Library/Signature/JWSVerifier.php
+++ b/src/Library/Signature/JWSVerifier.php
@@ -10,6 +10,7 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\KeyChecker;
 use Jose\Component\Signature\Algorithm\MacAlgorithm;
 use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
@@ -18,11 +19,16 @@ use function func_num_args;
 use function is_callable;
 use function sprintf;
 
-class JWSVerifier
+/**
+ * @final The class will be final in 5.0.0: implement JWSVerifierInterface and decorate the service instead of
+ * extending it.
+ */
+class JWSVerifier implements JWSVerifierInterface
 {
     public function __construct(
         private readonly AlgorithmManager $signatureAlgorithmManager
     ) {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWSVerifierInterface::class);
     }
 
     /**

--- a/src/Library/Signature/JWSVerifierInterface.php
+++ b/src/Library/Signature/JWSVerifierInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Signature;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+
+/**
+ * Verifies the signatures of a JWS.
+ *
+ * The interface is implemented by JWSVerifier and by every object that decorates it. Decoration is the supported way
+ * of plugging behaviour into the verifier: JWSVerifier is annotated as final and will be final in 5.0.0.
+ */
+interface JWSVerifierInterface
+{
+    /**
+     * Returns the algorithm manager associated to the verifier.
+     */
+    public function getSignatureAlgorithmManager(): AlgorithmManager;
+
+    /**
+     * Verifies the given signature of the JWS object using the given key.
+     *
+     * @return bool true if the verification of the signature succeeded, else false
+     */
+    public function verifyWithKey(JWS $jws, JWK $jwk, int $signature, ?string $detachedPayload = null): bool;
+
+    /**
+     * Verifies the given signature of the JWS object using the given key set.
+     *
+     * A key that cannot be used, or that does not verify the signature, does not abort the verification: the next key
+     * of the key set is tried and the reason of the failure is otherwise lost. A callable is accepted as an additional
+     * argument to observe those failures; it is called with every discarded Throwable. That argument is not part of
+     * the signature yet - it will be in 5.0.0 - and is read with func_num_args()/func_get_arg(5). An implementation
+     * that does not read it still behaves correctly, it only loses the reason of the failures.
+     *
+     * @param string|null $detachedPayload If not null, the value must be the detached payload encoded in Base64 URL safe. If the input contains a payload, throws an exception.
+     * @param JWK|null $jwk The key used to verify the signature in case of success
+     *
+     * @return bool true if the verification of the signature succeeded, else false
+     */
+    public function verifyWithKeySet(
+        JWS $jws,
+        JWKSet $jwkset,
+        int $signatureIndex,
+        ?string $detachedPayload = null,
+        ?JWK &$jwk = null
+    ): bool;
+}

--- a/tests/Bundle/JoseFramework/Functional/AutowiringAliasesTest.php
+++ b/tests/Bundle/JoseFramework/Functional/AutowiringAliasesTest.php
@@ -5,19 +5,40 @@ declare(strict_types=1);
 namespace Jose\Tests\Bundle\JoseFramework\Functional;
 
 use Jose\Bundle\JoseFramework\JoseFrameworkBundle;
+use Jose\Bundle\JoseFramework\Services\ClaimCheckerManager;
+use Jose\Bundle\JoseFramework\Services\HeaderCheckerManager;
+use Jose\Component\Checker\ClaimCheckerManagerInterface;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\JWEBuilderInterface;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWEDecrypterInterface;
+use Jose\Component\Encryption\JWELoader;
+use Jose\Component\Encryption\JWELoaderInterface;
 use Jose\Component\NestedToken\NestedTokenBuilder;
+use Jose\Component\NestedToken\NestedTokenBuilderInterface;
 use Jose\Component\NestedToken\NestedTokenLoader;
+use Jose\Component\NestedToken\NestedTokenLoaderInterface;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSBuilderInterface;
+use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSLoaderInterface;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\JWSVerifierInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
+use function array_keys;
 use function explode;
 use function is_a;
 use function iterator_to_array;
 use function sprintf;
 use function str_contains;
 use function str_starts_with;
+use function strlen;
+use function substr;
 
 /**
  * The bundle registers an autowiring alias for every service it creates from the configuration. The nested token
@@ -54,6 +75,52 @@ final class AutowiringAliasesTest extends TestCase
             NestedTokenBuilder::class . ' $nestedTokenBuilder1NestedTokenBuilder',
             $aliases
         );
+    }
+
+    #[Test]
+    #[DataProvider('services')]
+    public function theServiceIsAlsoAliasedWithItsInterface(string $class, string $interface): void
+    {
+        $aliases = array_keys(iterator_to_array(self::autowiringAliases()));
+
+        $arguments = self::argumentsAliasedWith($aliases, $class);
+        static::assertNotSame([], $arguments, sprintf('No service is aliased with "%s".', $class));
+        static::assertSame($arguments, self::argumentsAliasedWith($aliases, $interface));
+    }
+
+    /**
+     * @return iterable<string, array{class-string, class-string}>
+     */
+    public static function services(): iterable
+    {
+        yield 'JWS builder' => [JWSBuilder::class, JWSBuilderInterface::class];
+        yield 'JWS verifier' => [JWSVerifier::class, JWSVerifierInterface::class];
+        yield 'JWS loader' => [JWSLoader::class, JWSLoaderInterface::class];
+        yield 'JWE builder' => [JWEBuilder::class, JWEBuilderInterface::class];
+        yield 'JWE decrypter' => [JWEDecrypter::class, JWEDecrypterInterface::class];
+        yield 'JWE loader' => [JWELoader::class, JWELoaderInterface::class];
+        yield 'Nested token builder' => [NestedTokenBuilder::class, NestedTokenBuilderInterface::class];
+        yield 'Nested token loader' => [NestedTokenLoader::class, NestedTokenLoaderInterface::class];
+        yield 'Claim checker manager' => [ClaimCheckerManager::class, ClaimCheckerManagerInterface::class];
+        yield 'Header checker manager' => [HeaderCheckerManager::class, HeaderCheckerManagerInterface::class];
+    }
+
+    /**
+     * @param string[] $aliases
+     *
+     * @return string[]
+     */
+    private static function argumentsAliasedWith(array $aliases, string $type): array
+    {
+        $prefix = $type . ' $';
+        $arguments = [];
+        foreach ($aliases as $alias) {
+            if (str_starts_with($alias, $prefix)) {
+                $arguments[] = substr($alias, strlen($prefix));
+            }
+        }
+
+        return $arguments;
     }
 
     /**

--- a/tests/Bundle/JoseFramework/Services/CollectingEventDispatcher.php
+++ b/tests/Bundle/JoseFramework/Services/CollectingEventDispatcher.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Services;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use function count;
+
+/**
+ * Keeps every dispatched event so that the decorators of the bundle can be observed.
+ *
+ * @internal
+ */
+final class CollectingEventDispatcher implements EventDispatcherInterface
+{
+    /**
+     * @var object[]
+     */
+    private array $events = [];
+
+    public function dispatch(object $event): object
+    {
+        $this->events[] = $event;
+
+        return $event;
+    }
+
+    /**
+     * @return object[]
+     */
+    public function events(): array
+    {
+        return $this->events;
+    }
+
+    public function lastEvent(): ?object
+    {
+        return $this->events[count($this->events) - 1] ?? null;
+    }
+}

--- a/tests/Bundle/JoseFramework/Services/EventDispatchingCheckerServicesTest.php
+++ b/tests/Bundle/JoseFramework/Services/EventDispatchingCheckerServicesTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\ClaimCheckedFailureEvent;
+use Jose\Bundle\JoseFramework\Event\ClaimCheckedSuccessEvent;
+use Jose\Bundle\JoseFramework\Event\HeaderCheckedFailureEvent;
+use Jose\Bundle\JoseFramework\Event\HeaderCheckedSuccessEvent;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingClaimCheckerManager;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingHeaderCheckerManager;
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\IssuerChecker;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\HS256;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSTokenSupport;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * The event dispatching checker managers of the bundle used to extend the ones of the library. They are replaced by
+ * decorators, which dispatch the same events without inheriting anything.
+ *
+ * @internal
+ */
+final class EventDispatchingCheckerServicesTest extends TestCase
+{
+    #[Test]
+    public function theClaimCheckerManagerDispatchesTheSuccessEvent(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $manager = new EventDispatchingClaimCheckerManager(
+            new ClaimCheckerManager([new IssuerChecker(['issuer'])]),
+            $dispatcher
+        );
+
+        $checked = $manager->check([
+            'iss' => 'issuer',
+        ], ['iss']);
+
+        static::assertSame([
+            'iss' => 'issuer',
+        ], $checked);
+        static::assertInstanceOf(ClaimCheckedSuccessEvent::class, $dispatcher->lastEvent());
+        static::assertCount(1, $manager->getCheckers());
+    }
+
+    #[Test]
+    public function theClaimCheckerManagerDispatchesTheFailureEvent(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $manager = new EventDispatchingClaimCheckerManager(
+            new ClaimCheckerManager([new IssuerChecker(['issuer'])]),
+            $dispatcher
+        );
+
+        try {
+            $manager->check([
+                'iss' => 'another issuer',
+            ], ['iss']);
+            static::fail('The issuer is not allowed: the check was expected to fail.');
+        } catch (Throwable) {
+        }
+
+        static::assertInstanceOf(ClaimCheckedFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    #[Test]
+    public function theHeaderCheckerManagerDispatchesTheSuccessEvent(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $manager = new EventDispatchingHeaderCheckerManager(
+            new HeaderCheckerManager([new IssuerChecker(['issuer'])], [new JWSTokenSupport()]),
+            $dispatcher
+        );
+
+        $manager->check($this->token([
+            'alg' => 'HS256',
+            'iss' => 'issuer',
+        ]), 0, ['iss']);
+
+        static::assertInstanceOf(HeaderCheckedSuccessEvent::class, $dispatcher->lastEvent());
+        static::assertCount(1, $manager->getCheckers());
+    }
+
+    #[Test]
+    public function theHeaderCheckerManagerDispatchesTheFailureEvent(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $manager = new EventDispatchingHeaderCheckerManager(
+            new HeaderCheckerManager([new IssuerChecker(['issuer'])], [new JWSTokenSupport()]),
+            $dispatcher
+        );
+
+        try {
+            $manager->check($this->token([
+                'alg' => 'HS256',
+                'iss' => 'another issuer',
+            ]), 0, ['iss']);
+            static::fail('The issuer is not allowed: the check was expected to fail.');
+        } catch (Throwable) {
+        }
+
+        static::assertInstanceOf(HeaderCheckedFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    /**
+     * @param array<string, mixed> $protectedHeader
+     */
+    private function token(array $protectedHeader): JWS
+    {
+        $key = new JWK([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+
+        return (new JWSBuilder(new AlgorithmManager([new HS256()])))
+            ->withPayload('Hello World!')
+            ->addSignature($key, $protectedHeader)
+            ->build();
+    }
+}

--- a/tests/Bundle/JoseFramework/Services/EventDispatchingJWEServicesTest.php
+++ b/tests/Bundle/JoseFramework/Services/EventDispatchingJWEServicesTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWEBuiltFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWEBuiltSuccessEvent;
+use Jose\Bundle\JoseFramework\Event\JWEDecryptionFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWEDecryptionSuccessEvent;
+use Jose\Bundle\JoseFramework\Event\JWELoadingFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWELoadingSuccessEvent;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingJWEBuilder;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingJWEDecrypter;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingJWELoader;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A256CBCHS512;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\A256KW;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWELoader;
+use Jose\Component\Encryption\Serializer\CompactSerializer;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * The event dispatching services of the bundle used to extend the services of the library. They are replaced by
+ * decorators, which dispatch the same events without inheriting anything.
+ *
+ * @internal
+ */
+final class EventDispatchingJWEServicesTest extends TestCase
+{
+    private const SHARED_PROTECTED_HEADER = [
+        'alg' => 'A256KW',
+        'enc' => 'A256CBC-HS512',
+    ];
+
+    #[Test]
+    public function theBuilderDispatchesTheSuccessEventAndReturnsTheToken(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $builder = new EventDispatchingJWEBuilder($this->builder(), $dispatcher);
+
+        $jwe = $builder
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader(self::SHARED_PROTECTED_HEADER)
+            ->addRecipient($this->key())
+            ->build();
+
+        $event = $dispatcher->lastEvent();
+        static::assertInstanceOf(JWEBuiltSuccessEvent::class, $event);
+        static::assertSame($jwe, $event->getJwe());
+    }
+
+    #[Test]
+    public function theBuilderDispatchesTheFailureEventWithTheDataItWasGiven(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $key = $this->key();
+        $builder = (new EventDispatchingJWEBuilder($this->builder(), $dispatcher))
+            ->withAAD('additional data')
+            ->withSharedProtectedHeader(self::SHARED_PROTECTED_HEADER)
+            ->withSharedHeader([
+                'cty' => 'JWT',
+            ])
+            ->addRecipient($key);
+
+        try {
+            $builder->build();
+            static::fail('The payload is not set: the build was expected to fail.');
+        } catch (Throwable) {
+        }
+
+        $event = $dispatcher->lastEvent();
+        static::assertInstanceOf(JWEBuiltFailureEvent::class, $event);
+        static::assertNull($event->getPayload());
+        static::assertSame('additional data', $event->getAad());
+        static::assertSame(self::SHARED_PROTECTED_HEADER, $event->getSharedProtectedHeader());
+        static::assertSame([
+            'cty' => 'JWT',
+        ], $event->getSharedHeader());
+        static::assertSame([[
+            'key' => $key,
+            'header' => [],
+        ]], $event->getRecipients());
+    }
+
+    #[Test]
+    public function theBuilderForgetsTheAdditionalAuthenticatedDataOnceItIsUnset(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $builder = (new EventDispatchingJWEBuilder($this->builder(), $dispatcher))
+            ->withAAD('additional data')
+            ->withAAD(null);
+
+        try {
+            $builder->build();
+            static::fail('The payload is not set: the build was expected to fail.');
+        } catch (Throwable) {
+        }
+
+        $event = $dispatcher->lastEvent();
+        static::assertInstanceOf(JWEBuiltFailureEvent::class, $event);
+        static::assertNull($event->getAad());
+    }
+
+    #[Test]
+    public function theDecrypterDispatchesTheSuccessAndTheFailureEvents(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $decrypter = new EventDispatchingJWEDecrypter(new JWEDecrypter($this->algorithms()), $dispatcher);
+
+        $jwe = $this->token();
+        static::assertTrue($decrypter->decryptUsingKey($jwe, $this->key(), 0));
+        static::assertInstanceOf(JWEDecryptionSuccessEvent::class, $dispatcher->lastEvent());
+
+        $jwe = $this->token();
+        static::assertFalse($decrypter->decryptUsingKey($jwe, $this->otherKey(), 0));
+        static::assertInstanceOf(JWEDecryptionFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    #[Test]
+    public function theDecrypterForwardsTheCallableUsedToObserveTheDiscardedKeys(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $decrypter = new EventDispatchingJWEDecrypter(new JWEDecrypter($this->algorithms()), $dispatcher);
+        $jwe = $this->token();
+        $jwk = null;
+        $errors = [];
+
+        $decrypter->decryptUsingKeySet(
+            $jwe,
+            new JWKSet([$this->unusableKey()]),
+            0,
+            $jwk,
+            null,
+            static function (Throwable $throwable) use (&$errors): void {
+                $errors[] = $throwable;
+            }
+        );
+
+        static::assertCount(1, $errors);
+    }
+
+    #[Test]
+    public function theLoaderDispatchesTheSuccessAndTheFailureEvents(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $loader = new EventDispatchingJWELoader(
+            new JWELoader(new JWESerializerManager([new CompactSerializer()]), new JWEDecrypter(
+                $this->algorithms()
+            ), null),
+            $dispatcher
+        );
+        $token = (new CompactSerializer())->serialize($this->token(), 0);
+        $recipient = null;
+
+        $jwe = $loader->loadAndDecryptWithKeySet($token, new JWKSet([$this->key()]), $recipient);
+        static::assertSame('Hello World!', $jwe->getPayload());
+        static::assertInstanceOf(JWELoadingSuccessEvent::class, $dispatcher->lastEvent());
+
+        try {
+            $loader->loadAndDecryptWithKeySet($token, new JWKSet([$this->otherKey()]), $recipient);
+            static::fail('The key set cannot decrypt the token: the load was expected to fail.');
+        } catch (Throwable) {
+        }
+        static::assertInstanceOf(JWELoadingFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    private function algorithms(): AlgorithmManager
+    {
+        return new AlgorithmManager([new A256KW(), new A256CBCHS512()]);
+    }
+
+    private function builder(): JWEBuilder
+    {
+        return new JWEBuilder($this->algorithms());
+    }
+
+    private function key(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+    }
+
+    private function otherKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'dzI6nbW4OcNF-AtfxGAmuyz7IpHRudBI0WgGjZWgaRI',
+        ]);
+    }
+
+    private function unusableKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+            'use' => 'sig',
+        ]);
+    }
+
+    private function token(): JWE
+    {
+        return $this->builder()
+            ->withPayload('Hello World!')
+            ->withSharedProtectedHeader(self::SHARED_PROTECTED_HEADER)
+            ->addRecipient($this->key())
+            ->build();
+    }
+}

--- a/tests/Bundle/JoseFramework/Services/EventDispatchingJWSServicesTest.php
+++ b/tests/Bundle/JoseFramework/Services/EventDispatchingJWSServicesTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\JWSBuiltFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWSBuiltSuccessEvent;
+use Jose\Bundle\JoseFramework\Event\JWSLoadingFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWSLoadingSuccessEvent;
+use Jose\Bundle\JoseFramework\Event\JWSVerificationFailureEvent;
+use Jose\Bundle\JoseFramework\Event\JWSVerificationSuccessEvent;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingJWSBuilder;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingJWSLoader;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingJWSVerifier;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\Algorithm\HS256;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * The event dispatching services of the bundle used to extend the services of the library. They are replaced by
+ * decorators, which dispatch the same events without inheriting anything.
+ *
+ * @internal
+ */
+final class EventDispatchingJWSServicesTest extends TestCase
+{
+    #[Test]
+    public function theBuilderDispatchesTheSuccessEventAndReturnsTheToken(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $builder = new EventDispatchingJWSBuilder($this->builder(), $dispatcher);
+
+        $jws = $builder
+            ->withPayload('Hello World!')
+            ->addSignature($this->key(), [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        static::assertSame('Hello World!', $jws->getPayload());
+        $event = $dispatcher->lastEvent();
+        static::assertInstanceOf(JWSBuiltSuccessEvent::class, $event);
+        static::assertSame($jws, $event->getJws());
+    }
+
+    #[Test]
+    public function theBuilderDispatchesTheFailureEventWithTheDataItWasGiven(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $key = $this->key();
+        $protectedHeader = [
+            'alg' => 'HS256',
+            'b64' => false,
+            'crit' => ['b64'],
+        ];
+        $builder = (new EventDispatchingJWSBuilder($this->builder(), $dispatcher))
+            ->withPayload("\xB1\x31")
+            ->addSignature($key, $protectedHeader);
+
+        try {
+            $builder->build();
+            static::fail('The payload is not encoded in UTF-8: the build was expected to fail.');
+        } catch (Throwable) {
+        }
+
+        $event = $dispatcher->lastEvent();
+        static::assertInstanceOf(JWSBuiltFailureEvent::class, $event);
+        static::assertSame("\xB1\x31", $event->getPayload());
+        static::assertFalse($event->isPayloadDetached());
+        static::assertFalse($event->getisPayloadEncoded());
+        static::assertSame([[
+            'signature_key' => $key,
+            'protected_header' => $protectedHeader,
+            'header' => [],
+        ]], $event->getSignatures());
+    }
+
+    #[Test]
+    public function theVerifierDispatchesTheSuccessAndTheFailureEvents(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $verifier = new EventDispatchingJWSVerifier(new JWSVerifier($this->algorithms()), $dispatcher);
+        $jws = $this->token();
+
+        static::assertTrue($verifier->verifyWithKey($jws, $this->key(), 0));
+        static::assertInstanceOf(JWSVerificationSuccessEvent::class, $dispatcher->lastEvent());
+
+        static::assertFalse($verifier->verifyWithKey($jws, $this->otherKey(), 0));
+        static::assertInstanceOf(JWSVerificationFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    #[Test]
+    public function theVerifierForwardsTheCallableUsedToObserveTheDiscardedKeys(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $verifier = new EventDispatchingJWSVerifier(new JWSVerifier($this->algorithms()), $dispatcher);
+        $jws = $this->token();
+        $jwk = null;
+        $errors = [];
+
+        $verifier->verifyWithKeySet(
+            $jws,
+            new JWKSet([$this->unusableKey()]),
+            0,
+            null,
+            $jwk,
+            static function (Throwable $throwable) use (&$errors): void {
+                $errors[] = $throwable;
+            }
+        );
+
+        static::assertCount(1, $errors);
+    }
+
+    #[Test]
+    public function theLoaderDispatchesTheSuccessAndTheFailureEvents(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $loader = new EventDispatchingJWSLoader(
+            new JWSLoader(new JWSSerializerManager([new CompactSerializer()]), new JWSVerifier(
+                $this->algorithms()
+            ), null),
+            $dispatcher
+        );
+        $token = (new CompactSerializer())->serialize($this->token(), 0);
+        $signature = null;
+
+        $jws = $loader->loadAndVerifyWithKeySet($token, new JWKSet([$this->key()]), $signature);
+        static::assertSame('Hello World!', $jws->getPayload());
+        static::assertInstanceOf(JWSLoadingSuccessEvent::class, $dispatcher->lastEvent());
+
+        try {
+            $loader->loadAndVerifyWithKeySet($token, new JWKSet([$this->otherKey()]), $signature);
+            static::fail('The key set cannot verify the token: the load was expected to fail.');
+        } catch (Throwable) {
+        }
+        static::assertInstanceOf(JWSLoadingFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    #[Test]
+    public function theLoaderKeepsTheReasonOfTheFailureWhenTheVerifierIsDecorated(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $loader = new EventDispatchingJWSLoader(
+            new JWSLoader(new JWSSerializerManager([new CompactSerializer()]), new EventDispatchingJWSVerifier(
+                new JWSVerifier($this->algorithms()),
+                $dispatcher
+            ), null),
+            $dispatcher
+        );
+        $token = (new CompactSerializer())->serialize($this->token(), 0);
+        $signature = null;
+
+        try {
+            $loader->loadAndVerifyWithKeySet($token, new JWKSet([$this->unusableKey()]), $signature);
+            static::fail('The key cannot be used: the load was expected to fail.');
+        } catch (Throwable $throwable) {
+            static::assertNotNull($throwable->getPrevious());
+        }
+    }
+
+    private function algorithms(): AlgorithmManager
+    {
+        return new AlgorithmManager([new HS256()]);
+    }
+
+    private function builder(): JWSBuilder
+    {
+        return new JWSBuilder($this->algorithms());
+    }
+
+    private function key(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'dzI6nbW4OcNF-AtfxGAmuyz7IpHRudBI0WgGjZWgaRJt6prBn3DARXgUR8NVwKhfL43QBIU2Un3AvCGCHRgY4TbEqhOi8-i98xxmCggNjde4oaW6wkJ2NgM3Ss9SOX9zS3lcVzdCMdum-RwVJ301kbin4UtGztuzJBeg5oVN00MGxjC2xWwyI0tgXVs-zJs5WlafCuGfX1HrVkIf5bvpE0MQCSjdJpSeVao6-RSTYDajZf7T88a2eVjeW31mMAg-jzAWfUrii61T_bYPJFOXW8kkRWoa1InLRdG6bKB9wQs9-VdXZP60Q4Yuj_WZ-lO7qV9AMNwmSpJ2WdOFyOgKvjRj',
+        ]);
+    }
+
+    private function otherKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+    }
+
+    private function unusableKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+            'use' => 'enc',
+        ]);
+    }
+
+    private function token(): JWS
+    {
+        return $this->builder()
+            ->withPayload('Hello World!')
+            ->addSignature($this->key(), [
+                'alg' => 'HS256',
+            ])
+            ->build();
+    }
+}

--- a/tests/Bundle/JoseFramework/Services/EventDispatchingNestedTokenServicesTest.php
+++ b/tests/Bundle/JoseFramework/Services/EventDispatchingNestedTokenServicesTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Services;
+
+use Jose\Bundle\JoseFramework\Event\NestedTokenIssuedEvent;
+use Jose\Bundle\JoseFramework\Event\NestedTokenLoadingFailureEvent;
+use Jose\Bundle\JoseFramework\Event\NestedTokenLoadingSuccessEvent;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingNestedTokenBuilder;
+use Jose\Bundle\JoseFramework\Services\EventDispatchingNestedTokenLoader;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A256CBCHS512;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\A256KW;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWELoader;
+use Jose\Component\Encryption\Serializer\CompactSerializer as JWECompactSerializer;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use Jose\Component\NestedToken\NestedTokenBuilder;
+use Jose\Component\NestedToken\NestedTokenLoader;
+use Jose\Component\Signature\Algorithm\HS256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer as JWSCompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * The event dispatching nested token services of the bundle used to extend the ones of the library. They are replaced
+ * by decorators, which dispatch the same events without inheriting anything.
+ *
+ * @internal
+ */
+final class EventDispatchingNestedTokenServicesTest extends TestCase
+{
+    #[Test]
+    public function theBuilderDispatchesTheIssuedEventAndTheLoaderReadsTheTokenBack(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $builder = new EventDispatchingNestedTokenBuilder($this->builder(), $dispatcher);
+        $loader = new EventDispatchingNestedTokenLoader($this->loader(), $dispatcher);
+
+        $token = $builder->create(
+            'Hello World!',
+            [[
+                'key' => $this->signatureKey(),
+                'protected_header' => [
+                    'alg' => 'HS256',
+                ],
+            ]],
+            'jws_compact',
+            [
+                'alg' => 'A256KW',
+                'enc' => 'A256CBC-HS512',
+            ],
+            [],
+            [[
+                'key' => $this->encryptionKey(),
+            ]],
+            'jwe_compact'
+        );
+
+        $event = $dispatcher->lastEvent();
+        static::assertInstanceOf(NestedTokenIssuedEvent::class, $event);
+        static::assertSame($token, $event->getNestedToken());
+
+        $signature = null;
+        $jws = $loader->load(
+            $token,
+            new JWKSet([$this->encryptionKey()]),
+            new JWKSet([$this->signatureKey()]),
+            $signature
+        );
+
+        static::assertSame('Hello World!', $jws->getPayload());
+        static::assertInstanceOf(NestedTokenLoadingSuccessEvent::class, $dispatcher->lastEvent());
+    }
+
+    #[Test]
+    public function theLoaderDispatchesTheFailureEvent(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+        $loader = new EventDispatchingNestedTokenLoader($this->loader(), $dispatcher);
+        $signature = null;
+
+        try {
+            $loader->load(
+                'not.a.nested.token',
+                new JWKSet([$this->encryptionKey()]),
+                new JWKSet([$this->signatureKey()]),
+                $signature
+            );
+            static::fail('The token cannot be loaded: the load was expected to fail.');
+        } catch (Throwable) {
+        }
+
+        static::assertInstanceOf(NestedTokenLoadingFailureEvent::class, $dispatcher->lastEvent());
+    }
+
+    private function builder(): NestedTokenBuilder
+    {
+        return new NestedTokenBuilder(
+            new JWEBuilder($this->encryptionAlgorithms()),
+            new JWESerializerManager([new JWECompactSerializer()]),
+            new JWSBuilder($this->signatureAlgorithms()),
+            new JWSSerializerManager([new JWSCompactSerializer()])
+        );
+    }
+
+    private function loader(): NestedTokenLoader
+    {
+        return new NestedTokenLoader(
+            new JWELoader(new JWESerializerManager([new JWECompactSerializer()]), new JWEDecrypter(
+                $this->encryptionAlgorithms()
+            ), null),
+            new JWSLoader(new JWSSerializerManager([new JWSCompactSerializer()]), new JWSVerifier(
+                $this->signatureAlgorithms()
+            ), null)
+        );
+    }
+
+    private function signatureAlgorithms(): AlgorithmManager
+    {
+        return new AlgorithmManager([new HS256()]);
+    }
+
+    private function encryptionAlgorithms(): AlgorithmManager
+    {
+        return new AlgorithmManager([new A256KW(), new A256CBCHS512()]);
+    }
+
+    private function signatureKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'dzI6nbW4OcNF-AtfxGAmuyz7IpHRudBI0WgGjZWgaRJt6prBn3DARXgUR8NVwKhfL43QBIU2Un3AvCGCHRgY4TbEqhOi8-i98xxmCggNjde4oaW6wkJ2NgM3Ss9SOX9zS3lcVzdCMdum-RwVJ301kbin4UtGztuzJBeg5oVN00MGxjC2xWwyI0tgXVs-zJs5WlafCuGfX1HrVkIf5bvpE0MQCSjdJpSeVao6-RSTYDajZf7T88a2eVjeW31mMAg-jzAWfUrii61T_bYPJFOXW8kkRWoa1InLRdG6bKB9wQs9-VdXZP60Q4Yuj_WZ-lO7qV9AMNwmSpJ2WdOFyOgKvjRj',
+        ]);
+    }
+
+    private function encryptionKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => '3pWc2vAZpHoV7XmCT-z2hWhdQquwQwW5a3XTojbf87c',
+        ]);
+    }
+}

--- a/tests/Component/Core/ExtendedJWSBuilder.php
+++ b/tests/Component/Core/ExtendedJWSBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Core;
+
+use Jose\Component\Signature\JWSBuilder;
+
+/**
+ * Extending the services of the library is deprecated: the class only exists to observe the notice.
+ *
+ * @internal
+ */
+final class ExtendedJWSBuilder extends JWSBuilder
+{
+}

--- a/tests/Component/Core/ServiceInterfacesTest.php
+++ b/tests/Component/Core/ServiceInterfacesTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Core;
+
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Checker\ClaimCheckerManagerInterface;
+use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\HeaderCheckerManagerInterface;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\JWEBuilderInterface;
+use Jose\Component\Encryption\JWEDecrypter;
+use Jose\Component\Encryption\JWEDecrypterInterface;
+use Jose\Component\Encryption\JWELoader;
+use Jose\Component\Encryption\JWELoaderInterface;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use Jose\Component\NestedToken\NestedTokenBuilder;
+use Jose\Component\NestedToken\NestedTokenBuilderInterface;
+use Jose\Component\NestedToken\NestedTokenLoader;
+use Jose\Component\NestedToken\NestedTokenLoaderInterface;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSBuilderInterface;
+use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSLoaderInterface;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\JWSVerifierInterface;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function is_a;
+use function restore_error_handler;
+use function set_error_handler;
+use const E_USER_DEPRECATED;
+
+/**
+ * The services of the library are open only because the bundle used to extend them. They now carry an interface, so
+ * that they can be decorated instead, and extending them is deprecated.
+ *
+ * @internal
+ */
+final class ServiceInterfacesTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('services')]
+    public function theServiceImplementsItsInterface(string $service, string $interface): void
+    {
+        static::assertTrue(is_a($service, $interface, true));
+    }
+
+    #[Test]
+    public function extendingAServiceIsDeprecated(): void
+    {
+        $deprecations = $this->collectDeprecations(static fn (): object => new ExtendedJWSBuilder(
+            new AlgorithmManager([])
+        ));
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(JWSBuilder::class, $deprecations[0]);
+        static::assertStringContainsString(JWSBuilderInterface::class, $deprecations[0]);
+    }
+
+    #[Test]
+    public function usingAServiceIsNotDeprecated(): void
+    {
+        $deprecations = $this->collectDeprecations(
+            static fn (): object => new JWSBuilder(new AlgorithmManager([]))
+        );
+
+        static::assertSame([], $deprecations);
+    }
+
+    /**
+     * @return iterable<string, array{class-string, class-string}>
+     */
+    public static function services(): iterable
+    {
+        yield 'JWS builder' => [JWSBuilder::class, JWSBuilderInterface::class];
+        yield 'JWS verifier' => [JWSVerifier::class, JWSVerifierInterface::class];
+        yield 'JWS loader' => [JWSLoader::class, JWSLoaderInterface::class];
+        yield 'JWE builder' => [JWEBuilder::class, JWEBuilderInterface::class];
+        yield 'JWE decrypter' => [JWEDecrypter::class, JWEDecrypterInterface::class];
+        yield 'JWE loader' => [JWELoader::class, JWELoaderInterface::class];
+        yield 'Nested token builder' => [NestedTokenBuilder::class, NestedTokenBuilderInterface::class];
+        yield 'Nested token loader' => [NestedTokenLoader::class, NestedTokenLoaderInterface::class];
+        yield 'Claim checker manager' => [ClaimCheckerManager::class, ClaimCheckerManagerInterface::class];
+        yield 'Header checker manager' => [HeaderCheckerManager::class, HeaderCheckerManagerInterface::class];
+    }
+
+    #[Test]
+    public function theLoadersAcceptAnyImplementationOfTheInterfaces(): void
+    {
+        $jwsLoader = new JWSLoader(
+            new JWSSerializerManager([]),
+            static::createStub(JWSVerifierInterface::class),
+            static::createStub(HeaderCheckerManagerInterface::class)
+        );
+        $jweLoader = new JWELoader(
+            new JWESerializerManager([]),
+            static::createStub(JWEDecrypterInterface::class),
+            static::createStub(HeaderCheckerManagerInterface::class)
+        );
+
+        static::assertInstanceOf(JWSVerifierInterface::class, $jwsLoader->getJwsVerifier());
+        static::assertInstanceOf(JWEDecrypterInterface::class, $jweLoader->getJweDecrypter());
+
+        $nestedTokenLoader = new NestedTokenLoader($jweLoader, $jwsLoader);
+        $nestedTokenBuilder = new NestedTokenBuilder(
+            static::createStub(JWEBuilderInterface::class),
+            new JWESerializerManager([]),
+            static::createStub(JWSBuilderInterface::class),
+            new JWSSerializerManager([])
+        );
+
+        static::assertInstanceOf(NestedTokenLoaderInterface::class, $nestedTokenLoader);
+        static::assertInstanceOf(NestedTokenBuilderInterface::class, $nestedTokenBuilder);
+    }
+
+    /**
+     * @param callable(): object $callable
+     *
+     * @return string[]
+     */
+    private function collectDeprecations(callable $callable): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}


### PR DESCRIPTION
Closes #684.

## What

Every main service of the library now implements an interface, the library type-hints those interfaces internally, and the bundle ships a decorator for each of its event dispatching services. Nothing changes for existing code: no signature is narrowed, no service id moves, no runtime type changes.

### Library

New interfaces, implemented by the existing classes:

| Interface | Implementation |
| --- | --- |
| `Jose\Component\Signature\JWSBuilderInterface` | `JWSBuilder` |
| `Jose\Component\Signature\JWSVerifierInterface` | `JWSVerifier` |
| `Jose\Component\Signature\JWSLoaderInterface` | `JWSLoader` |
| `Jose\Component\Encryption\JWEBuilderInterface` | `JWEBuilder` |
| `Jose\Component\Encryption\JWEDecrypterInterface` | `JWEDecrypter` |
| `Jose\Component\Encryption\JWELoaderInterface` | `JWELoader` |
| `Jose\Component\NestedToken\NestedTokenBuilderInterface` | `NestedTokenBuilder` |
| `Jose\Component\NestedToken\NestedTokenLoaderInterface` | `NestedTokenLoader` |
| `Jose\Component\Checker\ClaimCheckerManagerInterface` | `ClaimCheckerManager` |
| `Jose\Component\Checker\HeaderCheckerManagerInterface` | `HeaderCheckerManager` |

`JWSLoader`, `JWELoader`, `NestedTokenBuilder` and `NestedTokenLoader` accept and return the interfaces instead of the concrete classes, so a decorator can be injected into any of them.

Extending the concrete classes is deprecated: they carry a `@final` annotation and their constructor raises a deprecation notice through `InheritanceChecker`. The event dispatching services of the bundle are excluded from that notice - they are deprecated themselves and cannot be avoided in 4.3 - so the notice only ever points at code the user owns.

### Bundle

- Ten decorators, one per event dispatching service: `EventDispatchingJWSBuilder`, `EventDispatchingJWSVerifier`, `EventDispatchingJWSLoader`, `EventDispatchingJWEBuilder`, `EventDispatchingJWEDecrypter`, `EventDispatchingJWELoader`, `EventDispatchingNestedTokenBuilder`, `EventDispatchingNestedTokenLoader`, `EventDispatchingClaimCheckerManager` and `EventDispatchingHeaderCheckerManager`. They dispatch the same events without inheriting anything.
- The inheritance based `Services\*` classes are annotated `@deprecated` and keep doing the work in 4.3: swapping them for the decorators changes the runtime type of `jose.jws_builder.*` and friends, which would break every `JWSBuilder $builder` type hint. That swap belongs to 5.0.0.
- Every service is now aliased with its interface as well as with its class, so `JWSBuilderInterface $builder1JwsBuilder` autowires exactly like `JWSBuilder $builder1JwsBuilder` does.

### One bug fixed along the way

`Services\JWSVerifier::verifyWithKeySet()` and `Services\JWEDecrypter::decryptUsingKeySet()` declared five parameters and forwarded only those five to the parent, dropping the callable the loaders pass as a sixth argument to observe the discarded keys. The exception chaining added in #699 was therefore lost as soon as the bundle services were in use. Both now read and forward it with `func_num_args()`/`func_get_arg(5)`, as the new decorators do.

## Deliberate limitations

- `create()` is deliberately absent from the two builder interfaces. #683 made the builders immutable and deprecated it, so there is no state to reset and the method disappears in 5.0.0. The concrete classes still carry it, so nothing existing breaks.
- The failure events of the two builders carry internal state (`signature_algorithm`, `key_encryption_algorithm`) that a decorator cannot read. The decorators report the key and the headers they were given instead; the class docblocks say so. Exposing that data through the events themselves is part of the 5.0.0 plan.
- The factories keep their concrete return types. A shared factory interface would have to settle the parameter name mismatch between `Component\NestedToken\NestedTokenLoaderFactory::create()` and its bundle counterpart, which is a change of its own.

## Backward compatibility

Constructor parameters were widened from classes to interfaces (contravariant, safe for callers). `JWSLoader::getJwsVerifier()`, `JWSLoader::getHeaderCheckerManager()`, `JWELoader::getJweDecrypter()` and `JWELoader::getHeaderCheckerManager()` now return the interface; the interfaces expose the full public API of the classes they replace, so no call site can break. Everything else is additive.

## Checks

Rebased on top of #706. `phpunit` (949 tests), `ecs`, `phpstan`, `deptrac` and `rector --dry-run` are green. The PHPStan baseline was regenerated: it gained the entries for the bundle's own use of its now deprecated services and lost four `missingType.iterableValue` entries that the new interface docblocks fix.

