### PR TITLE
feat(key-management): free JKUFactory and X5UFactory from a deprecated base

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -5198,18 +5198,6 @@ parameters:
 			path: ../src/Library/KeyManagement/Analyzer/ZxcvbnKeyAnalyzer.php
 
 		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JKUFactory::loadFromUrl() has parameter $header with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JKUFactory.php
-
-		-
-			rawMessage: 'Parameter #2 $header of method Jose\Component\KeyManagement\UrlKeySetFactory::getContent() expects array<string, array<string>|string>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/KeyManagement/JKUFactory.php
-
-		-
 			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromCertificate() has parameter $additional_values with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -5376,24 +5364,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/KeyManagement/KeyConverter/RSAKey.php
-
-		-
-			rawMessage: 'Call to an undefined method Jose\Component\KeyManagement\UrlKeySetFactory::sendPsrRequest().'
-			identifier: method.notFound
-			count: 1
-			path: ../src/Library/KeyManagement/UrlKeySetFactory.php
-
-		-
-			rawMessage: Instanceof between Symfony\Contracts\HttpClient\HttpClientInterface and Symfony\Contracts\HttpClient\HttpClientInterface will always evaluate to true.
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: ../src/Library/KeyManagement/UrlKeySetFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\UrlKeySetFactory::getContent() should return string but returns mixed.'
-			identifier: return.type
-			count: 1
-			path: ../src/Library/KeyManagement/UrlKeySetFactory.php
 
 		-
 			rawMessage: 'Parameter #2 $recipient of method Jose\Component\NestedToken\NestedTokenLoader::checkContentTypeHeader() expects int, int|null given.'

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "roave/security-advisories": "dev-latest",
         "spomky-labs/aes-key-wrap": "^7.0|^8.0",
         "symfony/browser-kit": "^7.0|^8.0",
+        "symfony/cache": "^7.0|^8.0",
         "symfony/clock": "^7.0|^8.0",
         "symfony/finder": "^7.0|^8.0",
         "symfony/framework-bundle": "^7.0|^8.0",

--- a/src/Library/KeyManagement/JKUFactory.php
+++ b/src/Library/KeyManagement/JKUFactory.php
@@ -9,10 +9,17 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\JsonConverter;
 use function is_array;
 
-class JKUFactory extends UrlKeySetFactory
+/**
+ * @see \Jose\Tests\Component\KeyManagement\UrlKeySetFactoryTest
+ */
+class JKUFactory
 {
+    use UrlKeySetFactoryTrait;
+
     /**
      * This method will try to fetch the url a retrieve the key set. Throws an exception in case of failure.
+     *
+     * @param array<string, string|string[]> $header
      */
     public function loadFromUrl(string $url, array $header = []): JWKSet
     {

--- a/src/Library/KeyManagement/UrlKeySetFactory.php
+++ b/src/Library/KeyManagement/UrlKeySetFactory.php
@@ -4,71 +4,37 @@ declare(strict_types=1);
 
 namespace Jose\Component\KeyManagement;
 
-use Jose\Component\Core\Exception\RuntimeException;
-use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use function trigger_deprecation;
 
 /**
- * @see \Jose\Tests\Component\KeyManagement\UrlKeySetFactoryTest
+ * Base class JKUFactory and X5UFactory used to extend.
+ *
+ * Those two classes now carry their own implementation, so nothing in this package extends this one any more and
+ * neither of them emits the deprecation below. What is deprecated is this class as a public extension point: it
+ * never had a behaviour of its own beyond fetching a URL and caching the response, and the cache it offers -
+ * a PSR-6 pool with a fixed lifetime, unaware of the cache directives of the endpoint - is better handled by the
+ * HTTP client it is given.
+ *
+ * @deprecated since 4.3.0 and will be removed in 5.0.0. Use JKUFactory or X5UFactory, which no longer extend this
+ *             class, or write a factory of your own: an HTTP client is all that is needed to fetch the document.
  */
 abstract class UrlKeySetFactory
 {
-    private CacheItemPoolInterface $cacheItemPool;
+    use UrlKeySetFactoryTrait;
 
-    private int $expiresAfter = 3600;
-
-    public function __construct(
-        private readonly HttpClientInterface $client,
-    ) {
-        $this->cacheItemPool = new NullAdapter();
-    }
-
-    /**
-     * @deprecated since 4.1 and will be removed in 5.0. Please use the Http Client to cache the responses instead.
-     */
-    public function enabledCache(CacheItemPoolInterface $cacheItemPool, int $expiresAfter = 3600): void
+    public function __construct(HttpClientInterface $client)
     {
-        $this->cacheItemPool = $cacheItemPool;
-        $this->expiresAfter = $expiresAfter;
-    }
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The class "%s" is deprecated and will be removed in 5.0.0. "%s" extends it: use "%s" or "%s", which do not extend it any more, or fetch the document with the HTTP client directly.',
+            self::class,
+            static::class,
+            JKUFactory::class,
+            X5UFactory::class
+        );
 
-    /**
-     * @param array<string, string|string[]> $header
-     */
-    protected function getContent(string $url, array $header = []): string
-    {
-        $cacheKey = hash('xxh128', $url);
-        $item = $this->cacheItemPool->getItem($cacheKey);
-        if ($item->isHit()) {
-            return $item->get();
-        }
-
-        $content = $this->client instanceof HttpClientInterface ? $this->sendSymfonyRequest(
-            $url,
-            $header
-        ) : $this->sendPsrRequest($url, $header);
-        $item = $this->cacheItemPool->getItem($cacheKey);
-        $item->expiresAfter($this->expiresAfter);
-        $item->set($content);
-        $this->cacheItemPool->save($item);
-
-        return $content;
-    }
-
-    /**
-     * @param array<string, string|string[]> $header
-     */
-    private function sendSymfonyRequest(string $url, array $header = []): string
-    {
-        $response = $this->client->request('GET', $url, [
-            'headers' => $header,
-        ]);
-
-        if ($response->getStatusCode() >= 400) {
-            throw new RuntimeException('Unable to get the key set.', $response->getStatusCode());
-        }
-
-        return $response->getContent();
+        $this->client = $client;
     }
 }

--- a/src/Library/KeyManagement/UrlKeySetFactoryTrait.php
+++ b/src/Library/KeyManagement/UrlKeySetFactoryTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\KeyManagement;
+
+use Jose\Component\Core\Exception\RuntimeException;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use function hash;
+use function is_string;
+use function trigger_deprecation;
+
+/**
+ * Fetches the document a "jku" or a "x5u" header parameter points to.
+ *
+ * This is the shared implementation of JKUFactory and X5UFactory, which used to inherit it from UrlKeySetFactory.
+ * That class is deprecated and removed in 5.0.0; a trait carries the same code without giving the two factories a
+ * base class they would then have to keep. It is an implementation detail of those two classes: it is not covered
+ * by the backward compatibility promise and must not be used outside of this package.
+ *
+ * @internal
+ *
+ * @see \Jose\Tests\Component\KeyManagement\UrlKeySetFactoryTest
+ */
+trait UrlKeySetFactoryTrait
+{
+    private readonly HttpClientInterface $client;
+
+    private ?CacheItemPoolInterface $cacheItemPool = null;
+
+    private int $expiresAfter = 3600;
+
+    public function __construct(HttpClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Stores the responses in the given pool instead of fetching the URL on every call.
+     *
+     * @deprecated since 4.1.0 and will be removed in 5.0.0. Give the constructor an HTTP client that caches the
+     *             responses instead: Symfony's CachingHttpClient wraps any client and honours the cache directives
+     *             of the "jku"/"x5u" endpoint, which the fixed lifetime used here ignores.
+     */
+    public function enabledCache(CacheItemPoolInterface $cacheItemPool, int $expiresAfter = 3600): void
+    {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.1.0',
+            'The method "%s::enabledCache()" is deprecated and will be removed in 5.0.0. Give the constructor an HTTP client that caches the responses instead, such as "Symfony\Component\HttpClient\CachingHttpClient".',
+            self::class
+        );
+
+        $this->cacheItemPool = $cacheItemPool;
+        $this->expiresAfter = $expiresAfter;
+    }
+
+    /**
+     * @param array<string, string|string[]> $header
+     */
+    protected function getContent(string $url, array $header = []): string
+    {
+        if ($this->cacheItemPool === null) {
+            return $this->sendRequest($url, $header);
+        }
+
+        $item = $this->cacheItemPool->getItem(hash('xxh128', $url));
+        $cached = $item->get();
+        if ($item->isHit() && is_string($cached)) {
+            return $cached;
+        }
+
+        $content = $this->sendRequest($url, $header);
+        $item->expiresAfter($this->expiresAfter);
+        $item->set($content);
+        $this->cacheItemPool->save($item);
+
+        return $content;
+    }
+
+    /**
+     * @param array<string, string|string[]> $header
+     */
+    private function sendRequest(string $url, array $header): string
+    {
+        $response = $this->client->request('GET', $url, [
+            'headers' => $header,
+        ]);
+
+        if ($response->getStatusCode() >= 400) {
+            throw new RuntimeException('Unable to get the key set.', $response->getStatusCode());
+        }
+
+        return $response->getContent();
+    }
+}

--- a/src/Library/KeyManagement/X5UFactory.php
+++ b/src/Library/KeyManagement/X5UFactory.php
@@ -13,8 +13,13 @@ use function assert;
 use function is_array;
 use function is_string;
 
-class X5UFactory extends UrlKeySetFactory
+/**
+ * @see \Jose\Tests\Component\KeyManagement\UrlKeySetFactoryTest
+ */
+class X5UFactory
 {
+    use UrlKeySetFactoryTrait;
+
     /**
      * This method will try to fetch the url a retrieve the key set. Throws an exception in case of failure.
      *

--- a/tests/Component/KeyManagement/UrlKeySetFactoryTest.php
+++ b/tests/Component/KeyManagement/UrlKeySetFactoryTest.php
@@ -6,19 +6,28 @@ namespace Jose\Tests\Component\KeyManagement;
 
 use InvalidArgumentException;
 use Jose\Component\KeyManagement\JKUFactory;
+use Jose\Component\KeyManagement\UrlKeySetFactory;
 use Jose\Component\KeyManagement\X5UFactory;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use function restore_error_handler;
+use function set_error_handler;
+use const E_USER_DEPRECATED;
 
 /**
  * @internal
  */
 final class UrlKeySetFactoryTest extends TestCase
 {
+    private const KEY_SET = '{"keys":[{"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}]}';
+
+    private const CERTIFICATE_SET = '["MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVM\nxITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR2\n8gRGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjExM\nTYwMTU0MzdaFw0yNjExMTYwMTU0MzdaMIHKMQswCQYDVQQGEwJVUzEQMA4GA1UE\nCBMHQXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEaMBgGA1UEChMRR29EYWR\nkeS5jb20sIEluYy4xMzAxBgNVBAsTKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYW\nRkeS5jb20vcmVwb3NpdG9yeTEwMC4GA1UEAxMnR28gRGFkZHkgU2VjdXJlIENlc\nnRpZmljYXRpb24gQXV0aG9yaXR5MREwDwYDVQQFEwgwNzk2OTI4NzCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMQt1RWMnCZM7DI161+4WQFapmGBWTt\nwY6vj3D3HKrjJM9N55DrtPDAjhI6zMBS2sofDPZVUBJ7fmd0LJR4h3mUpfjWoqV\nTr9vcyOdQmVZWt7/v+WIbXnvQAjYwqDL1CBM6nPwT27oDyqu9SoWlm2r4arV3aL\nGbqGmu75RpRSgAvSMeYddi5Kcju+GZtCpyz8/x4fKL4o/K1w/O5epHBp+YlLpyo\n7RJlbmr2EkRTcDCVw5wrWCs9CHRK8r5RsL+H0EwnWGu1NcWdrxcx+AuP7q2BNgW\nJCJjPOq8lh8BJ6qf9Z/dFjpfMFDniNoW1fho3/Rb2cRGadDAW/hOUoz+EDU8CAw\nEAAaOCATIwggEuMB0GA1UdDgQWBBT9rGEyk2xF1uLuhV+auud2mWjM5zAfBgNVH\nSMEGDAWgBTSxLDSkdRMEXGzYcs9of7dqGrU4zASBgNVHRMBAf8ECDAGAQH/AgEA\nMDMGCCsGAQUFBwEBBCcwJTAjBggrBgEFBQcwAYYXaHR0cDovL29jc3AuZ29kYWR\nkeS5jb20wRgYDVR0fBD8wPTA7oDmgN4Y1aHR0cDovL2NlcnRpZmljYXRlcy5nb2\nRhZGR5LmNvbS9yZXBvc2l0b3J5L2dkcm9vdC5jcmwwSwYDVR0gBEQwQjBABgRVH\nSAAMDgwNgYIKwYBBQUHAgEWKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5j\nb20vcmVwb3NpdG9yeTAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggE\nBANKGwOy9+aG2Z+5mC6IGOgRQjhVyrEp0lVPLN8tESe8HkGsz2ZbwlFalEzAFPI\nUyIXvJxwqoJKSQ3kbTJSMUA2fCENZvD117esyfxVgqwcSeIaha86ykRvOe5GPLL\n5CkKSkB2XIsKd83ASe8T+5o0yGPwLPk9Qnt0hCqU7S+8MxZC9Y7lhyVJEnfzuz9\np0iRFEUOOjZv2kWzRaJBydTXRE4+uXR21aITVSzGh6O1mawGhId/dQb8vxRMDsx\nuxN89txJx9OjxUUAiKEngHUuHqDTMBqLdElrRhjZkAzVvb3du6/KFUJheqwNTrZ\nEjYx8WnM25sgVjOuH0aBsXBTWVU+4="]';
+
     private ?JKUFactory $jkuFactory = null;
 
     private ?X5UFactory $x5uFactory = null;
@@ -120,6 +129,77 @@ final class UrlKeySetFactoryTest extends TestCase
             ->loadFromUrl('https://foo.bar/bad/url');
     }
 
+    #[Test]
+    public function theFactoriesDoNotExtendTheDeprecatedBaseClass(): void
+    {
+        static::assertNotInstanceOf(UrlKeySetFactory::class, $this->getJKUFactory());
+        static::assertNotInstanceOf(UrlKeySetFactory::class, $this->getX5UFactory());
+    }
+
+    #[Test]
+    public function loadingAKeySetDoesNotTriggerADeprecation(): void
+    {
+        $this->getHttpClient()
+            ->setResponseFactory([
+                new MockResponse(self::KEY_SET, [
+                    'http_code' => 200,
+                ]),
+                new MockResponse(self::CERTIFICATE_SET, [
+                    'http_code' => 200,
+                ]),
+            ]);
+        $jkuFactory = $this->getJKUFactory();
+        $x5uFactory = $this->getX5UFactory();
+
+        $deprecations = $this->collectDeprecations(static function () use ($jkuFactory, $x5uFactory): void {
+            $jkuFactory->loadFromUrl('https://foo.bar/keys');
+            $x5uFactory->loadFromUrl('https://foo.bar/keys');
+        });
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function extendingTheDeprecatedBaseClassTriggersADeprecation(): void
+    {
+        $client = $this->getHttpClient();
+
+        $deprecations = $this->collectDeprecations(static function () use ($client): void {
+            new class($client) extends UrlKeySetFactory {};
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            'The class "Jose\Component\KeyManagement\UrlKeySetFactory" is deprecated',
+            $deprecations[0]
+        );
+    }
+
+    #[Test]
+    public function theDeprecatedCacheStillPreventsASecondRequest(): void
+    {
+        $client = new MockHttpClient([
+            new MockResponse(self::KEY_SET, [
+                'http_code' => 200,
+            ]),
+            new MockResponse('Not found', [
+                'http_code' => 404,
+            ]),
+        ]);
+        $factory = new JKUFactory($client);
+
+        $deprecations = $this->collectDeprecations(static function () use ($factory): void {
+            $factory->enabledCache(new ArrayAdapter());
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('::enabledCache()" is deprecated', $deprecations[0]);
+
+        static::assertCount(1, $factory->loadFromUrl('https://foo.bar/keys'));
+        static::assertCount(1, $factory->loadFromUrl('https://foo.bar/keys'));
+        static::assertSame(1, $client->getRequestsCount());
+    }
+
     private function getJKUFactory(): JKUFactory
     {
         if ($this->jkuFactory === null) {
@@ -136,6 +216,29 @@ final class UrlKeySetFactoryTest extends TestCase
         }
 
         return $this->x5uFactory;
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
     }
 
     private function getHttpClient(): MockHttpClient


### PR DESCRIPTION
Closes #694.

`UrlKeySetFactory` is announced for removal in 5.0.0, but `JKUFactory` and `X5UFactory` — the documented way to load a `jku` / `x5u` key set, and not deprecated themselves — extend it. The removal could not happen as it stood, and the deprecation named no replacement.

## What changes

**The fetching code moves to an `@internal` trait**, `UrlKeySetFactoryTrait`, which `JKUFactory` and `X5UFactory` use. They no longer inherit anything from the deprecated class, so it can be deleted in 5.0.0 without touching them, and neither of them emits a deprecation. A trait rather than a shared base class: nothing can type-hint it, so the two factories keep a free hand for 5.0.0.

**`UrlKeySetFactory` keeps the same code** — it uses the same trait — and now says what is deprecated and what replaces it. It is the class *as a public extension point* that goes away; it never had a behaviour of its own beyond fetching a URL and caching the response. Extending it raises a deprecation notice, which is what the class annotation could not do on its own.

**`enabledCache()` states its replacement too**: an HTTP client that caches the responses, e.g. Symfony's `CachingHttpClient`, which honours the cache directives of the endpoint where the fixed lifetime of the pool ignores them. It raises the notice it only carried as an annotation since 4.1.0. Its behaviour is unchanged — a test covers that a second `loadFromUrl()` still hits the pool instead of the network.

**Two clean-ups on the way**, both in the code being moved:

- the pool is left unset until `enabledCache()` is called, instead of being seeded with a `NullAdapter` that was never a hit. The library no longer pulls `symfony/cache` in for it — it moves to `require-dev`, where the tests use it;
- a dead branch calling a `sendPsrRequest()` that does not exist, unreachable because the client is type-hinted as a Symfony one. Both PHPStan ignores it needed are gone from the baseline, along with the two `JKUFactory` entries that `@param array<string, string|string[]> $header` on `loadFromUrl()` now settles.

## Compatibility

One theoretical break: `$jkuFactory instanceof UrlKeySetFactory` is now `false`. The class is abstract, has no behaviour worth type-hinting, and nothing in the library, the bundle or the console commands ever referred to it — they all use the concrete classes. Every public method and signature of `JKUFactory` and `X5UFactory` is unchanged, `getContent()` included.

## Follow-up for 5.0.0

Delete `UrlKeySetFactory` and `enabledCache()`; fold the trait into the two factories if only they still use it.

## Checks

`phpunit` (953 tests), `ecs`, `phpstan`, `deptrac` — all green.