### PR TITLE
feat(core): seal the internal mutators of the JWS and the JWE

### DIFF
--- a/src/Library/Core/Util/InternalCallChecker.php
+++ b/src/Library/Core/Util/InternalCallChecker.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Core\Util;
+
+use function debug_backtrace;
+use function is_a;
+use function trigger_deprecation;
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
+
+/**
+ * Raises the deprecation notice emitted when a mutator reserved to the library is called from outside of it.
+ *
+ * The JWS and the JWE are not built in one go: the builders and the serializers create an empty object and then feed
+ * it with the signatures, respectively with the decrypted payload. Those mutators had to be public for that reason,
+ * which is also what leaves a token returned by a loader modifiable by anybody holding it. They are annotated
+ * "@internal" but nothing enforced it, and no static analyser could report their use.
+ *
+ * The caller is the class owning the frame below the mutator; a call made from a plain function, from a closure
+ * bound to no class or from the global scope has no such class and is therefore reported.
+ *
+ * @internal
+ */
+final class InternalCallChecker
+{
+    /**
+     * @param list<class-string> $allowedCallers The classes and interfaces the method is reserved to; a subclass or an
+     *                                           implementation of any of them is allowed as well
+     * @param string             $advice         What the caller is expected to do instead, appended to the notice
+     */
+    public static function warnIfCalledFromOutside(string $method, array $allowedCallers, string $advice): void
+    {
+        // @phpstan-ignore ekinoBannedCode.function (the caller is only identifiable through the stack, and the arguments are not collected)
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['class'] ?? null;
+        if ($caller !== null) {
+            foreach ($allowedCallers as $allowedCaller) {
+                if (is_a($caller, $allowedCaller, true)) {
+                    return;
+                }
+            }
+        }
+
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s()" is internal to the library. Calling it is deprecated and it will not be possible in '
+            . '5.0.0. %s',
+            $method,
+            $advice
+        );
+    }
+}

--- a/src/Library/Encryption/JWE.php
+++ b/src/Library/Encryption/JWE.php
@@ -7,11 +7,21 @@ namespace Jose\Component\Encryption;
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use Jose\Component\Core\JWT;
+use Jose\Component\Core\Util\InternalCallChecker;
 use Override;
 use function array_key_exists;
 use function count;
 use function sprintf;
 
+/**
+ * An encrypted token, as returned by the builder or by a serializer.
+ *
+ * Every part of the token is given to the constructor but the plaintext, which is only known once a recipient has
+ * been decrypted: withPayload() is reserved to the decrypter for that reason. The object is otherwise immutable and
+ * must be treated as such, since the payload it exposes is the one the decrypter authenticated against the
+ * ciphertext, the tag and the additional authenticated data. The class will be final and readonly in 5.0.0, where
+ * the decrypted payload is given to the constructor.
+ */
 class JWE implements JWT
 {
     private ?string $payload = null;
@@ -36,9 +46,22 @@ class JWE implements JWT
 
     /**
      * Set the payload. This method is immutable and a new object will be returned.
+     *
+     * The method is reserved to the JWE decrypter, the only object able to tell that the given plaintext is the one
+     * protected by the token. Calling it from anywhere else is deprecated since 4.3.0 and raises a deprecation
+     * notice: it lets any caller replace the payload of a decrypted token by an arbitrary value, and it will not be
+     * possible in 5.0.0, where the payload is given to the constructor.
+     *
+     * @internal
      */
     public function withPayload(string $payload): self
     {
+        InternalCallChecker::warnIfCalledFromOutside(
+            self::class . '::withPayload',
+            [self::class, JWEDecrypterInterface::class],
+            'The payload of a JWE is set by the decrypter only. In 5.0.0 it is passed to the constructor of the JWE.'
+        );
+
         $clone = clone $this;
         $clone->payload = $payload;
 

--- a/src/Library/Signature/JWS.php
+++ b/src/Library/Signature/JWS.php
@@ -6,10 +6,20 @@ namespace Jose\Component\Signature;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWT;
+use Jose\Component\Core\Util\InternalCallChecker;
+use Jose\Component\Signature\Serializer\JWSSerializer;
 use Override;
 use function count;
 
 /**
+ * A signed token, as returned by the builder or by a serializer.
+ *
+ * The object is assembled incrementally: the payload is given to the constructor and the signatures are appended by
+ * addSignature(), which is reserved to the builder and to the serializers. It is otherwise immutable and must be
+ * treated as such: a token returned by a loader carries signatures that have been verified against its payload, and
+ * nothing else is allowed to append to that list. The class will be final and readonly in 5.0.0, where the
+ * signatures are given to the constructor.
+ *
  * @see \Jose\Tests\Component\Signature\JWSTest
  */
 class JWS implements JWT
@@ -77,6 +87,11 @@ class JWS implements JWT
     /**
      * This method adds a signature to the JWS object. Its returns a new JWS object.
      *
+     * The method is reserved to the JWS builder and to the JWS serializers, the only objects that assemble a token
+     * from its parts. Calling it from anywhere else is deprecated since 4.3.0 and raises a deprecation notice: it
+     * defeats the immutability of the object and it will not be possible in 5.0.0, where the signatures are given
+     * to the constructor.
+     *
      * @internal
      *
      * @param array<string, mixed> $protectedHeader
@@ -88,6 +103,13 @@ class JWS implements JWT
         ?string $encodedProtectedHeader,
         array $header = []
     ): self {
+        InternalCallChecker::warnIfCalledFromOutside(
+            self::class . '::addSignature',
+            [self::class, JWSBuilderInterface::class, JWSSerializer::class],
+            'A JWS is assembled by the builder and by the serializers only. In 5.0.0 the signatures are passed to '
+            . 'the constructor of the JWS.'
+        );
+
         $jws = clone $this;
         $jws->signatures[] = new Signature($signature, $protectedHeader, $encodedProtectedHeader, $header);
 

--- a/src/Library/Signature/Signature.php
+++ b/src/Library/Signature/Signature.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature;
 
+use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use function array_key_exists;
 use function sprintf;
+use function trigger_deprecation;
 
+/**
+ * One signature of a JWS, with the two headers it was computed with.
+ *
+ * The protected header of a signature is defined by its encoded form: that string is what the signature covers, and
+ * it is the only proof that the parameters it carries were protected. A signature built without an encoded protected
+ * header therefore has no protected header at all, and the decoded one given to the constructor is discarded rather
+ * than exposed, so that getProtectedHeader() never advertises parameters no signature protects. The class will be
+ * final and readonly in 5.0.0, where the two arguments must agree.
+ */
 class Signature
 {
     private readonly ?string $encodedProtectedHeader;
@@ -18,8 +29,12 @@ class Signature
     private readonly array $protectedHeader;
 
     /**
-     * @param array<string, mixed> $protectedHeader
-     * @param array<string, mixed> $header
+     * @param array<string, mixed> $protectedHeader        The decoded protected header; it is discarded, and passing a
+     *                                                     non-empty one is deprecated since 4.3.0, when
+     *                                                     $encodedProtectedHeader is null
+     * @param string|null          $encodedProtectedHeader The Base64Url encoded protected header the signature covers,
+     *                                                     or null when the signature has no protected header
+     * @param array<string, mixed> $header                 The unprotected header
      */
     public function __construct(
         private readonly string $signature,
@@ -27,6 +42,15 @@ class Signature
         ?string $encodedProtectedHeader,
         private readonly array $header
     ) {
+        if ($encodedProtectedHeader === null && $protectedHeader !== []) {
+            trigger_deprecation(
+                'web-token/jwt-framework',
+                '4.3.0',
+                'Passing a protected header to "%s" without its encoded form is deprecated and will throw an "%s" in 5.0.0. The header is discarded: a signature that does not cover an encoded protected header has no protected header.',
+                self::class,
+                InvalidArgumentException::class
+            );
+        }
         $this->protectedHeader = $encodedProtectedHeader === null ? [] : $protectedHeader;
         $this->encodedProtectedHeader = $encodedProtectedHeader;
     }

--- a/tests/Component/Encryption/SealedJWEMutatorTest.php
+++ b/tests/Component/Encryption/SealedJWEMutatorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Encryption;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Encryption\DecryptionResult;
+use Jose\Component\Encryption\JWE;
+use PHPUnit\Framework\Attributes\Test;
+use function restore_error_handler;
+use function set_error_handler;
+use const E_USER_DEPRECATED;
+
+/**
+ * The payload of a JWE is only known once a recipient has been decrypted, which is why the decrypter is the only
+ * object allowed to set it. Calling the mutator from anywhere else is deprecated, so that the payload exposed by a
+ * token remains the one that was authenticated against the ciphertext.
+ *
+ * @internal
+ */
+final class SealedJWEMutatorTest extends EncryptionTestCase
+{
+    private const PAYLOAD = 'Live long and prosper.';
+
+    #[Test]
+    public function settingThePayloadFromOutsideTheLibraryIsDeprecated(): void
+    {
+        $jwe = $this->buildJWE();
+
+        $deprecations = $this->collectDeprecations(static function () use ($jwe): void {
+            $jwe->withPayload('Another payload.');
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            'The method "Jose\Component\Encryption\JWE::withPayload()" is internal to the library.',
+            $deprecations[0]
+        );
+    }
+
+    #[Test]
+    public function theDecrypterSetsThePayloadWithoutDeprecation(): void
+    {
+        $jwe = $this->buildJWE();
+
+        $result = null;
+        $deprecations = $this->collectDeprecations(function () use ($jwe, &$result): void {
+            $result = $this->getJWEDecrypterFactory()
+                ->create(['A128KW', 'A128CBC-HS256'])
+                ->decrypt($jwe, $this->getKey(), 0);
+        });
+
+        static::assertSame([], $deprecations);
+        static::assertInstanceOf(DecryptionResult::class, $result);
+        static::assertTrue($result->isDecrypted());
+        static::assertSame(self::PAYLOAD, $result->getJwe()->getPayload());
+    }
+
+    private function buildJWE(): JWE
+    {
+        return $this->getJWEBuilderFactory()
+            ->create(['A128KW', 'A128CBC-HS256'])
+            ->withPayload(self::PAYLOAD)
+            ->withSharedProtectedHeader([
+                'alg' => 'A128KW',
+                'enc' => 'A128CBC-HS256',
+            ])
+            ->addRecipient($this->getKey())
+            ->build();
+    }
+
+    private function getKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+        ]);
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}

--- a/tests/Component/Signature/JWSTest.php
+++ b/tests/Component/Signature/JWSTest.php
@@ -8,15 +8,20 @@ use InvalidArgumentException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Signature\JWS;
 use LogicException;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use const JSON_THROW_ON_ERROR;
 
 /**
+ * The tests that assemble a JWS by hand call the mutator reserved to the builder and to the serializers, hence the
+ * deprecation they are expected to trigger.
+ *
  * @internal
  */
 final class JWSTest extends SignatureTestCase
 {
     #[Test]
+    #[IgnoreDeprecations]
     public function jWS(): void
     {
         $claims = [
@@ -99,6 +104,7 @@ final class JWSTest extends SignatureTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function signatureContainsUnprotectedHeader(): void
     {
         $this->expectException(LogicException::class);
@@ -127,6 +133,7 @@ final class JWSTest extends SignatureTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function signatureDoesNotContainHeader(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -150,6 +157,7 @@ final class JWSTest extends SignatureTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function signatureDoesNotContainProtectedHeader(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Component/Signature/SealedJWSMutatorTest.php
+++ b/tests/Component/Signature/SealedJWSMutatorTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Signature;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\Signature;
+use PHPUnit\Framework\Attributes\Test;
+use function restore_error_handler;
+use function set_error_handler;
+use const E_USER_DEPRECATED;
+
+/**
+ * A JWS is assembled by the builder and by the serializers, the only objects allowed to append a signature to it.
+ * Calling the mutator from anywhere else is deprecated, so that a token returned by a loader is not modified after
+ * its signatures have been verified.
+ *
+ * @internal
+ */
+final class SealedJWSMutatorTest extends SignatureTestCase
+{
+    private const PAYLOAD = 'Live long and prosper.';
+
+    #[Test]
+    public function addingASignatureFromOutsideTheLibraryIsDeprecated(): void
+    {
+        $jws = new JWS(self::PAYLOAD);
+
+        $deprecations = $this->collectDeprecations(static function () use ($jws): void {
+            $jws->addSignature('signature', [], null);
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            'The method "Jose\Component\Signature\JWS::addSignature()" is internal to the library.',
+            $deprecations[0]
+        );
+    }
+
+    #[Test]
+    public function theBuilderAndTheSerializersAssembleAJWSWithoutDeprecation(): void
+    {
+        $jws = null;
+        $deprecations = $this->collectDeprecations(function () use (&$jws): void {
+            $jws = $this->getJWSBuilderFactory()
+                ->create(['HS256'])
+                ->withPayload(self::PAYLOAD)
+                ->addSignature($this->getKey(), [
+                    'alg' => 'HS256',
+                ])
+                ->build();
+        });
+
+        static::assertSame([], $deprecations);
+        static::assertInstanceOf(JWS::class, $jws);
+
+        $token = $this->getJWSSerializerManager()
+            ->serialize('jws_compact', $jws, 0);
+        $unserialized = null;
+        $deprecations = $this->collectDeprecations(function () use ($token, &$unserialized): void {
+            $unserialized = $this->getJWSSerializerManager()
+                ->unserialize($token);
+        });
+
+        static::assertSame([], $deprecations);
+        static::assertInstanceOf(JWS::class, $unserialized);
+        static::assertSame(self::PAYLOAD, $unserialized->getPayload());
+    }
+
+    #[Test]
+    public function splittingAJWSDoesNotEmitADeprecation(): void
+    {
+        $jws = $this->getJWSBuilderFactory()
+            ->create(['HS256'])
+            ->withPayload(self::PAYLOAD)
+            ->addSignature($this->getKey(), [
+                'alg' => 'HS256',
+            ])
+            ->build();
+
+        $split = null;
+        $deprecations = $this->collectDeprecations(static function () use ($jws, &$split): void {
+            $split = $jws->split();
+        });
+
+        static::assertSame([], $deprecations);
+        static::assertCount(1, $split);
+    }
+
+    #[Test]
+    public function aProtectedHeaderWithoutItsEncodedFormIsDiscardedAndDeprecated(): void
+    {
+        $signature = null;
+        $deprecations = $this->collectDeprecations(static function () use (&$signature): void {
+            $signature = new Signature('signature', [
+                'alg' => 'HS256',
+            ], null, []);
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            'Passing a protected header to "Jose\Component\Signature\Signature" without its encoded form is deprecated',
+            $deprecations[0]
+        );
+        static::assertInstanceOf(Signature::class, $signature);
+        static::assertSame([], $signature->getProtectedHeader());
+        static::assertNull($signature->getEncodedProtectedHeader());
+    }
+
+    #[Test]
+    public function aSignatureWithoutAnyProtectedHeaderIsNotDeprecated(): void
+    {
+        $deprecations = $this->collectDeprecations(static function (): void {
+            new Signature('signature', [], null, [
+                'alg' => 'HS256',
+            ]);
+        });
+
+        static::assertSame([], $deprecations);
+    }
+
+    private function getKey(): JWK
+    {
+        return new JWK([
+            'kty' => 'oct',
+            'k' => 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        ]);
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}


### PR DESCRIPTION
Closes #693.

## Why

`JWS::addSignature()` and `JWE::withPayload()` are public only because the token objects are not built in one go: the builder and the serializers append the signatures one by one, and the decrypter injects the plaintext once it has authenticated it. Both methods are therefore reachable by anybody holding a token, so a JWS returned by a loader can gain a signature that was never verified, and the payload of a decrypted JWE can be replaced by an arbitrary value. `addSignature()` carried an `@internal` annotation that nothing enforced and that no static analyser could act upon; `withPayload()` did not even carry that.

`Signature` had a related surprise: `new Signature($sig, ['alg' => 'HS256'], null, [])` returns an object whose `getProtectedHeader()` is `[]`, with no error and no documentation.

## What

* New `@internal` `Jose\Component\Core\Util\InternalCallChecker`: it reads the class owning the frame below the mutator and raises a deprecation when it is not one of the classes the method is reserved to. It mirrors `InheritanceChecker`, introduced by #709 for the services.
* `JWS::addSignature()` is reserved to the `JWS` itself (`split()`), to `JWSBuilderInterface` and to `JWSSerializer`. A custom serializer is a supported extension point and is the reason the interface is in the list: without it, an implementation outside the library would get a deprecation it could not act upon in 4.3.
* `JWE::withPayload()` is reserved to `JWEDecrypterInterface`.
* The `Signature` constructor documents why a decoded protected header is meaningless without its encoded form — the encoded string is what the signature covers — and deprecates the inconsistent call, which throws an `InvalidArgumentException` in 5.0.0.
* The three classes announce in their docblock that they become `final readonly` in 5.0.0, where the signatures and the payload are given to the constructor.

## Backward compatibility

No signature changed and nothing was removed; the public API only gains the `@internal` checker (verified by a reflection diff of `src/` against the base commit). The deprecated calls keep the behaviour and the return value they had.

Every internal path was checked to emit **zero** deprecation: `JWSBuilder::build()`, the three JWS serializers in both directions, `JWS::split()`, `JWSVerifier`, `JWEBuilder::build()` and `JWEDecrypter`. Only a call made from user code raises the notice.

**Cost**: the guard calls `debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)` once per appended signature, which measures ≈ 1 µs — a bare compact `unserialize()` goes from 4.4 µs to 5.4 µs, a full `loadAndVerifyWithKeySet()` from ≈ 24 µs to ≈ 25 µs. The guard disappears in 5.0.0 with the methods it protects.

## Note

A plain `@deprecated` tag was not used: the library itself has to call both methods, so every internal call site would have landed in the PHPStan baseline. The runtime caller check is the option the issue lists first.

The four `JWSTest` cases that assemble a JWS by hand exercise the reserved mutator on purpose and are marked `#[IgnoreDeprecations]`.

## Checks

Rebased on the current `4.3.x`; the `JWEDecrypter` now returns a `DecryptionResult`, so the test that asserts the decrypter raises no deprecation uses `decrypt()`, and the `Signature` notice points at the `InvalidArgumentException` of the JOSE hierarchy introduced by #707.


`castor ecs`, `castor phpstan`, `castor deptrac` and the full PHPUnit suite (1046 tests) are green.
