### PR TITLE
feat(key-mgmt): make the key factory an injectable service

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4332,8 +4332,6 @@ parameters:
 			count: 1
 			path: ../src/Library/Checker/HeaderCheckerManager.php
 
-
-
 		-
 			rawMessage: 'Method Jose\Component\Checker\HeaderCheckerManager::checkHeaders() has parameter $header with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
@@ -4371,28 +4369,10 @@ parameters:
 			path: ../src/Library/Checker/IssuerChecker.php
 
 		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createECKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/EcKeyGeneratorCommand.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
 			count: 1
 			path: ../src/Library/Console/EcKeysetGeneratorCommand.php
-
-		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createECKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/EcKeysetGeneratorCommand.php
-
-		-
-			rawMessage: 'Method Jose\Component\Console\GeneratorCommand::getOptions() return type has no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Console/GeneratorCommand.php
 
 		-
 			rawMessage: 'Parameter #1 $jwk of method Jose\Component\KeyManagement\Analyzer\KeyAnalyzerManager::analyze() expects Jose\Component\Core\JWK, mixed given.'
@@ -4407,20 +4387,8 @@ parameters:
 			path: ../src/Library/Console/KeysetAnalyzerCommand.php
 
 		-
-			rawMessage: 'Parameter #1 $values of static method Jose\Component\KeyManagement\JWKFactory::createNoneKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/NoneKeyGeneratorCommand.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
-			count: 1
-			path: ../src/Library/Console/OctKeyGeneratorCommand.php
-
-		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createOctKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
 			count: 1
 			path: ../src/Library/Console/OctKeyGeneratorCommand.php
 
@@ -4431,38 +4399,14 @@ parameters:
 			path: ../src/Library/Console/OctKeysetGeneratorCommand.php
 
 		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createOctKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/OctKeysetGeneratorCommand.php
-
-		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createOKPKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/OkpKeyGeneratorCommand.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
 			count: 1
 			path: ../src/Library/Console/OkpKeysetGeneratorCommand.php
 
 		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createOKPKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/OkpKeysetGeneratorCommand.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
-			count: 1
-			path: ../src/Library/Console/RsaKeyGeneratorCommand.php
-
-		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createRSAKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
 			count: 1
 			path: ../src/Library/Console/RsaKeyGeneratorCommand.php
 
@@ -4471,15 +4415,6 @@ parameters:
 			identifier: cast.int
 			count: 2
 			path: ../src/Library/Console/RsaKeysetGeneratorCommand.php
-
-		-
-			rawMessage: 'Parameter #2 $values of static method Jose\Component\KeyManagement\JWKFactory::createRSAKey() expects array<string, mixed>, array given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/Console/RsaKeysetGeneratorCommand.php
-
-
-
 
 		-
 			rawMessage: 'Method Jose\Component\Core\JWK::__construct() has parameter $values with no value type specified in iterable type array.'
@@ -4805,8 +4740,6 @@ parameters:
 			count: 1
 			path: ../src/Library/Encryption/JWEDecrypter.php
 
-
-
 		-
 			rawMessage: 'Method Jose\Component\Encryption\JWEDecrypter::decryptCEK() has parameter $completeHeader with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
@@ -5084,73 +5017,7 @@ parameters:
 			path: ../src/Library/KeyManagement/Analyzer/ZxcvbnKeyAnalyzer.php
 
 		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromCertificate() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromCertificateFile() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromKey() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromKeyFile() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromPKCS12CertificateFile() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromSecret() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromValues() has parameter $values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromX509Resource() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromX5C() has parameter $additional_values with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Method Jose\Component\KeyManagement\JWKFactory::createFromX5C() has parameter $x5c with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
 			rawMessage: 'Parameter #1 $details of static method Jose\Component\KeyManagement\KeyConverter\RSAKey::createFromKeyDetails() expects array<mixed>, mixed given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Library/KeyManagement/JWKFactory.php
-
-		-
-			rawMessage: 'Parameter #1 $key of static method Jose\Component\KeyManagement\JWKFactory::createFromKey() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Library/KeyManagement/JWKFactory.php

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSetSource/JWKSet.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSetSource/JWKSet.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWKSet as JWKSetAlias;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class JWKSet extends AbstractSource implements JWKSetSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWKSetAlias::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromJsonObject']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromJsonObject']);
         $definition->setArguments([$config['value']]);
         $definition->addTag('jose.jwkset');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/CertificateFile.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/CertificateFile.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class CertificateFile extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromCertificateFile']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromCertificateFile']);
         $definition->setArguments([$config['path'], $config['additional_values']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/JWK.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/JWK.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWKSource;
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,7 +21,7 @@ final readonly class JWK extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(\Jose\Component\Core\JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromJsonObject']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromJsonObject']);
         $definition->setArguments([$config['value']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/JWKSet.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/JWKSet.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,7 +24,7 @@ final readonly class JWKSet extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromKeySet']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromKeySet']);
         $definition->setArguments([new Reference($config['key_set']), $config['index']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/KeyFile.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/KeyFile.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class KeyFile extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromKeyFile']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromKeyFile']);
         $definition->setArguments([$config['path'], $config['password'], $config['additional_values']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/P12.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/P12.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class P12 extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromPKCS12CertificateFile']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromPKCS12CertificateFile']);
         $definition->setArguments([$config['path'], $config['password'], $config['additional_values']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/Secret.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class Secret extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromSecret']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromSecret']);
         $definition->setArguments([$config['secret'], $config['additional_values']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/Values.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/Values.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class Values extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromValues']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromValues']);
         $definition->setArguments([$config['values']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/X5C.php
+++ b/src/Bundle/DependencyInjection/Source/KeyManagement/JWKSource/X5C.php
@@ -6,7 +6,7 @@ namespace Jose\Bundle\JoseFramework\DependencyInjection\Source\KeyManagement\JWK
 
 use Jose\Bundle\JoseFramework\DependencyInjection\Source\AbstractSource;
 use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,7 +22,7 @@ final readonly class X5C extends AbstractSource implements JWKSource
     public function createDefinition(ContainerBuilder $container, array $config): Definition
     {
         $definition = new Definition(JWK::class);
-        $definition->setFactory([new Reference(JWKFactory::class), 'createFromCertificate']);
+        $definition->setFactory([new Reference(JWKFactoryInterface::class), 'fromCertificate']);
         $definition->setArguments([$config['value'], $config['additional_values']]);
         $definition->addTag('jose.jwk');
 

--- a/src/Bundle/Resources/config/jwk_factory.php
+++ b/src/Bundle/Resources/config/jwk_factory.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $container): void {
@@ -13,5 +14,8 @@ return function (ContainerConfigurator $container): void {
         ->autowire();
 
     $container->set(JWKFactory::class)
+        ->public();
+
+    $container->alias(JWKFactoryInterface::class, JWKFactory::class)
         ->public();
 };

--- a/src/Library/Console/EcKeyGeneratorCommand.php
+++ b/src/Library/Console/EcKeyGeneratorCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,7 +31,7 @@ final class EcKeyGeneratorCommand extends GeneratorCommand
         }
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createECKey($curve, $args);
+        $jwk = $this->jwkFactory->ec($curve, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/EcKeysetGeneratorCommand.php
+++ b/src/Library/Console/EcKeysetGeneratorCommand.php
@@ -6,7 +6,6 @@ namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,7 +39,7 @@ final class EcKeysetGeneratorCommand extends GeneratorCommand
         $keyset = new JWKSet([]);
         for ($i = 0; $i < $quantity; ++$i) {
             $args = $this->getOptions($input);
-            $keyset = $keyset->with(JWKFactory::createECKey($curve, $args));
+            $keyset = $keyset->with($this->jwkFactory->ec($curve, $args));
         }
         $this->prepareJsonOutput($input, $output, $keyset);
 

--- a/src/Library/Console/GeneratorCommand.php
+++ b/src/Library/Console/GeneratorCommand.php
@@ -7,6 +7,7 @@ namespace Jose\Component\Console;
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use Override;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -14,6 +15,19 @@ use function is_bool;
 
 abstract class GeneratorCommand extends ObjectOutputCommand
 {
+    protected readonly JWKFactoryInterface $jwkFactory;
+
+    /**
+     * The key factory is the second argument, and not the first as in the other commands of the library, so that the
+     * name inherited from the Symfony command stays where it was: "new EcKeyGeneratorCommand('my:command')" keeps
+     * working.
+     */
+    public function __construct(?string $name = null, ?JWKFactoryInterface $jwkFactory = null)
+    {
+        parent::__construct($name);
+        $this->jwkFactory = $jwkFactory ?? new JWKFactory();
+    }
+
     #[Override]
     public function isEnabled(): bool
     {
@@ -35,6 +49,9 @@ abstract class GeneratorCommand extends ObjectOutputCommand
             );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getOptions(InputInterface $input): array
     {
         $args = [];

--- a/src/Library/Console/KeyFileLoaderCommand.php
+++ b/src/Library/Console/KeyFileLoaderCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -38,7 +37,7 @@ final class KeyFileLoaderCommand extends GeneratorCommand
         }
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createFromKeyFile($file, $password, $args);
+        $jwk = $this->jwkFactory->fromKeyFile($file, $password, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/NoneKeyGeneratorCommand.php
+++ b/src/Library/Console/NoneKeyGeneratorCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Jose\Component\Console;
 
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,7 +20,7 @@ final class NoneKeyGeneratorCommand extends GeneratorCommand
     {
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createNoneKey($args);
+        $jwk = $this->jwkFactory->none($args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/OctKeyGeneratorCommand.php
+++ b/src/Library/Console/OctKeyGeneratorCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -31,7 +30,7 @@ final class OctKeyGeneratorCommand extends GeneratorCommand
         }
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createOctKey($size, $args);
+        $jwk = $this->jwkFactory->oct($size, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/OctKeysetGeneratorCommand.php
+++ b/src/Library/Console/OctKeysetGeneratorCommand.php
@@ -6,7 +6,6 @@ namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -39,7 +38,7 @@ final class OctKeysetGeneratorCommand extends GeneratorCommand
         $keyset = new JWKSet([]);
         for ($i = 0; $i < $quantity; ++$i) {
             $args = $this->getOptions($input);
-            $keyset = $keyset->with(JWKFactory::createOctKey($size, $args));
+            $keyset = $keyset->with($this->jwkFactory->oct($size, $args));
         }
         $this->prepareJsonOutput($input, $output, $keyset);
 

--- a/src/Library/Console/OkpKeyGeneratorCommand.php
+++ b/src/Library/Console/OkpKeyGeneratorCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,7 +31,7 @@ final class OkpKeyGeneratorCommand extends GeneratorCommand
         }
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createOKPKey($curve, $args);
+        $jwk = $this->jwkFactory->okp($curve, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/OkpKeysetGeneratorCommand.php
+++ b/src/Library/Console/OkpKeysetGeneratorCommand.php
@@ -6,7 +6,6 @@ namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -43,7 +42,7 @@ final class OkpKeysetGeneratorCommand extends GeneratorCommand
         $keyset = new JWKSet([]);
         for ($i = 0; $i < $quantity; ++$i) {
             $args = $this->getOptions($input);
-            $keyset = $keyset->with(JWKFactory::createOKPKey($curve, $args));
+            $keyset = $keyset->with($this->jwkFactory->okp($curve, $args));
         }
         $this->prepareJsonOutput($input, $output, $keyset);
 

--- a/src/Library/Console/P12CertificateLoaderCommand.php
+++ b/src/Library/Console/P12CertificateLoaderCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,7 +36,7 @@ final class P12CertificateLoaderCommand extends GeneratorCommand
             throw new InvalidArgumentException('Invalid secret');
         }
         $args = $this->getOptions($input);
-        $jwk = JWKFactory::createFromPKCS12CertificateFile($file, $password, $args);
+        $jwk = $this->jwkFactory->fromPKCS12CertificateFile($file, $password, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/RsaKeyGeneratorCommand.php
+++ b/src/Library/Console/RsaKeyGeneratorCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -31,7 +30,7 @@ final class RsaKeyGeneratorCommand extends GeneratorCommand
             throw new InvalidArgumentException('Invalid size');
         }
 
-        $jwk = JWKFactory::createRSAKey($size, $args);
+        $jwk = $this->jwkFactory->rsa($size, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/RsaKeysetGeneratorCommand.php
+++ b/src/Library/Console/RsaKeysetGeneratorCommand.php
@@ -6,7 +6,6 @@ namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWKSet;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -39,7 +38,7 @@ final class RsaKeysetGeneratorCommand extends GeneratorCommand
         $keyset = new JWKSet([]);
         for ($i = 0; $i < $quantity; ++$i) {
             $args = $this->getOptions($input);
-            $keyset = $keyset->with(JWKFactory::createRSAKey($size, $args));
+            $keyset = $keyset->with($this->jwkFactory->rsa($size, $args));
         }
         $this->prepareJsonOutput($input, $output, $keyset);
 

--- a/src/Library/Console/SecretKeyGeneratorCommand.php
+++ b/src/Library/Console/SecretKeyGeneratorCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -53,7 +52,7 @@ final class SecretKeyGeneratorCommand extends GeneratorCommand
         }
         $args = $this->getOptions($input);
 
-        $jwk = JWKFactory::createFromSecret($secret, $args);
+        $jwk = $this->jwkFactory->fromSecret($secret, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/Console/X509CertificateLoaderCommand.php
+++ b/src/Library/Console/X509CertificateLoaderCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jose\Component\Console;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
-use Jose\Component\KeyManagement\JWKFactory;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -38,7 +37,7 @@ final class X509CertificateLoaderCommand extends GeneratorCommand
             }
         }
 
-        $jwk = JWKFactory::createFromCertificateFile($file, $args);
+        $jwk = $this->jwkFactory->fromCertificateFile($file, $args);
         $this->prepareJsonOutput($input, $output, $jwk);
 
         return self::SUCCESS;

--- a/src/Library/KeyManagement/JWKFactory.php
+++ b/src/Library/KeyManagement/JWKFactory.php
@@ -12,9 +12,11 @@ use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\ECKey;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\KeyManagement\KeyConverter\KeyConverter;
 use Jose\Component\KeyManagement\KeyConverter\RSAKey;
 use OpenSSLCertificate;
+use Override;
 use Throwable;
 use function array_key_exists;
 use function extension_loaded;
@@ -22,21 +24,275 @@ use function is_array;
 use function is_string;
 use function sprintf;
 use function strlen;
+use function trigger_deprecation;
 use const JSON_THROW_ON_ERROR;
 use const OPENSSL_KEYTYPE_RSA;
 
 /**
+ * The default implementation of the key factory.
+ *
+ * The class used to be a bag of static methods, several of which reach for OpenSSL, for sodium or for the filesystem.
+ * It is an ordinary service now: it is registered in the bundle, it can be injected through JWKFactoryInterface and it
+ * can be decorated. The static methods are kept as thin delegations to a default instance and are deprecated; they are
+ * removed in 5.0.0.
+ *
+ * @final The class will be final and readonly in 5.0.0: implement JWKFactoryInterface and decorate the service instead
+ * of extending it.
+ *
  * @see \Jose\Tests\Component\KeyManagement\JWKFactoryTest
  */
-class JWKFactory
+class JWKFactory implements JWKFactoryInterface
 {
+    public function __construct()
+    {
+        InheritanceChecker::warnIfExtended(static::class, self::class, JWKFactoryInterface::class);
+    }
+
     /**
      * Creates a RSA key with the given key size and additional values.
      *
      * @param int $size The key size in bits
      * @param array<string, mixed> $values values to configure the key
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "rsa()" instead.
      */
     public static function createRSAKey(int $size, array $values = []): JWK
+    {
+        self::deprecateStaticCall('createRSAKey', 'rsa');
+
+        return (new self())->rsa($size, $values);
+    }
+
+    /**
+     * Creates a EC key with the given curve and additional values.
+     *
+     * @param string $curve The curve
+     * @param array<string, mixed> $values values to configure the key
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "ec()" instead.
+     */
+    public static function createECKey(string $curve, array $values = []): JWK
+    {
+        self::deprecateStaticCall('createECKey', 'ec');
+
+        return (new self())->ec($curve, $values);
+    }
+
+    /**
+     * Creates a octet key with the given key size and additional values.
+     *
+     * @param int $size The key size in bits
+     * @param array<string, mixed> $values values to configure the key
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "oct()" instead.
+     */
+    public static function createOctKey(int $size, array $values = []): JWK
+    {
+        self::deprecateStaticCall('createOctKey', 'oct');
+
+        return (new self())->oct($size, $values);
+    }
+
+    /**
+     * Creates a OKP key with the given curve and additional values.
+     *
+     * @param string $curve The curve
+     * @param array<string, mixed> $values values to configure the key
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "okp()" instead.
+     */
+    public static function createOKPKey(string $curve, array $values = []): JWK
+    {
+        self::deprecateStaticCall('createOKPKey', 'okp');
+
+        return (new self())->okp($curve, $values);
+    }
+
+    /**
+     * Creates a none key with the given additional values. Please note that this key type is not part of any
+     * specification. It is used to prevent the use of the "none" algorithm with other key types.
+     *
+     * @param array<string, mixed> $values values to configure the key
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "none()" instead.
+     */
+    public static function createNoneKey(array $values = []): JWK
+    {
+        self::deprecateStaticCall('createNoneKey', 'none');
+
+        return (new self())->none($values);
+    }
+
+    /**
+     * Creates a key from a Json string.
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromJsonObject()"
+     *             instead.
+     */
+    public static function createFromJsonObject(string $value): JWK|JWKSet
+    {
+        self::deprecateStaticCall('createFromJsonObject', 'fromJsonObject');
+
+        return (new self())->fromJsonObject($value);
+    }
+
+    /**
+     * Creates a key or key set from the given input.
+     *
+     * @param array<string, mixed> $values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromValues()"
+     *             instead.
+     */
+    public static function createFromValues(array $values): JWK|JWKSet
+    {
+        self::deprecateStaticCall('createFromValues', 'fromValues');
+
+        return (new self())->fromValues($values);
+    }
+
+    /**
+     * This method create a JWK object using a shared secret.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromSecret()"
+     *             instead.
+     */
+    public static function createFromSecret(string $secret, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromSecret', 'fromSecret');
+
+        return (new self())->fromSecret($secret, $additional_values);
+    }
+
+    /**
+     * This method will try to load a X.509 certificate and convert it into a public key.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call
+     *             "fromCertificateFile()" instead.
+     */
+    public static function createFromCertificateFile(string $file, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromCertificateFile', 'fromCertificateFile');
+
+        return (new self())->fromCertificateFile($file, $additional_values);
+    }
+
+    /**
+     * Extract a keyfrom a key set identified by the given index .
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromKeySet()"
+     *             instead.
+     */
+    public static function createFromKeySet(JWKSet $jwkset, int|string $index): JWK
+    {
+        self::deprecateStaticCall('createFromKeySet', 'fromKeySet');
+
+        return (new self())->fromKeySet($jwkset, $index);
+    }
+
+    /**
+     * This method will try to load a PKCS#12 file and convert it into a public key.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call
+     *             "fromPKCS12CertificateFile()" instead.
+     */
+    public static function createFromPKCS12CertificateFile(
+        string $file,
+        string $secret = '',
+        array $additional_values = []
+    ): JWK {
+        self::deprecateStaticCall('createFromPKCS12CertificateFile', 'fromPKCS12CertificateFile');
+
+        return (new self())->fromPKCS12CertificateFile($file, $secret, $additional_values);
+    }
+
+    /**
+     * This method will try to convert a X.509 certificate into a public key.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromCertificate()"
+     *             instead.
+     */
+    public static function createFromCertificate(string $certificate, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromCertificate', 'fromCertificate');
+
+        return (new self())->fromCertificate($certificate, $additional_values);
+    }
+
+    /**
+     * This method will try to convert a X.509 certificate resource into a public key.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromX509Resource()"
+     *             instead.
+     */
+    public static function createFromX509Resource(OpenSSLCertificate $res, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromX509Resource', 'fromX509Resource');
+
+        return (new self())->fromX509Resource($res, $additional_values);
+    }
+
+    /**
+     * This method will try to load and convert a key file into a JWK object. If the key is encrypted, the password must
+     * be set.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromKeyFile()"
+     *             instead.
+     */
+    public static function createFromKeyFile(string $file, ?string $password = null, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromKeyFile', 'fromKeyFile');
+
+        return (new self())->fromKeyFile($file, $password, $additional_values);
+    }
+
+    /**
+     * This method will try to load and convert a key into a JWK object. If the key is encrypted, the password must be
+     * set.
+     *
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromKey()" instead.
+     */
+    public static function createFromKey(string $key, ?string $password = null, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromKey', 'fromKey');
+
+        return (new self())->fromKey($key, $password, $additional_values);
+    }
+
+    /**
+     * This method will try to load and convert a X.509 certificate chain into a public key.
+     *
+     * Be careful! The certificate chain is loaded, but it is NOT VERIFIED by any mean! It is mandatory to verify the
+     * root CA or intermediate  CA are trusted. If not done, it may lead to potential security issues.
+     *
+     * @param array<array-key, mixed> $x5c
+     * @param array<string, mixed> $additional_values
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. Inject "JWKFactoryInterface" and call "fromX5C()" instead.
+     */
+    public static function createFromX5C(array $x5c, array $additional_values = []): JWK
+    {
+        self::deprecateStaticCall('createFromX5C', 'fromX5C');
+
+        return (new self())->fromX5C($x5c, $additional_values);
+    }
+
+    #[Override]
+    public function rsa(int $size, array $values = []): JWK
     {
         if (! extension_loaded('openssl')) {
             throw new MissingDependencyException('Please install the OpenSSL extension');
@@ -65,39 +321,24 @@ class JWKFactory
         return new JWK($values);
     }
 
-    /**
-     * Creates a EC key with the given curve and additional values.
-     *
-     * @param string $curve The curve
-     * @param array<string, mixed> $values values to configure the key
-     */
-    public static function createECKey(string $curve, array $values = []): JWK
+    #[Override]
+    public function ec(string $curve, array $values = []): JWK
     {
         return ECKey::createECKey($curve, $values);
     }
 
-    /**
-     * Creates a octet key with the given key size and additional values.
-     *
-     * @param int $size The key size in bits
-     * @param array<string, mixed> $values values to configure the key
-     */
-    public static function createOctKey(int $size, array $values = []): JWK
+    #[Override]
+    public function oct(int $size, array $values = []): JWK
     {
         if ($size < 8 || $size % 8 !== 0) {
             throw new InvalidKeyException('Invalid key size.');
         }
 
-        return self::createFromSecret(random_bytes(max(1, intdiv($size, 8))), $values);
+        return $this->fromSecret(random_bytes(max(1, intdiv($size, 8))), $values);
     }
 
-    /**
-     * Creates a OKP key with the given curve and additional values.
-     *
-     * @param string $curve The curve
-     * @param array<string, mixed> $values values to configure the key
-     */
-    public static function createOKPKey(string $curve, array $values = []): JWK
+    #[Override]
+    public function okp(string $curve, array $values = []): JWK
     {
         if (! extension_loaded('sodium')) {
             throw new MissingDependencyException('The extension "sodium" is not available. Please install it to use this method');
@@ -135,13 +376,8 @@ class JWKFactory
         return new JWK($values);
     }
 
-    /**
-     * Creates a none key with the given additional values. Please note that this key type is not part of any
-     * specification. It is used to prevent the use of the "none" algorithm with other key types.
-     *
-     * @param array<string, mixed> $values values to configure the key
-     */
-    public static function createNoneKey(array $values = []): JWK
+    #[Override]
+    public function none(array $values = []): JWK
     {
         $values = [
             ...$values,
@@ -153,23 +389,19 @@ class JWKFactory
         return new JWK($values);
     }
 
-    /**
-     * Creates a key from a Json string.
-     */
-    public static function createFromJsonObject(string $value): JWK|JWKSet
+    #[Override]
+    public function fromJsonObject(string $value): JWK|JWKSet
     {
         $json = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         if (! is_array($json)) {
             throw new InvalidKeyException('Invalid key or key set.');
         }
-
-        return self::createFromValues($json);
+        /** @var array<string, mixed> $json */
+        return $this->fromValues($json);
     }
 
-    /**
-     * Creates a key or key set from the given input.
-     */
-    public static function createFromValues(array $values): JWK|JWKSet
+    #[Override]
+    public function fromValues(array $values): JWK|JWKSet
     {
         if (array_key_exists('keys', $values) && is_array($values['keys'])) {
             return JWKSet::createFromKeyData($values);
@@ -178,13 +410,11 @@ class JWKFactory
         return new JWK($values);
     }
 
-    /**
-     * This method create a JWK object using a shared secret.
-     */
-    public static function createFromSecret(string $secret, array $additional_values = []): JWK
+    #[Override]
+    public function fromSecret(string $secret, array $additionalValues = []): JWK
     {
         $values = array_merge(
-            $additional_values,
+            $additionalValues,
             [
                 'kty' => 'oct',
                 'k' => Base64UrlSafe::encodeUnpadded($secret),
@@ -194,33 +424,24 @@ class JWKFactory
         return new JWK($values);
     }
 
-    /**
-     * This method will try to load a X.509 certificate and convert it into a public key.
-     */
-    public static function createFromCertificateFile(string $file, array $additional_values = []): JWK
+    #[Override]
+    public function fromCertificateFile(string $file, array $additionalValues = []): JWK
     {
         $values = KeyConverter::loadKeyFromCertificateFile($file);
-        $values = array_merge($values, $additional_values);
+        $values = array_merge($values, $additionalValues);
 
         return new JWK($values);
     }
 
-    /**
-     * Extract a keyfrom a key set identified by the given index .
-     */
-    public static function createFromKeySet(JWKSet $jwkset, int|string $index): JWK
+    #[Override]
+    public function fromKeySet(JWKSet $jwkset, int|string $index): JWK
     {
         return $jwkset->get($index);
     }
 
-    /**
-     * This method will try to load a PKCS#12 file and convert it into a public key.
-     */
-    public static function createFromPKCS12CertificateFile(
-        string $file,
-        string $secret = '',
-        array $additional_values = []
-    ): JWK {
+    #[Override]
+    public function fromPKCS12CertificateFile(string $file, string $secret = '', array $additionalValues = []): JWK
+    {
         try {
             $content = file_get_contents($file);
             if (! is_string($content)) {
@@ -230,70 +451,71 @@ class JWKFactory
             if (! is_array($certs) || ! array_key_exists('pkey', $certs)) {
                 throw new RuntimeException('Unable to load the certificates.');
             }
-
-            return self::createFromKey($certs['pkey'], null, $additional_values);
+            /** @var array{pkey: string} $certs */
+            return $this->fromKey($certs['pkey'], null, $additionalValues);
         } catch (Throwable $throwable) {
             throw new RuntimeException('Unable to load the certificates.', $throwable->getCode(), $throwable);
         }
     }
 
-    /**
-     * This method will try to convert a X.509 certificate into a public key.
-     */
-    public static function createFromCertificate(string $certificate, array $additional_values = []): JWK
+    #[Override]
+    public function fromCertificate(string $certificate, array $additionalValues = []): JWK
     {
         $values = KeyConverter::loadKeyFromCertificate($certificate);
-        $values = array_merge($values, $additional_values);
+        $values = array_merge($values, $additionalValues);
 
         return new JWK($values);
     }
 
-    /**
-     * This method will try to convert a X.509 certificate resource into a public key.
-     */
-    public static function createFromX509Resource(OpenSSLCertificate $res, array $additional_values = []): JWK
+    #[Override]
+    public function fromX509Resource(OpenSSLCertificate $res, array $additionalValues = []): JWK
     {
         $values = KeyConverter::loadKeyFromX509Resource($res);
-        $values = array_merge($values, $additional_values);
+        $values = array_merge($values, $additionalValues);
 
         return new JWK($values);
     }
 
-    /**
-     * This method will try to load and convert a key file into a JWK object. If the key is encrypted, the password must
-     * be set.
-     */
-    public static function createFromKeyFile(string $file, ?string $password = null, array $additional_values = []): JWK
+    #[Override]
+    public function fromKeyFile(string $file, ?string $password = null, array $additionalValues = []): JWK
     {
         $values = KeyConverter::loadFromKeyFile($file, $password);
-        $values = array_merge($values, $additional_values);
+        $values = array_merge($values, $additionalValues);
 
         return new JWK($values);
     }
 
-    /**
-     * This method will try to load and convert a key into a JWK object. If the key is encrypted, the password must be
-     * set.
-     */
-    public static function createFromKey(string $key, ?string $password = null, array $additional_values = []): JWK
+    #[Override]
+    public function fromKey(string $key, ?string $password = null, array $additionalValues = []): JWK
     {
         $values = KeyConverter::loadFromKey($key, $password);
-        $values = array_merge($values, $additional_values);
+        $values = array_merge($values, $additionalValues);
+
+        return new JWK($values);
+    }
+
+    #[Override]
+    public function fromX5C(array $x5c, array $additionalValues = []): JWK
+    {
+        $values = KeyConverter::loadFromX5C($x5c);
+        $values = array_merge($values, $additionalValues);
 
         return new JWK($values);
     }
 
     /**
-     * This method will try to load and convert a X.509 certificate chain into a public key.
-     *
-     * Be careful! The certificate chain is loaded, but it is NOT VERIFIED by any mean! It is mandatory to verify the
-     * root CA or intermediate  CA are trusted. If not done, it may lead to potential security issues.
+     * Raises the notice emitted when one of the static methods is used instead of the service.
      */
-    public static function createFromX5C(array $x5c, array $additional_values = []): JWK
+    private static function deprecateStaticCall(string $method, string $replacement): void
     {
-        $values = KeyConverter::loadFromX5C($x5c);
-        $values = array_merge($values, $additional_values);
-
-        return new JWK($values);
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::%s()" is deprecated and will be removed in 5.0.0. Inject "%s" and call "%s()" instead.',
+            self::class,
+            $method,
+            JWKFactoryInterface::class,
+            $replacement
+        );
     }
 }

--- a/src/Library/KeyManagement/JWKFactoryInterface.php
+++ b/src/Library/KeyManagement/JWKFactoryInterface.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\KeyManagement;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use OpenSSLCertificate;
+
+/**
+ * Creates keys and key sets.
+ *
+ * Several of those methods reach for OpenSSL, for sodium or for the filesystem, which is why the factory is a service
+ * and not a bag of static methods any more: application code that generates or loads keys can now depend on this
+ * interface, be unit tested without any of them, and be decorated to audit, cache or delegate the generation to a
+ * hardware backed implementation.
+ */
+interface JWKFactoryInterface
+{
+    /**
+     * Creates a RSA key with the given key size and additional values.
+     *
+     * @param int                  $size   The key size in bits
+     * @param array<string, mixed> $values Values to configure the key
+     */
+    public function rsa(int $size, array $values = []): JWK;
+
+    /**
+     * Creates an EC key with the given curve and additional values.
+     *
+     * @param string               $curve  The curve
+     * @param array<string, mixed> $values Values to configure the key
+     */
+    public function ec(string $curve, array $values = []): JWK;
+
+    /**
+     * Creates an octet key with the given key size and additional values.
+     *
+     * @param int                  $size   The key size in bits
+     * @param array<string, mixed> $values Values to configure the key
+     */
+    public function oct(int $size, array $values = []): JWK;
+
+    /**
+     * Creates an OKP key with the given curve and additional values.
+     *
+     * @param string               $curve  The curve
+     * @param array<string, mixed> $values Values to configure the key
+     */
+    public function okp(string $curve, array $values = []): JWK;
+
+    /**
+     * Creates a none key with the given additional values. Please note that this key type is not part of any
+     * specification. It is used to prevent the use of the "none" algorithm with other key types.
+     *
+     * @param array<string, mixed> $values Values to configure the key
+     */
+    public function none(array $values = []): JWK;
+
+    /**
+     * Creates a key or a key set from a JSON string.
+     */
+    public function fromJsonObject(string $value): JWK|JWKSet;
+
+    /**
+     * Creates a key or a key set from the given input.
+     *
+     * @param array<string, mixed> $values
+     */
+    public function fromValues(array $values): JWK|JWKSet;
+
+    /**
+     * Creates a key using a shared secret.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromSecret(string $secret, array $additionalValues = []): JWK;
+
+    /**
+     * Loads a X.509 certificate file and converts it into a public key.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromCertificateFile(string $file, array $additionalValues = []): JWK;
+
+    /**
+     * Extracts a key from a key set, identified by the given index.
+     */
+    public function fromKeySet(JWKSet $jwkset, int|string $index): JWK;
+
+    /**
+     * Loads a PKCS#12 file and converts it into a public key.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromPKCS12CertificateFile(string $file, string $secret = '', array $additionalValues = []): JWK;
+
+    /**
+     * Converts a X.509 certificate into a public key.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromCertificate(string $certificate, array $additionalValues = []): JWK;
+
+    /**
+     * Converts a X.509 certificate resource into a public key.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromX509Resource(OpenSSLCertificate $res, array $additionalValues = []): JWK;
+
+    /**
+     * Loads a key file and converts it into a JWK object. If the key is encrypted, the password must be set.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromKeyFile(string $file, ?string $password = null, array $additionalValues = []): JWK;
+
+    /**
+     * Loads a key and converts it into a JWK object. If the key is encrypted, the password must be set.
+     *
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromKey(string $key, ?string $password = null, array $additionalValues = []): JWK;
+
+    /**
+     * Loads a X.509 certificate chain and converts it into a public key.
+     *
+     * Be careful! The certificate chain is loaded, but it is NOT VERIFIED by any mean! It is mandatory to verify the
+     * root CA or intermediate CA are trusted. If not done, it may lead to potential security issues.
+     *
+     * @param array<array-key, mixed> $x5c
+     * @param array<string, mixed> $additionalValues
+     */
+    public function fromX5C(array $x5c, array $additionalValues = []): JWK;
+}

--- a/tests/Bundle/JoseFramework/Functional/KeyManagement/JWKFactoryServiceTest.php
+++ b/tests/Bundle/JoseFramework/Functional/KeyManagement/JWKFactoryServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Functional\KeyManagement;
+
+use Jose\Component\Console\RsaKeyGeneratorCommand;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
+use Jose\Tests\Bundle\JoseFramework\WebTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The key factory is a service of the bundle and is aliased with its interface, so that it can be autowired and
+ * decorated. The console commands that generate or load keys receive it instead of calling the static methods.
+ *
+ * @internal
+ */
+final class JWKFactoryServiceTest extends WebTestCase
+{
+    #[Test]
+    public static function theKeyFactoryIsAvailableAsAService(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $container = $client->getContainer();
+
+        static::assertTrue($container->has(JWKFactory::class));
+        static::assertInstanceOf(JWKFactoryInterface::class, $container->get(JWKFactory::class));
+    }
+
+    #[Test]
+    public static function theKeyFactoryIsAliasedWithItsInterface(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $container = $client->getContainer();
+
+        static::assertTrue($container->has(JWKFactoryInterface::class));
+        static::assertInstanceOf(JWKFactoryInterface::class, $container->get(JWKFactoryInterface::class));
+    }
+
+    #[Test]
+    public static function theGeneratorCommandsReceiveTheKeyFactory(): void
+    {
+        static::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $container = $client->getContainer();
+
+        static::assertTrue($container->has(RsaKeyGeneratorCommand::class));
+        static::assertInstanceOf(RsaKeyGeneratorCommand::class, $container->get(RsaKeyGeneratorCommand::class));
+    }
+}

--- a/tests/Component/Console/KeyConversionCommandTest.php
+++ b/tests/Component/Console/KeyConversionCommandTest.php
@@ -165,19 +165,19 @@ final class KeyConversionCommandTest extends TestCase
     #[Test]
     public function iCanConvertARsaKeyIntoPKCS8(): void
     {
-        $jwk = JWKFactory::createRSAKey(2048);
+        $jwk = (new JWKFactory())->rsa(2048);
 
         $content = self::convertIntoPKCS8($jwk);
 
         static::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $content);
-        self::assertSameKeyMaterial($jwk, JWKFactory::createFromKey($content));
+        self::assertSameKeyMaterial($jwk, (new JWKFactory())->fromKey($content));
     }
 
     #[Test]
     #[DataProvider('ecCurves')]
     public function iCanConvertAnEcKeyIntoPKCS8(string $curve, int $size): void
     {
-        $jwk = JWKFactory::createECKey($curve);
+        $jwk = (new JWKFactory())->ec($curve);
 
         $content = self::convertIntoPKCS8($jwk);
 
@@ -192,12 +192,12 @@ final class KeyConversionCommandTest extends TestCase
     #[DataProvider('okpCurves')]
     public function iCanConvertAnOkpKeyIntoPKCS8(string $curve): void
     {
-        $jwk = JWKFactory::createOKPKey($curve);
+        $jwk = (new JWKFactory())->okp($curve);
 
         $content = self::convertIntoPKCS8($jwk);
 
         static::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $content);
-        self::assertSameKeyMaterial($jwk, JWKFactory::createFromKey($content));
+        self::assertSameKeyMaterial($jwk, (new JWKFactory())->fromKey($content));
     }
 
     /**
@@ -210,7 +210,7 @@ final class KeyConversionCommandTest extends TestCase
         $content = self::convertIntoPKCS8($jwk->toPublic());
 
         static::assertStringStartsWith('-----BEGIN PUBLIC KEY-----', $content);
-        self::assertSameKeyMaterial($jwk->toPublic(), JWKFactory::createFromKey($content));
+        self::assertSameKeyMaterial($jwk->toPublic(), (new JWKFactory())->fromKey($content));
     }
 
     #[Test]
@@ -218,7 +218,7 @@ final class KeyConversionCommandTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        self::convertIntoPKCS8(JWKFactory::createOctKey(256));
+        self::convertIntoPKCS8((new JWKFactory())->oct(256));
     }
 
     /**
@@ -249,9 +249,9 @@ final class KeyConversionCommandTest extends TestCase
      */
     public static function publicKeys(): iterable
     {
-        yield 'RSA' => [JWKFactory::createRSAKey(2048)];
-        yield 'EC' => [JWKFactory::createECKey('P-256')];
-        yield 'OKP' => [JWKFactory::createOKPKey('Ed25519')];
+        yield 'RSA' => [(new JWKFactory())->rsa(2048)];
+        yield 'EC' => [(new JWKFactory())->ec('P-256')];
+        yield 'OKP' => [(new JWKFactory())->okp('Ed25519')];
     }
 
     #[Test]

--- a/tests/Component/Encryption/RSA15ExpectedCekSizeTest.php
+++ b/tests/Component/Encryption/RSA15ExpectedCekSizeTest.php
@@ -127,7 +127,7 @@ final class RSA15ExpectedCekSizeTest extends TestCase
     #[Test]
     public function algorithmsThatDoNotExpectTheCekSizeStillWork(): void
     {
-        $jwk = JWKFactory::createOctKey(256, [
+        $jwk = (new JWKFactory())->oct(256, [
             'use' => 'enc',
         ]);
         $algorithm = new LegacyKeyEncryptionAlgorithm();
@@ -145,7 +145,7 @@ final class RSA15ExpectedCekSizeTest extends TestCase
 
     private function createKey(): JWK
     {
-        return JWKFactory::createRSAKey(2048, [
+        return (new JWKFactory())->rsa(2048, [
             'alg' => 'RSA1_5',
             'use' => 'enc',
         ]);

--- a/tests/Component/Encryption/RSA15ImplicitRejectionTest.php
+++ b/tests/Component/Encryption/RSA15ImplicitRejectionTest.php
@@ -21,7 +21,7 @@ final class RSA15ImplicitRejectionTest extends TestCase
     #[Test]
     public function validRoundTripStillWorks(): void
     {
-        $jwk = JWKFactory::createRSAKey(2048, [
+        $jwk = (new JWKFactory())->rsa(2048, [
             'alg' => 'RSA1_5',
             'use' => 'enc',
         ]);
@@ -42,7 +42,7 @@ final class RSA15ImplicitRejectionTest extends TestCase
     #[Test]
     public function malformedCiphertextDoesNotThrowAndReturnsExpectedLength(): void
     {
-        $jwk = JWKFactory::createRSAKey(2048, [
+        $jwk = (new JWKFactory())->rsa(2048, [
             'alg' => 'RSA1_5',
             'use' => 'enc',
         ]);
@@ -63,7 +63,7 @@ final class RSA15ImplicitRejectionTest extends TestCase
     #[Test]
     public function implicitRejectionRespectsEncCekLength(): void
     {
-        $jwk = JWKFactory::createRSAKey(2048, [
+        $jwk = (new JWKFactory())->rsa(2048, [
             'alg' => 'RSA1_5',
             'use' => 'enc',
         ]);
@@ -91,7 +91,7 @@ final class RSA15ImplicitRejectionTest extends TestCase
     #[Test]
     public function legacyDirectDecryptStillThrowsOnGarbage(): void
     {
-        $jwk = JWKFactory::createRSAKey(2048, [
+        $jwk = (new JWKFactory())->rsa(2048, [
             'alg' => 'RSA1_5',
             'use' => 'enc',
         ]);

--- a/tests/Component/Encryption/ResultObjectsTest.php
+++ b/tests/Component/Encryption/ResultObjectsTest.php
@@ -217,7 +217,7 @@ final class ResultObjectsTest extends EncryptionTestCase
     private function getKey(): JWK
     {
         if ($this->key === null) {
-            $this->key = JWKFactory::createOctKey(256, [
+            $this->key = (new JWKFactory())->oct(256, [
                 'alg' => 'A256KW',
                 'use' => 'enc',
             ]);
@@ -229,7 +229,7 @@ final class ResultObjectsTest extends EncryptionTestCase
     private function getWrongKey(): JWK
     {
         if ($this->wrongKey === null) {
-            $this->wrongKey = JWKFactory::createOctKey(256, [
+            $this->wrongKey = (new JWKFactory())->oct(256, [
                 'alg' => 'A256KW',
                 'use' => 'enc',
             ]);

--- a/tests/Component/KeyManagement/CertificateTest.php
+++ b/tests/Component/KeyManagement/CertificateTest.php
@@ -330,7 +330,7 @@ final class CertificateTest extends TestCase
             ],
         ]);
 
-        $certificate = JWKFactory::createFromX5C($key->get('x5c'), [
+        $certificate = (new JWKFactory())->fromX5C($key->get('x5c'), [
             'use' => 'sig',
             'kid' => '1b94c',
         ]);

--- a/tests/Component/KeyManagement/JWKAnalyzerTest.php
+++ b/tests/Component/KeyManagement/JWKAnalyzerTest.php
@@ -34,7 +34,7 @@ final class JWKAnalyzerTest extends TestCase
     #[Test]
     public function iCanAnalyzeANoneKeyAndGetMessages(): void
     {
-        $key = JWKFactory::createNoneKey();
+        $key = (new JWKFactory())->none();
         $messages = $this->getKeyAnalyzer()
             ->analyze($key);
 
@@ -77,7 +77,7 @@ final class JWKAnalyzerTest extends TestCase
     #[Test]
     public function iCanAnalyzeAnOctKeyAndGetMessages(): void
     {
-        $key = JWKFactory::createOctKey(16, [
+        $key = (new JWKFactory())->oct(16, [
             'use' => 'foo',
             'key_ops' => 'foo',
         ]);
@@ -90,7 +90,7 @@ final class JWKAnalyzerTest extends TestCase
     #[Test]
     public function iCanAnalyzeAnES521OctKeyAndGetMessages(): void
     {
-        $key = JWKFactory::createECKey('P-521', [
+        $key = (new JWKFactory())->ec('P-521', [
             'kid' => '0123456789',
             'alg' => 'ES521',
             'use' => 'sig',

--- a/tests/Component/KeyManagement/JWKFactoryServiceTest.php
+++ b/tests/Component/KeyManagement/JWKFactoryServiceTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\KeyManagement;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+use const E_USER_DEPRECATED;
+
+/**
+ * The key factory is a service: it can be injected through its interface, decorated and unit tested. The static
+ * methods it used to expose are kept as delegations to a default instance and are deprecated.
+ *
+ * @internal
+ */
+final class JWKFactoryServiceTest extends TestCase
+{
+    #[Test]
+    public function theFactoryImplementsItsInterface(): void
+    {
+        static::assertInstanceOf(JWKFactoryInterface::class, new JWKFactory());
+    }
+
+    #[Test]
+    public function usingTheServiceIsNotDeprecated(): void
+    {
+        $key = null;
+        $deprecations = $this->collectDeprecations(static function () use (&$key): void {
+            $key = (new JWKFactory())->fromSecret('This is a very secured secret!!!!');
+        });
+
+        static::assertSame([], $deprecations);
+        static::assertInstanceOf(JWK::class, $key);
+        static::assertSame('oct', $key->get('kty'));
+    }
+
+    #[Test]
+    #[DataProvider('deprecatedStaticMethods')]
+    public function theStaticMethodsAreDeprecatedAndKeepWorking(
+        string $static,
+        string $replacement,
+        callable $call
+    ): void {
+        $result = null;
+        $deprecations = $this->collectDeprecations(static function () use ($call, &$result): void {
+            $result = $call();
+        });
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(
+            sprintf('The method "%s::%s()" is deprecated', JWKFactory::class, $static),
+            $deprecations[0]
+        );
+        static::assertStringContainsString(sprintf('call "%s()" instead', $replacement), $deprecations[0]);
+        static::assertTrue($result instanceof JWK || $result instanceof JWKSet);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, callable}>
+     */
+    public static function deprecatedStaticMethods(): iterable
+    {
+        yield 'createOctKey' => [
+            'createOctKey',
+            'oct',
+            static fn (): JWK => JWKFactory::createOctKey(128),
+        ];
+        yield 'createNoneKey' => [
+            'createNoneKey',
+            'none',
+            JWKFactory::createNoneKey(...),
+        ];
+        yield 'createECKey' => [
+            'createECKey',
+            'ec',
+            static fn (): JWK => JWKFactory::createECKey('P-256'),
+        ];
+        yield 'createFromSecret' => [
+            'createFromSecret',
+            'fromSecret',
+            static fn (): JWK => JWKFactory::createFromSecret('This is a very secured secret!!!!'),
+        ];
+        yield 'createFromValues' => [
+            'createFromValues',
+            'fromValues',
+            static fn (): JWK|JWKSet => JWKFactory::createFromValues([
+                'kty' => 'oct',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+        ];
+        yield 'createFromJsonObject' => [
+            'createFromJsonObject',
+            'fromJsonObject',
+            static fn (): JWK|JWKSet => JWKFactory::createFromJsonObject('{"kty":"oct","k":"GawgguFyGrWKav7AX4VKUg"}'),
+        ];
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}

--- a/tests/Component/KeyManagement/JWKFactoryTest.php
+++ b/tests/Component/KeyManagement/JWKFactoryTest.php
@@ -8,6 +8,7 @@ use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
 use Jose\Component\Core\Util\Base64UrlSafe;
 use Jose\Component\Core\Util\ECKey;
 use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\KeyManagement\JWKFactoryInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,8 @@ final class JWKFactoryTest extends TestCase
     public function iCanLoadAP12CertificateThatContainsARSAKey(): never
     {
         static::markTestIncomplete('Unable to run this test using the last OpenSSL versions');
-        $result = JWKFactory::createFromPKCS12CertificateFile(__DIR__ . '/P12/CertRSA.p12', 'cert');
+        $result = $this->factory()
+            ->fromPKCS12CertificateFile(__DIR__ . '/P12/CertRSA.p12', 'cert');
 
         static::assertSame([
             'kty' => 'RSA',
@@ -40,7 +42,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromECCertificateFileInDERFormat(): void
     {
-        $result = JWKFactory::createFromCertificateFile(__DIR__ . '/EC/DER/prime256v1-cert.der');
+        $result = $this->factory()
+            ->fromCertificateFile(__DIR__ . '/EC/DER/prime256v1-cert.der');
 
         static::assertSame([
             'kty' => 'EC',
@@ -58,9 +61,10 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromSecret(): void
     {
-        $jwk = JWKFactory::createFromSecret('This is a very secured secret!!!!', [
-            'kid' => 'FOO',
-        ]);
+        $jwk = $this->factory()
+            ->fromSecret('This is a very secured secret!!!!', [
+                'kid' => 'FOO',
+            ]);
         static::assertTrue($jwk->has('kty'));
         static::assertTrue($jwk->has('k'));
         static::assertTrue($jwk->has('kid'));
@@ -72,7 +76,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromKey(): void
     {
-        $jwk = JWKFactory::createFromKey(file_get_contents(__DIR__ . '/Keys/EC/private.es256.encrypted.key'), 'test');
+        $jwk = $this->factory()
+            ->fromKey(file_get_contents(__DIR__ . '/Keys/EC/private.es256.encrypted.key'), 'test');
         static::assertSame(
             '{"kty":"EC","crv":"P-256","d":"q_VkzNnxTG39jHB0qkwA_SeVXud7yCHT7kb7kZv-0xQ","x":"vuYsP-QnrqAbM7Iyhzjt08hFSuzapyojCB_gFsBt65U","y":"oq-E2K-X0kPeqGuKnhlXkxc5fnxomRSC6KLby7Ij8AE"}',
             json_encode($jwk, JSON_THROW_ON_ERROR)
@@ -83,7 +88,8 @@ final class JWKFactoryTest extends TestCase
     public function createFromResource(): void
     {
         $res = openssl_x509_read(file_get_contents(__DIR__ . '/RSA/PEM/1024b-rsa-example-cert.pem'));
-        $jwk = JWKFactory::createFromX509Resource($res);
+        $jwk = $this->factory()
+            ->fromX509Resource($res);
 
         static::assertSame([
             'kty' => 'RSA',
@@ -100,7 +106,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromECCertificateFileInPEMFormat(): void
     {
-        $result = JWKFactory::createFromCertificateFile(__DIR__ . '/EC/PEM/prime256v1-cert.pem');
+        $result = $this->factory()
+            ->fromCertificateFile(__DIR__ . '/EC/PEM/prime256v1-cert.pem');
 
         static::assertSame([
             'kty' => 'EC',
@@ -118,7 +125,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFrom32kRSACertificateFileInDERFormat(): void
     {
-        $result = JWKFactory::createFromCertificateFile(__DIR__ . '/RSA/DER/32k-rsa-example-cert.der');
+        $result = $this->factory()
+            ->fromCertificateFile(__DIR__ . '/RSA/DER/32k-rsa-example-cert.der');
 
         static::assertSame([
             'kty' => 'RSA',
@@ -135,7 +143,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFrom32kRSACertificateFileInPEMFormat(): void
     {
-        $result = JWKFactory::createFromCertificateFile(__DIR__ . '/RSA/PEM/32k-rsa-example-cert.pem');
+        $result = $this->factory()
+            ->fromCertificateFile(__DIR__ . '/RSA/PEM/32k-rsa-example-cert.pem');
 
         static::assertSame([
             'kty' => 'RSA',
@@ -152,7 +161,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromPrivateEC256KeyFileEncrypted(): void
     {
-        $result = JWKFactory::createFromKeyFile(__DIR__ . '/Keys/EC/private.es256.encrypted.key', 'test');
+        $result = $this->factory()
+            ->fromKeyFile(__DIR__ . '/Keys/EC/private.es256.encrypted.key', 'test');
 
         static::assertSame(
             '{"kty":"EC","crv":"P-256","d":"q_VkzNnxTG39jHB0qkwA_SeVXud7yCHT7kb7kZv-0xQ","x":"vuYsP-QnrqAbM7Iyhzjt08hFSuzapyojCB_gFsBt65U","y":"oq-E2K-X0kPeqGuKnhlXkxc5fnxomRSC6KLby7Ij8AE"}',
@@ -163,7 +173,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromPrivateEC384KeyFileEncrypted(): void
     {
-        $result = JWKFactory::createFromKeyFile(__DIR__ . '/Keys/EC/private.es384.encrypted.key', 'test');
+        $result = $this->factory()
+            ->fromKeyFile(__DIR__ . '/Keys/EC/private.es384.encrypted.key', 'test');
 
         static::assertSame(
             '{"kty":"EC","crv":"P-384","d":"pcSSXrbeZEOaBIs7IwqcU9M_OOM81XhZuOHoGgmS_2PdECwcdQcXzv7W8-lYL0cr","x":"6f-XZsg2Tvn0EoEapQ-ylMYNtsm8CPf0cb8HI2EkfY9Bqpt3QMzwlM7mVsFRmaMZ","y":"b8nOnRwmpmEnvA2U8ydS-dbnPv7bwYl-q1qNeh8Wpjor3VO-RTt4ce0Pn25oGGWU"}',
@@ -174,7 +185,8 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromPrivateEC512KeyFileEncrypted(): void
     {
-        $result = JWKFactory::createFromKeyFile(__DIR__ . '/Keys/EC/private.es512.encrypted.key', 'test');
+        $result = $this->factory()
+            ->fromKeyFile(__DIR__ . '/Keys/EC/private.es512.encrypted.key', 'test');
 
         static::assertSame(
             '{"kty":"EC","crv":"P-521","d":"Fp6KFKRiHIdR_7PP2VKxz6OkS_phyoQqwzv2I89-8zP7QScrx5r8GFLcN5mCCNJt3rN3SIgI4XoIQbNePlAj6vE","x":"AVpvo7TGpQk5P7ZLo0qkBpaT-fFDv6HQrWElBKMxcrJd_mRNapweATsVv83YON4lTIIRXzgGkmWeqbDr6RQO-1cS","y":"AIs-MoRmLaiPyG2xmPwQCHX2CGX_uCZiT3iOxTAJEZuUbeSA828K4WfAA4ODdGiB87YVShhPOkiQswV3LpbpPGhC"}',
@@ -190,7 +202,8 @@ final class JWKFactoryTest extends TestCase
         $content = file_get_contents($filename);
 
         // When
-        $jwk = JWKFactory::createFromKeyFile($filename);
+        $jwk = $this->factory()
+            ->fromKeyFile($filename);
 
         // Then
         static::assertSame($expectedJWK, json_encode($jwk, JSON_THROW_ON_ERROR));
@@ -216,13 +229,14 @@ final class JWKFactoryTest extends TestCase
     #[Test]
     public function createFromValues(): void
     {
-        $result = JWKFactory::createFromValues([
-            'kty' => 'EC',
-            'crv' => 'P-521',
-            'd' => 'Fp6KFKRiHIdR_7PP2VKxz6OkS_phyoQqwzv2I89-8zP7QScrx5r8GFLcN5mCCNJt3rN3SIgI4XoIQbNePlAj6vE',
-            'x' => 'AVpvo7TGpQk5P7ZLo0qkBpaT-fFDv6HQrWElBKMxcrJd_mRNapweATsVv83YON4lTIIRXzgGkmWeqbDr6RQO-1cS',
-            'y' => 'AIs-MoRmLaiPyG2xmPwQCHX2CGX_uCZiT3iOxTAJEZuUbeSA828K4WfAA4ODdGiB87YVShhPOkiQswV3LpbpPGhC',
-        ]);
+        $result = $this->factory()
+            ->fromValues([
+                'kty' => 'EC',
+                'crv' => 'P-521',
+                'd' => 'Fp6KFKRiHIdR_7PP2VKxz6OkS_phyoQqwzv2I89-8zP7QScrx5r8GFLcN5mCCNJt3rN3SIgI4XoIQbNePlAj6vE',
+                'x' => 'AVpvo7TGpQk5P7ZLo0qkBpaT-fFDv6HQrWElBKMxcrJd_mRNapweATsVv83YON4lTIIRXzgGkmWeqbDr6RQO-1cS',
+                'y' => 'AIs-MoRmLaiPyG2xmPwQCHX2CGX_uCZiT3iOxTAJEZuUbeSA828K4WfAA4ODdGiB87YVShhPOkiQswV3LpbpPGhC',
+            ]);
 
         static::assertSame(
             '{"kty":"EC","crv":"P-521","d":"Fp6KFKRiHIdR_7PP2VKxz6OkS_phyoQqwzv2I89-8zP7QScrx5r8GFLcN5mCCNJt3rN3SIgI4XoIQbNePlAj6vE","x":"AVpvo7TGpQk5P7ZLo0qkBpaT-fFDv6HQrWElBKMxcrJd_mRNapweATsVv83YON4lTIIRXzgGkmWeqbDr6RQO-1cS","y":"AIs-MoRmLaiPyG2xmPwQCHX2CGX_uCZiT3iOxTAJEZuUbeSA828K4WfAA4ODdGiB87YVShhPOkiQswV3LpbpPGhC"}',
@@ -235,7 +249,8 @@ final class JWKFactoryTest extends TestCase
     #[MaximumDuration(500)]
     public function loadKeyPEMEncoded(string $filename, array $expectedValues): void
     {
-        $jwk = JWKFactory::createFromKeyFile($filename);
+        $jwk = $this->factory()
+            ->fromKeyFile($filename);
 
         static::assertSame($expectedValues, $jwk->all());
     }
@@ -323,5 +338,10 @@ final class JWKFactoryTest extends TestCase
                 'd' => 'mG-fgDwkr58hwIeqCQKZbR8HKeY4yg_AzvU6zyNaVUE',
             ],
         ];
+    }
+
+    private function factory(): JWKFactoryInterface
+    {
+        return new JWKFactory();
     }
 }

--- a/tests/Component/KeyManagement/JWKSetTest.php
+++ b/tests/Component/KeyManagement/JWKSetTest.php
@@ -96,7 +96,7 @@ final class JWKSetTest extends TestCase
                 'use' => 'sig',
             ]],
         ];
-        $jwkset = JWKFactory::createFromValues($values);
+        $jwkset = (new JWKFactory())->fromValues($values);
         static::assertInstanceOf(JWKSet::class, $jwkset);
         static::assertSame(1, is_countable($jwkset) ? count($jwkset) : 0);
         static::assertTrue($jwkset->has('71ee230371d19630bc17fb90ccf20ae632ad8cf8'));

--- a/tests/Component/KeyManagement/JWKTest.php
+++ b/tests/Component/KeyManagement/JWKTest.php
@@ -201,7 +201,7 @@ final class JWKTest extends TestCase
     #[Test]
     public function loadCertificateChain(): void
     {
-        $key = JWKFactory::createFromCertificateFile(
+        $key = (new JWKFactory())->fromCertificateFile(
             __DIR__ . '/Chain/google.crt',
             [
                 'kid' => 'From www.google.com',

--- a/tests/Component/KeyManagement/Keys/BrainpoolKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/BrainpoolKeysTest.php
@@ -24,7 +24,7 @@ final class BrainpoolKeysTest extends TestCase
     #[DataProvider('curves')]
     public function aKeyIsCreatedOnTheExpectedCurve(string $curve, string $file, int $size): void
     {
-        $jwk = JWKFactory::createECKey($curve);
+        $jwk = (new JWKFactory())->ec($curve);
 
         static::assertSame('EC', $jwk->get('kty'));
         static::assertSame($curve, $jwk->get('crv'));
@@ -74,7 +74,7 @@ final class BrainpoolKeysTest extends TestCase
     #[DataProvider('curves')]
     public function aKeyIsConvertedToPemAndLoadedAgain(string $curve, string $file, int $size): void
     {
-        $jwk = JWKFactory::createECKey($curve);
+        $jwk = (new JWKFactory())->ec($curve);
 
         $private = KeyConverter::loadFromKey(ECKey::convertToPEM($jwk));
         $public = KeyConverter::loadFromKey(ECKey::convertToPEM($jwk->toPublic()));

--- a/tests/Component/KeyManagement/Keys/ECKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/ECKeysTest.php
@@ -262,7 +262,7 @@ PEM);
     #[Test]
     public function createECKeyOnP256(): void
     {
-        $jwk = JWKFactory::createECKey('P-256');
+        $jwk = (new JWKFactory())->ec('P-256');
 
         static::assertSame('EC', $jwk->get('kty'));
         static::assertTrue($jwk->has('d'));
@@ -273,7 +273,7 @@ PEM);
     #[Test]
     public function createECKeyOnP384(): void
     {
-        $jwk = JWKFactory::createECKey('P-384');
+        $jwk = (new JWKFactory())->ec('P-384');
 
         static::assertSame('EC', $jwk->get('kty'));
         static::assertTrue($jwk->has('d'));
@@ -284,7 +284,7 @@ PEM);
     #[Test]
     public function createECKeyOnP521(): void
     {
-        $jwk = JWKFactory::createECKey('P-521');
+        $jwk = (new JWKFactory())->ec('P-521');
 
         static::assertSame('EC', $jwk->get('kty'));
         static::assertTrue($jwk->has('d'));

--- a/tests/Component/KeyManagement/Keys/NoneKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/NoneKeysTest.php
@@ -40,7 +40,7 @@ final class NoneKeysTest extends TestCase
     #[Test]
     public function createNoneKey(): void
     {
-        $key = JWKFactory::createNoneKey([
+        $key = (new JWKFactory())->none([
             'kid' => 'NONE_KEY',
         ]);
 

--- a/tests/Component/KeyManagement/Keys/OKPKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/OKPKeysTest.php
@@ -20,13 +20,13 @@ final class OKPKeysTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported "Ed455" curve');
 
-        JWKFactory::createOKPKey('Ed455');
+        (new JWKFactory())->okp('Ed455');
     }
 
     #[Test]
     public function createOKPKeyWithCurveX25519(): void
     {
-        $jwk = JWKFactory::createOKPKey('X25519', [
+        $jwk = (new JWKFactory())->okp('X25519', [
             'kid' => 'KEY',
             'alg' => 'ECDH-ES',
             'use' => 'enc',
@@ -43,7 +43,7 @@ final class OKPKeysTest extends TestCase
     #[Test]
     public function createOKPKeyWithCurveEd25519(): void
     {
-        $jwk = JWKFactory::createOKPKey('Ed25519', [
+        $jwk = (new JWKFactory())->okp('Ed25519', [
             'kid' => 'KEY',
             'alg' => 'EdDSA',
             'use' => 'sig',

--- a/tests/Component/KeyManagement/Keys/OctKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/OctKeysTest.php
@@ -20,13 +20,13 @@ final class OctKeysTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid key size.');
 
-        JWKFactory::createOctKey(12);
+        (new JWKFactory())->oct(12);
     }
 
     #[Test]
     public function createOctKey(): void
     {
-        $jwk = JWKFactory::createOctKey(64);
+        $jwk = (new JWKFactory())->oct(64);
 
         static::assertSame('oct', $jwk->get('kty'));
         static::assertTrue($jwk->has('k'));

--- a/tests/Component/KeyManagement/Keys/RSAKeysTest.php
+++ b/tests/Component/KeyManagement/Keys/RSAKeysTest.php
@@ -260,7 +260,7 @@ final class RSAKeysTest extends TestCase
     #[Test]
     public function createRSAKey512Bits(): void
     {
-        $jwk = JWKFactory::createRSAKey(512);
+        $jwk = (new JWKFactory())->rsa(512);
 
         static::assertSame('RSA', $jwk->get('kty'));
         static::assertTrue($jwk->has('p'));
@@ -317,7 +317,7 @@ final class RSAKeysTest extends TestCase
     #[Test]
     public function loadsRSASSAPSSKey(): void
     {
-        $key = JWKFactory::createFromKeyFile(__DIR__ . '/RSA/rsassa-pss.pem');
+        $key = (new JWKFactory())->fromKeyFile(__DIR__ . '/RSA/rsassa-pss.pem');
 
         static::assertSame(
             [

--- a/tests/Component/NestedToken/ResultObjectsTest.php
+++ b/tests/Component/NestedToken/ResultObjectsTest.php
@@ -101,7 +101,7 @@ final class ResultObjectsTest extends NestedTokenTestCase
     private function getEncryptionKey(): JWK
     {
         if ($this->encryptionKey === null) {
-            $this->encryptionKey = JWKFactory::createOctKey(256, [
+            $this->encryptionKey = (new JWKFactory())->oct(256, [
                 'alg' => 'A256KW',
                 'use' => 'enc',
             ]);
@@ -113,7 +113,7 @@ final class ResultObjectsTest extends NestedTokenTestCase
     private function getSignatureKey(): JWK
     {
         if ($this->signatureKey === null) {
-            $this->signatureKey = JWKFactory::createOctKey(512, [
+            $this->signatureKey = (new JWKFactory())->oct(512, [
                 'alg' => 'HS256',
                 'use' => 'sig',
             ]);


### PR DESCRIPTION
Closes #691.

## Why

`JWKFactory` is a bag of sixteen static methods, several of which reach for OpenSSL, for sodium or for the filesystem. Application code that generates or loads keys cannot be unit tested without any of them, the factory cannot be decorated (auditing, caching, a hardware-backed implementation, a deterministic generator in tests), and it is invisible in the container and in the profiler, unlike every other component of the library.

## What

* New `JWKFactoryInterface` with the behaviour as instance methods. The `create` prefix disappears, since it was only there because the methods were static:

  | static (deprecated) | service |
  | --- | --- |
  | `createRSAKey()` | `rsa()` |
  | `createECKey()` | `ec()` |
  | `createOctKey()` | `oct()` |
  | `createOKPKey()` | `okp()` |
  | `createNoneKey()` | `none()` |
  | `createFromJsonObject()` | `fromJsonObject()` |
  | `createFromValues()` | `fromValues()` |
  | `createFromSecret()` | `fromSecret()` |
  | `createFromCertificateFile()` | `fromCertificateFile()` |
  | `createFromCertificate()` | `fromCertificate()` |
  | `createFromX509Resource()` | `fromX509Resource()` |
  | `createFromX5C()` | `fromX5C()` |
  | `createFromKeyFile()` | `fromKeyFile()` |
  | `createFromKey()` | `fromKey()` |
  | `createFromPKCS12CertificateFile()` | `fromPKCS12CertificateFile()` |
  | `createFromKeySet()` | `fromKeySet()` |

* `JWKFactory` implements the interface and carries the logic. The static methods are thin delegations to a default instance, raise a deprecation notice and are removed in 5.0.0. The class is annotated `@final` and its constructor warns when it is extended, as the other services do since #709.
* The bundle already registered `JWKFactory`; it is now also aliased with `JWKFactoryInterface`, so `JWKFactoryInterface $factory` is autowired and a decorator can be injected in its place. The nine JWK/JWKSet configuration sources reference the interface and the instance methods.
* The thirteen console commands that generate or load a key use the injected service.

## Backward compatibility

The public API only gains methods and the interface; not one static was removed and not one signature changed (verified by a reflection diff of `src/` against the base commit). The sixteen statics were run side by side against the base commit: identical keys, identical exception classes and messages, the only difference being the deprecation notice.

`GeneratorCommand` gains `__construct(?string $name = null, ?JWKFactoryInterface $jwkFactory = null)`, where it used to inherit `Command::__construct(?string $name = null)`. The factory is deliberately the **second** argument, unlike the other commands of the library which put their dependency first, so that the inherited name keeps its position: `new EcKeyGeneratorCommand()` and `new EcKeyGeneratorCommand('my:command')` both keep working, which was checked by running the commands from both signatures. The argument is optional and falls back to a default factory, so the commands stay usable outside of a container, and they emit no deprecation.

The only scenario that would break is an application that replaced the `Jose\Component\KeyManagement\JWKFactory` service id by a class of its own that is not a `JWKFactory`: the bundle now calls `fromCertificate()` and friends on that service rather than the static names. A subclass of `JWKFactory` is unaffected.

Typing the values that were only reachable through the untyped statics removed **133 entries** from the PHPStan baseline; nothing was added to it.

## Checks

`castor ecs`, `castor phpstan`, `castor deptrac` and the full PHPUnit suite (1050 tests) are green.
