### PR TITLE
feat(core): typed accessors on the JWK, sealed helpers on the JWKSet

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4548,18 +4548,6 @@ parameters:
 			path: ../src/Library/Core/JWKSet.php
 
 		-
-			rawMessage: 'Method Jose\Component\Core\JWKSet::sortKeys() has parameter $a with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Core/JWKSet.php
-
-		-
-			rawMessage: 'Method Jose\Component\Core\JWKSet::sortKeys() has parameter $b with no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Library/Core/JWKSet.php
-
-		-
 			rawMessage: 'Only numeric types are allowed in +, int|true given on the right side.'
 			identifier: plus.rightNonNumeric
 			count: 2

--- a/src/Library/Core/JWK.php
+++ b/src/Library/Core/JWK.php
@@ -13,12 +13,21 @@ use Override;
 use function array_key_exists;
 use function in_array;
 use function is_array;
+use function is_string;
 use function sprintf;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 
 /**
+ * A JSON Web Key.
+ *
+ * The parameters are stored as they were given: only the presence of "kty" is checked. The typed accessors - kty(),
+ * alg(), use() and getString() - read a parameter and assert its type once, so that the callers do not have to write
+ * the "has() then get() then is_string()" dance every time; find() returns null instead of throwing when a parameter
+ * is absent. The class will be final and readonly in 5.0.0, where the parameters are validated against the key type
+ * at construction time.
+ *
  * @see \Jose\Tests\Component\Core\JWKTest
  */
 class JWK implements JsonSerializable
@@ -72,6 +81,63 @@ class JWK implements JsonSerializable
         }
 
         return $this->values[$key];
+    }
+
+    /**
+     * Get the value with a specific key, as a string.
+     *
+     * @param string $key The key
+     *
+     * @throws InvalidKeyException if the value does not exist or is not a string
+     */
+    public function getString(string $key): string
+    {
+        $value = $this->get($key);
+        if (! is_string($value)) {
+            throw new InvalidKeyException(sprintf('Invalid key parameter "%s". Should be a string.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the value with a specific key, or null when the JWK does not carry it.
+     *
+     * @param string $key The key
+     */
+    public function find(string $key): mixed
+    {
+        return $this->has($key) ? $this->values[$key] : null;
+    }
+
+    /**
+     * The key type. The parameter is mandatory: a JWK cannot be created without one.
+     *
+     * @throws InvalidKeyException if the value is not a string
+     */
+    public function kty(): string
+    {
+        return $this->getString('kty');
+    }
+
+    /**
+     * The algorithm the key is restricted to, or null when it is not restricted to any.
+     *
+     * @throws InvalidKeyException if the value is not a string
+     */
+    public function alg(): ?string
+    {
+        return $this->has('alg') ? $this->getString('alg') : null;
+    }
+
+    /**
+     * The usage the key is restricted to - "sig" or "enc" - or null when it is not restricted to any.
+     *
+     * @throws InvalidKeyException if the value is not a string
+     */
+    public function use(): ?string
+    {
+        return $this->has('use') ? $this->getString('use') : null;
     }
 
     /**

--- a/src/Library/Core/JWKSet.php
+++ b/src/Library/Core/JWKSet.php
@@ -19,9 +19,16 @@ use function is_array;
 use function is_int;
 use function is_string;
 use function sprintf;
+use function trigger_deprecation;
 use const COUNT_NORMAL;
 use const JSON_THROW_ON_ERROR;
 
+/**
+ * A set of JSON Web Keys.
+ *
+ * Keys carrying a "kid" are indexed by it, so that get() and has() accept either a position or a "kid". The class will
+ * be final and readonly in 5.0.0.
+ */
 class JWKSet implements Countable, IteratorAggregate, JsonSerializable
 {
     private array $keys = [];
@@ -160,6 +167,10 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Try to find a key that fits on the selected requirements. Returns null if not found.
      *
+     * A key that does not fit is skipped, never rejected: a key set is often built from a remote source and a single
+     * key carrying a malformed "kty", "alg" or "use" must not make the whole selection fail. This is why the selection
+     * reads those parameters with find() and compares them, instead of asserting their type with the typed accessors.
+     *
      * @param string $type Must be 'sig' (signature) or 'enc' (encryption)
      * @param Algorithm|null $algorithm Specifies the algorithm to be used
      * @param array<string, mixed> $restrictions More restrictions such as 'kid' or 'kty'
@@ -200,25 +211,37 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
             return null;
         }
 
-        usort($result, [$this, 'sortKeys']);
+        usort($result, static fn (array $a, array $b): int => $b['ind'] <=> $a['ind']);
 
         return $result[0]['key'];
     }
 
     /**
-     * Internal method only. Should not be used.
+     * Compares two candidates of selectKey() by the score they were given.
      *
-     * @internal
+     * The method was only public because the comparison used to be passed to usort() as a callable; it is a closure
+     * now and nothing in the library calls this method any more.
+     *
+     * @param array{key: JWK, ind: int} $a
+     * @param array{key: JWK, ind: int} $b
+     *
+     * @deprecated since 4.3.0 and will be removed in 5.0.0. The method is an implementation detail of selectKey().
      */
     public static function sortKeys(array $a, array $b): int
     {
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The method "%s::sortKeys()" is deprecated and will be removed in 5.0.0. It is an implementation detail of "selectKey()".',
+            self::class
+        );
+
         return $b['ind'] <=> $a['ind'];
     }
 
     /**
-     * Internal method only. Should not be used.
-     *
-     * @internal
+     * Returns an iterator over the keys of the key set, as required by the IteratorAggregate contract: iterating over
+     * a key set with "foreach" is supported.
      */
     public function getIterator(): Traversable
     {
@@ -232,13 +255,11 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
      */
     private function add(JWK $jwk): void
     {
-        if ($jwk->has('kid')) {
-            $kid = $jwk->get('kid');
-            if ((is_string($kid) || is_int($kid)) && ! array_key_exists($kid, $this->keys)) {
-                $this->keys[$kid] = $jwk;
+        $kid = $jwk->find('kid');
+        if ((is_string($kid) || is_int($kid)) && ! array_key_exists($kid, $this->keys)) {
+            $this->keys[$kid] = $jwk;
 
-                return;
-            }
+            return;
         }
 
         $this->keys[] = $jwk;
@@ -258,7 +279,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
             return null;
         }
         foreach ($this->all() as $key => $jwk) {
-            if ($jwk->has('kid') && $jwk->get('kid') === $index) {
+            if ($jwk->find('kid') === $index) {
                 return $key;
             }
         }
@@ -268,8 +289,9 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
 
     private function canKeyBeUsedFor(string $type, JWK $key): bool|int
     {
-        if ($key->has('use')) {
-            return $type === $key->get('use') ? 1 : false;
+        $use = $key->find('use');
+        if ($use !== null) {
+            return $type === $use ? 1 : false;
         }
         if ($key->has('key_ops')) {
             $key_ops = $key->get('key_ops');
@@ -290,11 +312,12 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
         if ($algorithm === null) {
             return 0;
         }
-        if (! in_array($key->get('kty'), $algorithm->allowedKeyTypes(), true)) {
+        if (! in_array($key->find('kty'), $algorithm->allowedKeyTypes(), true)) {
             return false;
         }
-        if ($key->has('alg')) {
-            return $algorithm->name() === $key->get('alg') ? 2 : false;
+        $alg = $key->find('alg');
+        if ($alg !== null) {
+            return $algorithm->name() === $alg ? 2 : false;
         }
 
         return 1;

--- a/src/Library/Core/Util/KeyChecker.php
+++ b/src/Library/Core/Util/KeyChecker.php
@@ -8,7 +8,6 @@ use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
 use function in_array;
 use function is_array;
-use function is_string;
 use function sprintf;
 
 /**
@@ -28,12 +27,9 @@ final readonly class KeyChecker
 
     public static function checkKeyAlgorithm(JWK $key, string $algorithm): void
     {
-        if (! $key->has('alg')) {
+        $alg = $key->alg();
+        if ($alg === null) {
             return;
-        }
-        $alg = $key->get('alg');
-        if (! is_string($alg)) {
-            throw new InvalidKeyException('Invalid algorithm.');
         }
         if ($alg !== $algorithm) {
             throw new InvalidKeyException(sprintf('Key is only allowed for algorithm "%s".', $alg));
@@ -91,7 +87,7 @@ final readonly class KeyChecker
 
     private static function checkUsage(JWK $key, string $usage): void
     {
-        $use = $key->get('use');
+        $use = $key->use();
 
         switch ($usage) {
             case 'verification':

--- a/src/Library/Signature/JWSBuilder.php
+++ b/src/Library/Signature/JWSBuilder.php
@@ -304,8 +304,8 @@ class JWSBuilder implements JWSBuilderInterface
         if (! is_string($alg)) {
             throw new InvalidHeaderParameterException('No "alg" parameter set in the header.');
         }
-        $keyAlg = $key->has('alg') ? $key->get('alg') : null;
-        if (is_string($keyAlg) && $keyAlg !== $alg) {
+        $keyAlg = $key->alg();
+        if ($keyAlg !== null && $keyAlg !== $alg) {
             throw new InvalidKeyException(sprintf('The algorithm "%s" is not allowed with this key.', $alg));
         }
 

--- a/tests/Component/Core/JWKTypedAccessorsTest.php
+++ b/tests/Component/Core/JWKTypedAccessorsTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Core;
+
+use InvalidArgumentException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\Algorithm\HS256;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function iterator_to_array;
+use function restore_error_handler;
+use function set_error_handler;
+use function usort;
+use const E_USER_DEPRECATED;
+
+/**
+ * The typed accessors of the JWK assert the type of a parameter once, so that the callers stop writing the "has()
+ * then get() then is_string()" dance. The internal helpers of the JWKSet that were only public because of the way
+ * they were used are deprecated, and the iterator is documented as the public contract it is.
+ *
+ * @internal
+ */
+final class JWKTypedAccessorsTest extends TestCase
+{
+    #[Test]
+    public function theTypedAccessorsReturnTheParameters(): void
+    {
+        $jwk = new JWK([
+            'kty' => 'oct',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+            'alg' => 'HS256',
+            'use' => 'sig',
+        ]);
+
+        static::assertSame('oct', $jwk->kty());
+        static::assertSame('HS256', $jwk->alg());
+        static::assertSame('sig', $jwk->use());
+        static::assertSame('GawgguFyGrWKav7AX4VKUg', $jwk->getString('k'));
+    }
+
+    #[Test]
+    public function theOptionalAccessorsReturnNullWhenTheParameterIsAbsent(): void
+    {
+        $jwk = new JWK([
+            'kty' => 'oct',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+        ]);
+
+        static::assertNull($jwk->alg());
+        static::assertNull($jwk->use());
+        static::assertNull($jwk->find('kid'));
+        static::assertSame('GawgguFyGrWKav7AX4VKUg', $jwk->find('k'));
+    }
+
+    #[Test]
+    public function anAbsentParameterCannotBeReadAsAString(): void
+    {
+        $jwk = new JWK([
+            'kty' => 'oct',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value identified by "kid" does not exist.');
+
+        $jwk->getString('kid');
+    }
+
+    #[Test]
+    public function aParameterThatIsNotAStringIsRejected(): void
+    {
+        $jwk = new JWK([
+            'kty' => 'oct',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+            'alg' => 123,
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid key parameter "alg". Should be a string.');
+
+        $jwk->alg();
+    }
+
+    #[Test]
+    public function aKeySetIsIterable(): void
+    {
+        $first = new JWK([
+            'kty' => 'oct',
+            'kid' => 'first',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+        ]);
+        $second = new JWK([
+            'kty' => 'oct',
+            'kid' => 'second',
+            'k' => 'GawgguFyGrWKav7AX4VKUg',
+        ]);
+        $jwkset = new JWKSet([$first, $second]);
+
+        static::assertSame([
+            'first' => $first,
+            'second' => $second,
+        ], iterator_to_array($jwkset->getIterator()));
+    }
+
+    #[Test]
+    public function sortingTheCandidatesOfSelectKeyIsDeprecated(): void
+    {
+        $candidates = [[
+            'key' => new JWK([
+                'kty' => 'oct',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+            'ind' => 1,
+        ], [
+            'key' => new JWK([
+                'kty' => 'oct',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+            'ind' => 2,
+        ]];
+
+        $deprecations = $this->collectDeprecations(static function () use (&$candidates): void {
+            usort($candidates, JWKSet::sortKeys(...));
+        });
+
+        static::assertNotEmpty($deprecations);
+        static::assertStringContainsString(
+            'The method "Jose\Component\Core\JWKSet::sortKeys()" is deprecated',
+            $deprecations[0]
+        );
+        static::assertSame(2, $candidates[0]['ind']);
+    }
+
+    #[Test]
+    public function selectingAKeyDoesNotEmitADeprecation(): void
+    {
+        $jwkset = new JWKSet([
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'first',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'second',
+                'use' => 'sig',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+        ]);
+
+        $key = null;
+        $deprecations = $this->collectDeprecations(static function () use ($jwkset, &$key): void {
+            $key = $jwkset->selectKey('sig');
+        });
+
+        static::assertSame([], $deprecations);
+        static::assertInstanceOf(JWK::class, $key);
+        static::assertSame('second', $key->getString('kid'));
+    }
+
+    #[Test]
+    public function aMalformedKeyIsSkippedByTheSelectionInsteadOfRejectingTheWholeKeySet(): void
+    {
+        $jwkset = new JWKSet([
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'malformed use',
+                'use' => 123,
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'malformed alg',
+                'alg' => 123,
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+            new JWK([
+                'kty' => 123,
+                'kid' => 'malformed kty',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+            new JWK([
+                'kty' => 'oct',
+                'kid' => 'usable',
+                'use' => 'sig',
+                'alg' => 'HS256',
+                'k' => 'GawgguFyGrWKav7AX4VKUg',
+            ]),
+        ]);
+
+        $key = $jwkset->selectKey('sig', new HS256());
+
+        static::assertInstanceOf(JWK::class, $key);
+        static::assertSame('usable', $key->getString('kid'));
+    }
+
+    /**
+     * @param callable(): void $callback
+     *
+     * @return list<string>
+     */
+    private function collectDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}


### PR DESCRIPTION
Closes #690.

## Why

`JWK::get()` returns an undeclared `mixed` and throws when the parameter is absent, so every caller writes `has()` then `get()` then a type assertion, and each one decides on its own what to do with a malformed value. Those `is_string($alg)` checks were scattered over `JWSBuilder`, `KeyChecker` and `JWKSet`.

`JWKSet` had two annotations pointing the wrong way: `sortKeys()` was public and `@internal`, only because the comparison was handed to `usort()` as a callable, while `getIterator()` was `@internal` although it *is* the `IteratorAggregate` contract — users were told not to `foreach` over a key set.

## What

**`JWK`**

| accessor | behaviour |
| --- | --- |
| `kty(): string` | the mandatory key type |
| `alg(): ?string` | the algorithm restriction, `null` when there is none |
| `use(): ?string` | the usage restriction, `null` when there is none |
| `getString(string $key): string` | `get()` plus a string assertion |
| `find(string $key): mixed` | `null` instead of throwing when the parameter is absent |

`get()`, `has()` and `all()` are unchanged.

**`JWKSet`**

* `usort()` takes a closure; `sortKeys()` is no longer called by the library and calling it is deprecated.
* `getIterator()` loses the `@internal` annotation and is documented as the public contract it is.
* `add()` and `indexOf()` use `find()`, which removes the `has()` + `get()` pair.

**Callers**: `KeyChecker` drops its own assertions and reads `alg()` / `use()`.

Both classes announce in their docblock that they become `final readonly` in 5.0.0.

## Backward compatibility

The public API only gains methods; nothing is removed and no signature changes (verified by a reflection diff of `src/` against the base commit).

One behavioural regression was found while checking this and is fixed here: reading `kty`, `alg` and `use` with the typed accessors made `selectKey()` **throw** on a key set holding a single key whose value is not a string, where it used to skip that key and return the next usable one. A key set is often fetched from a remote source — `JKUFactory` does exactly that — so one sloppy key published by a third party would have broken every verification. The selection reads those three parameters with `find()` again; a regression test covers a key set mixing three malformed keys and a usable one.

What remains is an exception **message** change, same exception class, asserted nowhere: a key whose `alg` is not a string made `KeyChecker::checkKeyAlgorithm()` throw `InvalidKeyException("Invalid algorithm.")` and now throws `InvalidKeyException('Invalid key parameter "alg". Should be a string.')`.

The typed `sortKeys()` signature removed entries from the PHPStan baseline; nothing was added.

## Note

The issue also asks to centralise the `kid` indexing written three times; that was already done by the fix for #682 — the constructor, `createFromKeyData()` and `with()` all go through the private `add()`. Nothing to do there.

## Checks

`castor ecs`, `castor phpstan`, `castor deptrac` and the full PHPUnit suite (1054 tests) are green.
