### PR TITLE
feat(algorithms): ship "none" and RSA1_5 in their own packages

### DIFF
--- a/.ci-tools/deptrac.yaml
+++ b/.ci-tools/deptrac.yaml
@@ -8,6 +8,12 @@ parameters:
     - name: 'Experimental'
       collectors:
         - { type: classLike, value: '^Jose\\Experimental\\' }
+    - name: 'Unsecured'
+      collectors:
+        - { type: classLike, value: '^Jose\\Unsecured\\' }
+    - name: 'Rsa15'
+      collectors:
+        - { type: classLike, value: '^Jose\\Rsa15\\' }
     - name: 'Bundle'
       collectors:
         - { type: classLike, value: '^Jose\\Bundle\\' }
@@ -24,11 +30,21 @@ parameters:
         - { type: classLike, value: '^Psr\\' }
   ruleset:
     Library:
+      - 'Rsa15'
+      - 'Unsecured'
       - 'Vendors'
     Experimental:
+      - 'Library'
+      - 'Vendors'
+    Unsecured:
+      - 'Library'
+      - 'Vendors'
+    Rsa15:
       - 'Library'
       - 'Vendors'
     Bundle:
       - 'Library'
       - 'Experimental'
+      - 'Rsa15'
+      - 'Unsecured'
       - 'Vendors'

--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -5,6 +5,10 @@ splits:
     target: "https://${GH_TOKEN}@github.com/web-token/jwt-library.git"
   - prefix: "src/Experimental"
     target: "https://${GH_TOKEN}@github.com/web-token/jwt-experimental.git"
+  - prefix: "src/Unsecured"
+    target: "https://${GH_TOKEN}@github.com/web-token/jwt-unsecured.git"
+  - prefix: "src/Rsa15"
+    target: "https://${GH_TOKEN}@github.com/web-token/jwt-rsa15.git"
 
 origins:
   - ^\d+\.\d+\.x$

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
     "autoload": {
         "psr-4": {
             "Jose\\Bundle\\JoseFramework\\": "src/Bundle/",
+            "Jose\\Rsa15\\": "src/Rsa15/",
+            "Jose\\Unsecured\\": "src/Unsecured/",
             "Jose\\Experimental\\": "src/Experimental/",
             "Jose\\Component\\": "src/Library/"
         }
@@ -82,6 +84,8 @@
     "replace": {
         "web-token/jwt-bundle": "self.version",
         "web-token/jwt-library": "self.version",
+        "web-token/jwt-rsa15": "self.version",
+        "web-token/jwt-unsecured": "self.version",
         "web-token/jwt-experimental": "self.version"
     },
     "suggest": {

--- a/performance/JWE/EncryptionBench.php
+++ b/performance/JWE/EncryptionBench.php
@@ -27,7 +27,7 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHESA256KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS256A128KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS384A192KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS512A256KW;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP256;
 use Jose\Component\Encryption\JWEBuilder;

--- a/performance/JWS/SignatureBench.php
+++ b/performance/JWS/SignatureBench.php
@@ -13,7 +13,6 @@ use Jose\Component\Signature\Algorithm\ES512;
 use Jose\Component\Signature\Algorithm\HS256;
 use Jose\Component\Signature\Algorithm\HS384;
 use Jose\Component\Signature\Algorithm\HS512;
-use Jose\Component\Signature\Algorithm\None;
 use Jose\Component\Signature\Algorithm\PS256;
 use Jose\Component\Signature\Algorithm\PS384;
 use Jose\Component\Signature\Algorithm\PS512;
@@ -27,6 +26,7 @@ use Jose\Component\Signature\Serializer\CompactSerializer;
 use Jose\Component\Signature\Serializer\JSONFlattenedSerializer;
 use Jose\Component\Signature\Serializer\JSONGeneralSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Jose\Unsecured\Signature\None;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
 /**

--- a/src/Bundle/DependencyInjection/Source/Encryption/EncryptionSource.php
+++ b/src/Bundle/DependencyInjection/Source/Encryption/EncryptionSource.php
@@ -18,6 +18,7 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA;
 use Jose\Component\Encryption\Serializer\JWESerializer as JWESerializerAlias;
 use Jose\Experimental\KeyEncryption\A128CTR;
 use Jose\Experimental\KeyEncryption\Chacha20Poly1305;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\FileLocator;
@@ -116,6 +117,7 @@ final readonly class EncryptionSource implements SourceWithCompilerPasses
             ECDHES::class => 'encryption_ecdhes.php',
             PBES2AESKW::class => 'encryption_pbes2.php',
             RSA::class => 'encryption_rsa.php',
+            RSA15::class => 'encryption_rsa15.php',
             A128CTR::class => 'encryption_experimental.php',
         ];
         if (in_array('chacha20-poly1305', openssl_get_cipher_methods(), true)) {

--- a/src/Bundle/DependencyInjection/Source/Signature/SignatureSource.php
+++ b/src/Bundle/DependencyInjection/Source/Signature/SignatureSource.php
@@ -10,9 +10,9 @@ use Jose\Bundle\JoseFramework\DependencyInjection\Source\SourceWithCompilerPasse
 use Jose\Component\Signature\Algorithm\ECDSA;
 use Jose\Component\Signature\Algorithm\EdDSA;
 use Jose\Component\Signature\Algorithm\HMAC;
-use Jose\Component\Signature\Algorithm\None;
 use Jose\Component\Signature\Algorithm\RSAPSS;
 use Jose\Experimental\Signature\HS1;
+use Jose\Unsecured\Signature\None;
 use Override;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\FileLocator;

--- a/src/Bundle/Resources/config/Algorithms/encryption_rsa15.php
+++ b/src/Bundle/Resources/config/Algorithms/encryption_rsa15.php
@@ -2,8 +2,7 @@
 
 declare(strict_types=1);
 
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP256;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $container): void {
@@ -13,13 +12,8 @@ return function (ContainerConfigurator $container): void {
         ->autoconfigure()
         ->autowire();
 
-    $container->set(RSAOAEP::class)
+    $container->set(RSA15::class)
         ->tag('jose.algorithm', [
-            'alias' => 'RSA-OAEP',
-        ]);
-
-    $container->set(RSAOAEP256::class)
-        ->tag('jose.algorithm', [
-            'alias' => 'RSA-OAEP-256',
+            'alias' => 'RSA1_5',
         ]);
 };

--- a/src/Bundle/Resources/config/Algorithms/signature_none.php
+++ b/src/Bundle/Resources/config/Algorithms/signature_none.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Jose\Component\Signature\Algorithm\None;
+use Jose\Unsecured\Signature\None;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $container): void {

--- a/src/Library/Encryption/Algorithm/KeyEncryption/RSA15.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/RSA15.php
@@ -4,103 +4,23 @@ declare(strict_types=1);
 
 namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
 
-use Jose\Component\Core\Exception\InvalidKeyException;
-use Jose\Component\Core\JWK;
-use Jose\Component\Core\Util\RSAKey;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\RSACrypt;
-use Override;
-use function func_get_arg;
-use function func_num_args;
-use function is_int;
-use function is_string;
+use Jose\Rsa15\KeyEncryption\RSA15 as Rsa15KeyEncryption;
 use function trigger_deprecation;
 
-final readonly class RSA15 extends RSA
+/**
+ * @deprecated since 4.3.0, will be removed in 5.0.0. The RSA1_5 algorithm moved to the "web-token/jwt-rsa15"
+ *             package: use Jose\Rsa15\KeyEncryption\RSA15 instead.
+ */
+final readonly class RSA15 extends Rsa15KeyEncryption
 {
-    /**
-     * BC NOTE: deprecated since 4.2 and will be removed in 5.0. The expected CEK size is now provided by the
-     * caller as the fourth argument of the "decryptKey" method.
-     *
-     * @var array<string, int>
-     */
-    private const CEK_LENGTHS = [
-        'A128GCM' => 16,
-        'A192GCM' => 24,
-        'A256GCM' => 32,
-        'A128CBC-HS256' => 32,
-        'A192CBC-HS384' => 48,
-        'A256CBC-HS512' => 64,
-    ];
-
-    #[Override]
-    public function name(): string
+    public function __construct()
     {
-        return 'RSA1_5';
-    }
-
-    /**
-     * The size (in bits) of the key expected by the content encryption algorithm may be passed as a fourth
-     * argument. That argument is not declared yet for BC reasons; it will be in 5.0 (see the KeyEncryption
-     * interface).
-     *
-     * @param array<string, mixed> $header
-     */
-    #[Override]
-    public function decryptKey(JWK $key, string $encrypted_cek, array $header): string
-    {
-        $encryptionKeyLength = func_num_args() > 3 ? func_get_arg(3) : null;
-        $this->checkKey($key);
-        if (! $key->has('d')) {
-            throw new InvalidKeyException('The key is not a private key');
-        }
-        $priv = RSAKey::createFromJWK($key);
-
-        return RSACrypt::decrypt(
-            $priv,
-            $encrypted_cek,
-            RSACrypt::ENCRYPTION_PKCS1,
-            null,
-            $this->getExpectedCekLength($header, $encryptionKeyLength)
-        );
-    }
-
-    #[Override]
-    protected function getEncryptionMode(): int
-    {
-        return RSACrypt::ENCRYPTION_PKCS1;
-    }
-
-    #[Override]
-    protected function getHashAlgorithm(): ?string
-    {
-        return null;
-    }
-
-    /**
-     * Returns the expected CEK length in bytes.
-     *
-     * @param array<string, mixed> $header
-     * @param mixed $encryptionKeyLength Size (in bits) of the key expected by the content encryption
-     *                                   algorithm, or null when the caller did not provide it
-     */
-    private function getExpectedCekLength(array $header, mixed $encryptionKeyLength): ?int
-    {
-        if (is_int($encryptionKeyLength)) {
-            return intdiv($encryptionKeyLength, 8);
-        }
-
         trigger_deprecation(
             'web-token/jwt-framework',
-            '4.2.0',
-            'Calling "%s::decryptKey()" without the size of the key expected by the content encryption algorithm as fourth argument is deprecated. That size is currently deduced from a hardcoded table that will be removed in 5.0.0: pass the value returned by "getCEKSize()" of the content encryption algorithm in use instead.',
-            self::class
+            '4.3.0',
+            'The class "%s" is deprecated and will be removed in 5.0.0. The "RSA1_5" algorithm is now shipped by the "web-token/jwt-rsa15" package: require it and use "%s" instead.',
+            self::class,
+            Rsa15KeyEncryption::class
         );
-
-        $enc = $header['enc'] ?? null;
-        if (! is_string($enc)) {
-            return null;
-        }
-
-        return self::CEK_LENGTHS[$enc] ?? null;
     }
 }

--- a/src/Library/Signature/Algorithm/None.php
+++ b/src/Library/Signature/Algorithm/None.php
@@ -4,43 +4,23 @@ declare(strict_types=1);
 
 namespace Jose\Component\Signature\Algorithm;
 
-use Jose\Component\Core\Exception\InvalidKeyException;
-use Jose\Component\Core\JWK;
-use Override;
-use function in_array;
+use Jose\Unsecured\Signature\None as DeprecatedNone;
+use function trigger_deprecation;
 
-final readonly class None implements SignatureAlgorithm
+/**
+ * @deprecated since 4.3.0, will be removed in 5.0.0. The "none" algorithm moved to the "web-token/jwt-unsecured"
+ *             package: use Jose\Unsecured\Signature\None instead.
+ */
+final readonly class None extends DeprecatedNone
 {
-    #[Override]
-    public function allowedKeyTypes(): array
+    public function __construct()
     {
-        return ['none'];
-    }
-
-    #[Override]
-    public function sign(JWK $key, string $input): string
-    {
-        $this->checkKey($key);
-
-        return '';
-    }
-
-    #[Override]
-    public function verify(JWK $key, string $input, string $signature): bool
-    {
-        return $signature === '';
-    }
-
-    #[Override]
-    public function name(): string
-    {
-        return 'none';
-    }
-
-    private function checkKey(JWK $key): void
-    {
-        if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
-            throw new InvalidKeyException('Wrong key type.');
-        }
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'The class "%s" is deprecated and will be removed in 5.0.0. The "none" algorithm is now shipped by the "web-token/jwt-unsecured" package: require it and use "%s" instead.',
+            self::class,
+            DeprecatedNone::class
+        );
     }
 }

--- a/src/Library/composer.json
+++ b/src/Library/composer.json
@@ -42,7 +42,9 @@
         "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19",
         "psr/clock": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1",
-        "symfony/deprecation-contracts": "^2.5|^3.0"
+        "symfony/deprecation-contracts": "^2.5|^3.0",
+        "web-token/jwt-rsa15": "^4.3",
+        "web-token/jwt-unsecured": "^4.3"
     },
     "conflict": {
         "spomky-labs/jose": "*"

--- a/src/Rsa15/KeyEncryption/RSA15.php
+++ b/src/Rsa15/KeyEncryption/RSA15.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Rsa15\KeyEncryption;
+
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\Util\RSAKey;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\RSACrypt;
+use Override;
+use function func_get_arg;
+use function func_num_args;
+use function is_int;
+use function is_string;
+use function trigger_deprecation;
+
+/**
+ * The RSA1_5 key encryption algorithm (RSAES-PKCS1-v1_5) of RFC 7518, section 4.2.
+ *
+ * Its padding is vulnerable to the Bleichenbacher adaptive chosen-ciphertext attack. Use RSA-OAEP-256 instead
+ * whenever the other party supports it.
+ *
+ * The class is not final because the deprecated Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15 extends it
+ * until 5.0.0.
+ */
+readonly class RSA15 extends RSA
+{
+    /**
+     * BC NOTE: deprecated since 4.2 and will be removed in 5.0. The expected CEK size is now provided by the
+     * caller as the fourth argument of the "decryptKey" method.
+     *
+     * @var array<string, int>
+     */
+    private const CEK_LENGTHS = [
+        'A128GCM' => 16,
+        'A192GCM' => 24,
+        'A256GCM' => 32,
+        'A128CBC-HS256' => 32,
+        'A192CBC-HS384' => 48,
+        'A256CBC-HS512' => 64,
+    ];
+
+    #[Override]
+    public function name(): string
+    {
+        return 'RSA1_5';
+    }
+
+    /**
+     * The size (in bits) of the key expected by the content encryption algorithm may be passed as a fourth
+     * argument. That argument is not declared yet for BC reasons; it will be in 5.0 (see the KeyEncryption
+     * interface).
+     *
+     * @param array<string, mixed> $header
+     */
+    #[Override]
+    public function decryptKey(JWK $key, string $encrypted_cek, array $header): string
+    {
+        $encryptionKeyLength = func_num_args() > 3 ? func_get_arg(3) : null;
+        $this->checkKey($key);
+        if (! $key->has('d')) {
+            throw new InvalidKeyException('The key is not a private key');
+        }
+        $priv = RSAKey::createFromJWK($key);
+
+        return RSACrypt::decrypt(
+            $priv,
+            $encrypted_cek,
+            RSACrypt::ENCRYPTION_PKCS1,
+            null,
+            $this->getExpectedCekLength($header, $encryptionKeyLength)
+        );
+    }
+
+    #[Override]
+    protected function getEncryptionMode(): int
+    {
+        return RSACrypt::ENCRYPTION_PKCS1;
+    }
+
+    #[Override]
+    protected function getHashAlgorithm(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Returns the expected CEK length in bytes.
+     *
+     * @param array<string, mixed> $header
+     * @param mixed $encryptionKeyLength Size (in bits) of the key expected by the content encryption
+     *                                   algorithm, or null when the caller did not provide it
+     */
+    private function getExpectedCekLength(array $header, mixed $encryptionKeyLength): ?int
+    {
+        if (is_int($encryptionKeyLength)) {
+            return intdiv($encryptionKeyLength, 8);
+        }
+
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.2.0',
+            'Calling "%s::decryptKey()" without the size of the key expected by the content encryption algorithm as fourth argument is deprecated. That size is currently deduced from a hardcoded table that will be removed in 5.0.0: pass the value returned by "getCEKSize()" of the content encryption algorithm in use instead.',
+            static::class
+        );
+
+        $enc = $header['enc'] ?? null;
+        if (! is_string($enc)) {
+            return null;
+        }
+
+        return self::CEK_LENGTHS[$enc] ?? null;
+    }
+}

--- a/src/Rsa15/LICENSE
+++ b/src/Rsa15/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2024 Spomky-Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Rsa15/README.md
+++ b/src/Rsa15/README.md
@@ -1,0 +1,28 @@
+RSA1_5 Key Encryption For JWT-Framework
+=======================================
+
+This repository is a sub repository of [the JWT Framework](https://github.com/web-token/jwt-framework) project and is
+READ ONLY.
+
+**Please do not submit any Pull Request here.**
+You should go to [the main repository](https://github.com/web-token/jwt-framework) instead.
+
+# What Is In This Package?
+
+The `RSA1_5` key encryption algorithm (RSAES-PKCS1-v1_5) of RFC 7518, section 4.2.
+
+It is not an experimental algorithm: it is perfectly standard, but its padding is vulnerable to the Bleichenbacher
+adaptive chosen-ciphertext attack, and RFC 8017 discourages it for new applications. It is shipped apart from the main
+library so that using it is an explicit and auditable decision. Use `RSA-OAEP-256` instead whenever the other party
+supports it.
+
+The RSASSA-PKCS1-v1_5 **signature** algorithms (`RS256`, `RS384`, `RS512`) are a different family: they are not
+affected by this attack and remain in the main library.
+
+# Documentation
+
+The official documentation is available as https://web-token.spomky-labs.com/
+
+# Licence
+
+This software is release under [MIT licence](LICENSE).

--- a/src/Rsa15/composer.json
+++ b/src/Rsa15/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "web-token/jwt-rsa15",
+    "description": "The RSA1_5 key encryption algorithm for the JWT Framework.",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "JWS",
+        "JWT",
+        "JWE",
+        "JWA",
+        "JWK",
+        "JWKSet",
+        "Jot",
+        "Jose",
+        "RFC7515",
+        "RFC7516",
+        "RFC7517",
+        "RFC7518",
+        "RFC7519",
+        "RFC7520",
+        "Bundle",
+        "Symfony"
+    ],
+    "homepage": "https://github.com/web-token",
+    "authors": [
+        {
+            "name": "Florent Morselli",
+            "homepage": "https://github.com/Spomky"
+        },
+        {
+            "name": "All contributors",
+            "homepage": "https://github.com/web-token/jwt-framework/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Jose\\Rsa15\\": ""
+        }
+    },
+    "require": {
+        "php": ">=8.2",
+        "web-token/jwt-library": "^4.3"
+    }
+}

--- a/src/Unsecured/LICENSE
+++ b/src/Unsecured/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2024 Spomky-Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Unsecured/README.md
+++ b/src/Unsecured/README.md
@@ -1,0 +1,25 @@
+Unsecured JWS For JWT-Framework
+===============================
+
+This repository is a sub repository of [the JWT Framework](https://github.com/web-token/jwt-framework) project and is
+READ ONLY.
+
+**Please do not submit any Pull Request here.**
+You should go to [the main repository](https://github.com/web-token/jwt-framework) instead.
+
+# What Is In This Package?
+
+The `none` signature algorithm, used by the unsecured JWT of RFC 7519, section 6.
+
+It is not an experimental algorithm: it is perfectly standard, but a JWS that uses it has no integrity protection at
+all, and it is the root cause of the JWT "alg confusion" family of vulnerabilities. It is shipped apart from the main
+library so that using it is an explicit and auditable decision: an application that does not require this package
+simply cannot be tricked into accepting an unsecured token.
+
+# Documentation
+
+The official documentation is available as https://web-token.spomky-labs.com/
+
+# Licence
+
+This software is release under [MIT licence](LICENSE).

--- a/src/Unsecured/Signature/None.php
+++ b/src/Unsecured/Signature/None.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Unsecured\Signature;
+
+use Jose\Component\Core\Exception\InvalidKeyException;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
+use Override;
+use function in_array;
+
+/**
+ * The "none" algorithm of RFC 7515, used by unsecured JWS.
+ *
+ * This algorithm does not sign anything and verifies nothing: a JWS using it offers no integrity protection at all.
+ * It is only shipped for the applications that have to interoperate with unsecured JWT (RFC 7519, section 6).
+ *
+ * The class is not final because the deprecated Jose\Component\Signature\Algorithm\None extends it until 5.0.0.
+ */
+readonly class None implements SignatureAlgorithm
+{
+    #[Override]
+    public function allowedKeyTypes(): array
+    {
+        return ['none'];
+    }
+
+    #[Override]
+    public function sign(JWK $key, string $input): string
+    {
+        $this->checkKey($key);
+
+        return '';
+    }
+
+    #[Override]
+    public function verify(JWK $key, string $input, string $signature): bool
+    {
+        $this->checkKey($key);
+
+        return $signature === '';
+    }
+
+    #[Override]
+    public function name(): string
+    {
+        return 'none';
+    }
+
+    private function checkKey(JWK $key): void
+    {
+        if (! in_array($key->get('kty'), $this->allowedKeyTypes(), true)) {
+            throw new InvalidKeyException('Wrong key type.');
+        }
+    }
+}

--- a/src/Unsecured/composer.json
+++ b/src/Unsecured/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "web-token/jwt-unsecured",
+    "description": "Unsecured JWS (the \"none\" algorithm) for the JWT Framework.",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "JWS",
+        "JWT",
+        "JWE",
+        "JWA",
+        "JWK",
+        "JWKSet",
+        "Jot",
+        "Jose",
+        "RFC7515",
+        "RFC7516",
+        "RFC7517",
+        "RFC7518",
+        "RFC7519",
+        "RFC7520",
+        "Bundle",
+        "Symfony"
+    ],
+    "homepage": "https://github.com/web-token",
+    "authors": [
+        {
+            "name": "Florent Morselli",
+            "homepage": "https://github.com/Spomky"
+        },
+        {
+            "name": "All contributors",
+            "homepage": "https://github.com/web-token/jwt-framework/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Jose\\Unsecured\\": ""
+        }
+    },
+    "require": {
+        "php": ">=8.2",
+        "web-token/jwt-library": "^4.3"
+    }
+}

--- a/tests/Bundle/JoseFramework/Functional/Rsa15AlgorithmTest.php
+++ b/tests/Bundle/JoseFramework/Functional/Rsa15AlgorithmTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Functional;
+
+use Jose\Component\Core\AlgorithmManagerFactory;
+use Jose\Rsa15\KeyEncryption\RSA15;
+use Jose\Tests\Bundle\JoseFramework\WebTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The "RSA1_5" algorithm of the jose-rsa15 package is registered by its own configuration file. That file is only
+ * loaded when the package is installed, so a stale class name would silently make the algorithm unavailable.
+ *
+ * @internal
+ */
+final class Rsa15AlgorithmTest extends WebTestCase
+{
+    #[Test]
+    public function theRsa15AlgorithmIsRegistered(): void
+    {
+        static::ensureKernelShutdown();
+        $container = static::createClient()
+            ->getContainer();
+
+        /** @var AlgorithmManagerFactory $factory */
+        $factory = $container->get(AlgorithmManagerFactory::class);
+
+        static::assertContains('RSA1_5', $factory->aliases());
+        static::assertSame('RSA1_5', $factory->create(['RSA1_5'])->get('RSA1_5')->name());
+    }
+
+    #[Test]
+    public function theRsa15AlgorithmIsTheOneOfTheRsa15Package(): void
+    {
+        static::assertTrue(class_exists(RSA15::class));
+
+        static::ensureKernelShutdown();
+        $container = static::createClient()
+            ->getContainer();
+
+        /** @var AlgorithmManagerFactory $factory */
+        $factory = $container->get(AlgorithmManagerFactory::class);
+
+        static::assertInstanceOf(RSA15::class, $factory->create(['RSA1_5'])->get('RSA1_5'));
+    }
+}

--- a/tests/Bundle/JoseFramework/Functional/UnsecuredAlgorithmTest.php
+++ b/tests/Bundle/JoseFramework/Functional/UnsecuredAlgorithmTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Bundle\JoseFramework\Functional;
+
+use Jose\Component\Core\AlgorithmManagerFactory;
+use Jose\Tests\Bundle\JoseFramework\WebTestCase;
+use Jose\Unsecured\Signature\None;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The "none" algorithm of the jose-unsecured package is registered by its own configuration file. That file is only
+ * loaded when the package is installed, so a stale class name would silently make the algorithm unavailable.
+ *
+ * @internal
+ */
+final class UnsecuredAlgorithmTest extends WebTestCase
+{
+    #[Test]
+    public function theNoneAlgorithmIsRegistered(): void
+    {
+        static::ensureKernelShutdown();
+        $container = static::createClient()
+            ->getContainer();
+
+        /** @var AlgorithmManagerFactory $factory */
+        $factory = $container->get(AlgorithmManagerFactory::class);
+
+        static::assertContains('none', $factory->aliases());
+        static::assertSame('none', $factory->create(['none'])->get('none')->name());
+    }
+
+    #[Test]
+    public function theNoneAlgorithmIsTheOneOfTheUnsecuredPackage(): void
+    {
+        static::assertTrue(class_exists(None::class));
+
+        static::ensureKernelShutdown();
+        $container = static::createClient()
+            ->getContainer();
+
+        /** @var AlgorithmManagerFactory $factory */
+        $factory = $container->get(AlgorithmManagerFactory::class);
+
+        static::assertInstanceOf(None::class, $factory->create(['none'])->get('none'));
+    }
+}

--- a/tests/Component/Encryption/EncryptionTestCase.php
+++ b/tests/Component/Encryption/EncryptionTestCase.php
@@ -29,7 +29,6 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHSSA256KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS256A128KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS384A192KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS512A256KW;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP256;
 use Jose\Component\Encryption\JWEBuilderFactory;
@@ -40,6 +39,7 @@ use Jose\Component\Encryption\Serializer\JSONFlattenedSerializer;
 use Jose\Component\Encryption\Serializer\JSONGeneralSerializer;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Jose\Component\Encryption\Serializer\JWESerializerManagerFactory;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use PHPUnit\Framework\TestCase;
 
 abstract class EncryptionTestCase extends TestCase

--- a/tests/Component/Encryption/RSA15ExpectedCekSizeTest.php
+++ b/tests/Component/Encryption/RSA15ExpectedCekSizeTest.php
@@ -8,11 +8,11 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\RSAKey;
 use Jose\Component\Encryption\Algorithm\ContentEncryption\A128GCM;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15;
 use Jose\Component\Encryption\JWEBuilder;
 use Jose\Component\Encryption\JWEDecrypter;
 use Jose\Component\Encryption\Serializer\CompactSerializer;
 use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function mb_strlen;
@@ -54,7 +54,7 @@ final class RSA15ExpectedCekSizeTest extends TestCase
         static::assertSame($cek, $decrypted);
         static::assertCount(1, $deprecations);
         static::assertStringContainsString(
-            'Calling "Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15::decryptKey()" without the size of the key expected by the content encryption algorithm as fourth argument is deprecated.',
+            'Calling "Jose\Rsa15\KeyEncryption\RSA15::decryptKey()" without the size of the key expected by the content encryption algorithm as fourth argument is deprecated.',
             $deprecations[0]
         );
     }

--- a/tests/Component/Encryption/RSA15ImplicitRejectionTest.php
+++ b/tests/Component/Encryption/RSA15ImplicitRejectionTest.php
@@ -6,9 +6,9 @@ namespace Jose\Tests\Component\Encryption;
 
 use InvalidArgumentException;
 use Jose\Component\Core\Util\RSAKey;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\Util\RSACrypt;
 use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function mb_strlen;

--- a/tests/Component/Encryption/RSAKeyEncryptionTest.php
+++ b/tests/Component/Encryption/RSAKeyEncryptionTest.php
@@ -8,9 +8,11 @@ use InvalidArgumentException;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Core\Util\Base64UrlSafe;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15 as DeprecatedRSA15;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP256;
+use Jose\Rsa15\KeyEncryption\RSA15;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use const STR_PAD_LEFT;
 
@@ -21,6 +23,21 @@ use const STR_PAD_LEFT;
  */
 final class RSAKeyEncryptionTest extends EncryptionTestCase
 {
+    /**
+     * The algorithm shipped by the library until 5.0.0 is now an empty subclass of the one of the
+     * web-token/jwt-rsa15 package, so that the applications that migrate can mix both classes.
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function theDeprecatedClassOfTheLibraryIsStillUsable(): void
+    {
+        $algorithm = new DeprecatedRSA15();
+
+        static::assertInstanceOf(RSA15::class, $algorithm);
+        static::assertSame('RSA1_5', $algorithm->name());
+        static::assertSame(['RSA'], $algorithm->allowedKeyTypes());
+    }
+
     #[Test]
     public function invalidKey(): void
     {

--- a/tests/Component/NestedToken/NestedTokenTestCase.php
+++ b/tests/Component/NestedToken/NestedTokenTestCase.php
@@ -25,7 +25,6 @@ use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHESA256KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS256A128KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS384A192KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\PBES2HS512A256KW;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP256;
 use Jose\Component\Encryption\JWEBuilderFactory;
@@ -36,6 +35,7 @@ use Jose\Component\Encryption\Serializer\JSONFlattenedSerializer;
 use Jose\Component\Encryption\Serializer\JSONGeneralSerializer;
 use Jose\Component\Encryption\Serializer\JWESerializerManager;
 use Jose\Component\Encryption\Serializer\JWESerializerManagerFactory;
+use Jose\Rsa15\KeyEncryption\RSA15;
 use PHPUnit\Framework\TestCase;
 
 abstract class NestedTokenTestCase extends TestCase

--- a/tests/Component/Signature/SignatureTestCase.php
+++ b/tests/Component/Signature/SignatureTestCase.php
@@ -12,7 +12,6 @@ use Jose\Component\Signature\Algorithm\ES512;
 use Jose\Component\Signature\Algorithm\HS256;
 use Jose\Component\Signature\Algorithm\HS384;
 use Jose\Component\Signature\Algorithm\HS512;
-use Jose\Component\Signature\Algorithm\None;
 use Jose\Component\Signature\Algorithm\PS256;
 use Jose\Component\Signature\Algorithm\PS384;
 use Jose\Component\Signature\Algorithm\PS512;
@@ -27,6 +26,7 @@ use Jose\Component\Signature\Serializer\JSONFlattenedSerializer;
 use Jose\Component\Signature\Serializer\JSONGeneralSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Jose\Component\Signature\Serializer\JWSSerializerManagerFactory;
+use Jose\Unsecured\Signature\None;
 use PHPUnit\Framework\TestCase;
 
 abstract class SignatureTestCase extends TestCase

--- a/tests/SignatureAlgorithm/None/NoneSignatureTest.php
+++ b/tests/SignatureAlgorithm/None/NoneSignatureTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Jose\Tests\SignatureAlgorithm\None;
 
-use InvalidArgumentException;
 use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\JWK;
-use Jose\Component\Signature\Algorithm\None;
+use Jose\Component\Signature\Algorithm\None as DeprecatedNone;
 use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Unsecured\Signature\None;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +39,7 @@ final class NoneSignatureTest extends TestCase
     #[Test]
     public function invalidKey(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidKeyException::class);
         $this->expectExceptionMessage('Wrong key type.');
         $key = new JWK([
             'kty' => 'EC',
@@ -47,6 +49,20 @@ final class NoneSignatureTest extends TestCase
         $data = 'Live long and Prosper.';
 
         $none->sign($key, $data);
+    }
+
+    #[Test]
+    public function verificationWithAnInvalidKey(): void
+    {
+        $this->expectException(InvalidKeyException::class);
+        $this->expectExceptionMessage('Wrong key type.');
+        $key = new JWK([
+            'kty' => 'EC',
+        ]);
+
+        $none = new None();
+
+        $none->verify($key, 'Live long and Prosper.', '');
     }
 
     #[Test]
@@ -76,5 +92,25 @@ final class NoneSignatureTest extends TestCase
         static::assertSame(1, $result->countSignatures());
         static::assertTrue($result->getSignature(0)->hasProtectedHeaderParameter('alg'));
         static::assertSame('none', $result->getSignature(0)->getProtectedHeaderParameter('alg'));
+    }
+
+    /**
+     * The algorithm shipped by the library until 5.0.0 is now an empty subclass of the one of the
+     * web-token/jwt-unsecured package, so that the applications that migrate can mix both classes.
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function theDeprecatedClassOfTheLibraryIsStillUsable(): void
+    {
+        $key = new JWK([
+            'kty' => 'none',
+        ]);
+
+        $none = new DeprecatedNone();
+
+        static::assertInstanceOf(None::class, $none);
+        static::assertSame('none', $none->name());
+        static::assertSame('', $none->sign($key, 'Live long and Prosper.'));
+        static::assertTrue($none->verify($key, 'Live long and Prosper.', ''));
     }
 }


### PR DESCRIPTION
Target branch: 4.3.x
Resolves issue # #692

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] It is related to dependencies

Includes:
- [ ] Breaks BC
- [x] Deprecations

## What

`none` and `RSA1_5` are perfectly standard algorithms, but both are dangerous: the first one turns the signature
verification into a no-op (it is the root cause of the JWT "alg confusion" family of vulnerabilities), the second one
uses a padding vulnerable to the Bleichenbacher adaptive chosen-ciphertext attack. Shipped in the main library, they
were as easy to enable as `RS256`: a single copy-paste in a configuration file was enough.

They now live in two dedicated packages:

| Package | Namespace | Contains |
| --- | --- | --- |
| `web-token/jwt-unsecured` | `Jose\Unsecured\Signature` | `None` |
| `web-token/jwt-rsa15` | `Jose\Rsa15\KeyEncryption` | `RSA15` |

They are deliberately **not** moved to `web-token/jwt-experimental`: they are not experimental, and an application
that installs that package for Blake2b or ES256K should not get `none` in the bargain. A dedicated package also makes
the decision greppable in a `composer.json`, for a security review or an SBOM.

## Migration

`Jose\Component\Signature\Algorithm\None` and `Jose\Component\Encryption\Algorithm\KeyEncryption\RSA15` are kept until
5.0.0 as **empty deprecated subclasses** of the new ones, and the library depends on both new packages. So nothing
breaks, the migration is a change of `use` statement, and an application can already type-hint the new classes while
still receiving instances built by the old ones.

In 5.0.0 the two classes of the library are removed; the packages stay.

## Bundle

The `none` and `RSA1_5` aliases are unchanged, but the bundle now registers the classes of the new packages, each from
its own configuration file loaded under `class_exists()` — the same pattern as the experimental algorithms. This is on
purpose: `AlgorithmCompilerPass` adds a method call per tagged algorithm, so every algorithm is instantiated as soon as
an `AlgorithmManagerFactory` is built. Registering the deprecated classes would have flooded every application with a
deprecation, including those that never enable these algorithms.

Two functional tests assert that both aliases resolve to a class of the right package, so a stale namespace cannot
silently make an algorithm unavailable again.

## Behaviour change

`None::verify()` now checks the key type, as `None::sign()` already did: verifying with a key whose `kty` is not
`none` throws an `InvalidKeyException` instead of returning `true`. It has no practical impact — the algorithm manager
selects the algorithm by its `alg` — but it is a visible change for anyone calling the algorithm directly.

## Before merging

`web-token/jwt-library` 4.3 requires the two new packages, so **their repositories must be registered on Packagist
before 4.3.0 is tagged**, otherwise the library cannot be installed. The gitsplit configuration creates the
repositories on the next push to `4.3.x`.

## Still open on #692

- The deprecation when `'none'` appears in a `signature_algorithms` list of the bundle configuration.
- The documentation.
