### PR TITLE
feat(core): announce the 5.0.0 breaks that were still silent

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -4705,6 +4705,12 @@ parameters:
 			path: ../src/Library/Encryption/JWE.php
 
 		-
+			rawMessage: 'Method Jose\Component\Encryption\JWE::getIV() never returns null so it can be removed from the return type.'
+			identifier: return.unusedType
+			count: 1
+			path: ../src/Library/Encryption/JWE.php
+
+		-
 			rawMessage: 'Method Jose\Component\Encryption\JWE::getRecipient() should return Jose\Component\Encryption\Recipient but returns mixed.'
 			identifier: return.type
 			count: 1
@@ -4725,6 +4731,12 @@ parameters:
 		-
 			rawMessage: 'Method Jose\Component\Encryption\JWE::getSharedProtectedHeader() return type has no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
+			count: 1
+			path: ../src/Library/Encryption/JWE.php
+
+		-
+			rawMessage: 'Method Jose\Component\Encryption\JWE::getTag() never returns null so it can be removed from the return type.'
+			identifier: return.unusedType
 			count: 1
 			path: ../src/Library/Encryption/JWE.php
 

--- a/src/Library/Core/JWK.php
+++ b/src/Library/Core/JWK.php
@@ -8,6 +8,7 @@ use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\Exception\UnsupportedAlgorithmException;
 use Jose\Component\Core\Util\Base64UrlSafe;
+use Jose\Component\Core\Util\InheritanceChecker;
 use JsonSerializable;
 use Override;
 use function array_key_exists;
@@ -28,6 +29,8 @@ use const JSON_UNESCAPED_UNICODE;
  * is absent. The class will be final and readonly in 5.0.0, where the parameters are validated against the key type
  * at construction time.
  *
+ * @final The class will be final and readonly in 5.0.0: build it with its constructor instead of extending it.
+ *
  * @see \Jose\Tests\Component\Core\JWKTest
  */
 class JWK implements JsonSerializable
@@ -39,6 +42,7 @@ class JWK implements JsonSerializable
      */
     public function __construct(array $values)
     {
+        InheritanceChecker::warnIfValueObjectExtended(static::class, self::class);
         if (! isset($values['kty'])) {
             throw new InvalidKeyException('The parameter "kty" is mandatory.');
         }

--- a/src/Library/Core/JWKSet.php
+++ b/src/Library/Core/JWKSet.php
@@ -10,6 +10,7 @@ use IteratorAggregate;
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidKeyException;
 use Jose\Component\Core\Exception\InvalidKeySetException;
+use Jose\Component\Core\Util\InheritanceChecker;
 use JsonSerializable;
 use Traversable;
 use function array_key_exists;
@@ -28,6 +29,8 @@ use const JSON_THROW_ON_ERROR;
  *
  * Keys carrying a "kid" are indexed by it, so that get() and has() accept either a position or a "kid". The class will
  * be final and readonly in 5.0.0.
+ *
+ * @final The class will be final and readonly in 5.0.0: build it with its constructor instead of extending it.
  */
 class JWKSet implements Countable, IteratorAggregate, JsonSerializable
 {
@@ -38,6 +41,7 @@ class JWKSet implements Countable, IteratorAggregate, JsonSerializable
      */
     public function __construct(array $keys)
     {
+        InheritanceChecker::warnIfValueObjectExtended(static::class, self::class);
         foreach ($keys as $key) {
             if (! $key instanceof JWK) {
                 throw new InvalidKeySetException('Invalid list. Should only contains JWK objects');

--- a/src/Library/Core/Util/InheritanceChecker.php
+++ b/src/Library/Core/Util/InheritanceChecker.php
@@ -8,12 +8,16 @@ use function str_starts_with;
 use function trigger_deprecation;
 
 /**
- * Raises the deprecation notice emitted when one of the services of the library is extended.
+ * Raises the deprecation notice emitted when one of the classes the library seals is extended.
  *
- * Those services will be final in 5.0.0. The behaviour they used to be extended for is now available through the
+ * The services will be final in 5.0.0. The behaviour they used to be extended for is now available through the
  * interfaces they implement: a decorator implements the same interface, wraps the service and is injected in its
- * place. The event dispatching services of the bundle are the only subclasses shipped by the project; they are
- * deprecated as well and replaced by decorators, so they are left out of the notice to keep it actionable.
+ * place. The value objects - the key, the key set, the two tokens and the signature - will be final and readonly as
+ * well, and they have no interface to decorate: they carry no behaviour to change, and the state a subclass adds to
+ * them cannot survive the constructor becoming the only way to populate them.
+ *
+ * The event dispatching services of the bundle are the only subclasses shipped by the project; they are deprecated as
+ * well and replaced by decorators, so they are left out of the notice to keep it actionable.
  *
  * @internal
  */
@@ -23,10 +27,7 @@ final class InheritanceChecker
 
     public static function warnIfExtended(string $actualClass, string $finalClass, string $interface): void
     {
-        if ($actualClass === $finalClass) {
-            return;
-        }
-        if (str_starts_with($actualClass, self::DEPRECATED_BUNDLE_SERVICES)) {
+        if (! self::isExtendedFromOutside($actualClass, $finalClass)) {
             return;
         }
 
@@ -39,5 +40,33 @@ final class InheritanceChecker
             $interface,
             $actualClass
         );
+    }
+
+    /**
+     * Same notice for the value objects, which have no interface to implement in place of the inheritance.
+     */
+    public static function warnIfValueObjectExtended(string $actualClass, string $finalClass): void
+    {
+        if (! self::isExtendedFromOutside($actualClass, $finalClass)) {
+            return;
+        }
+
+        trigger_deprecation(
+            'web-token/jwt-framework',
+            '4.3.0',
+            'Extending "%s" is deprecated: the class will be final and readonly in 5.0.0. Build the object with its '
+            . 'constructor and keep the state "%s" adds to it in the object of yours that uses it.',
+            $finalClass,
+            $actualClass
+        );
+    }
+
+    private static function isExtendedFromOutside(string $actualClass, string $finalClass): bool
+    {
+        if ($actualClass === $finalClass) {
+            return false;
+        }
+
+        return ! str_starts_with($actualClass, self::DEPRECATED_BUNDLE_SERVICES);
     }
 }

--- a/src/Library/Encryption/Algorithm/KeyEncryption/KeyAgreementWithKeyWrapping.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/KeyAgreementWithKeyWrapping.php
@@ -17,6 +17,12 @@ interface KeyAgreementWithKeyWrapping extends KeyEncryptionAlgorithm
      * @param int $encryption_key_length Size of the key expected for the algorithm used for data encryption
      * @param array<string, mixed> $complete_header The complete header of the JWT
      * @param array<string, mixed> $additional_header_values Set additional header values if needed
+     *
+     * BC NOTE: in 5.0, this method will return a "WrappedKey" object - the wrapped agreement key and the header
+     * parameters to add to the token - and the "array &$additional_header_values" output parameter will be removed.
+     * The change cannot be made now without breaking every implementation of this interface. Implementations are
+     * encouraged to prepare for it: the object is already available as
+     * Jose\Component\Encryption\Algorithm\KeyEncryption\WrappedKey.
      */
     public function wrapAgreementKey(
         JWK $recipientKey,

--- a/src/Library/Encryption/Algorithm/KeyEncryption/WrappedKey.php
+++ b/src/Library/Encryption/Algorithm/KeyEncryption/WrappedKey.php
@@ -8,9 +8,10 @@ namespace Jose\Component\Encryption\Algorithm\KeyEncryption;
  * The key produced by a key management algorithm, together with the header parameters the algorithm needs to add
  * to the token so that the recipient is able to compute the key back.
  *
- * It is the return type announced for KeyEncryption::encryptKey(), KeyWrapping::wrapKey() and
- * KeyAgreement::getAgreementKey() in 5.0.0, where it replaces the "array &$additionalHeader" output parameter. It
- * is not used by those interfaces yet: adding it now would break every third-party implementation of them.
+ * It is the return type announced for KeyEncryption::encryptKey(), KeyWrapping::wrapKey(),
+ * KeyAgreement::getAgreementKey() and KeyAgreementWithKeyWrapping::wrapAgreementKey() in 5.0.0, where it replaces
+ * the "array &$additionalHeader" output parameter. It is not used by those interfaces yet: adding it now would
+ * break every third-party implementation of them.
  */
 final readonly class WrappedKey
 {

--- a/src/Library/Encryption/JWE.php
+++ b/src/Library/Encryption/JWE.php
@@ -7,6 +7,7 @@ namespace Jose\Component\Encryption;
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidHeaderParameterException;
 use Jose\Component\Core\JWT;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\InternalCallChecker;
 use Override;
 use function array_key_exists;
@@ -21,6 +22,8 @@ use function sprintf;
  * must be treated as such, since the payload it exposes is the one the decrypter authenticated against the
  * ciphertext, the tag and the additional authenticated data. The class will be final and readonly in 5.0.0, where
  * the decrypted payload is given to the constructor.
+ *
+ * @final The class will be final and readonly in 5.0.0: build it with its constructor instead of extending it.
  */
 class JWE implements JWT
 {
@@ -36,6 +39,7 @@ class JWE implements JWT
         private readonly ?string $encodedSharedProtectedHeader = null,
         private readonly array $recipients = []
     ) {
+        InheritanceChecker::warnIfValueObjectExtended(static::class, self::class);
     }
 
     #[Override]

--- a/src/Library/Signature/JWS.php
+++ b/src/Library/Signature/JWS.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Signature;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\JWT;
+use Jose\Component\Core\Util\InheritanceChecker;
 use Jose\Component\Core\Util\InternalCallChecker;
 use Jose\Component\Signature\Serializer\JWSSerializer;
 use Override;
@@ -19,6 +20,8 @@ use function count;
  * treated as such: a token returned by a loader carries signatures that have been verified against its payload, and
  * nothing else is allowed to append to that list. The class will be final and readonly in 5.0.0, where the
  * signatures are given to the constructor.
+ *
+ * @final The class will be final and readonly in 5.0.0: build it with its constructor instead of extending it.
  *
  * @see \Jose\Tests\Component\Signature\JWSTest
  */
@@ -34,6 +37,7 @@ class JWS implements JWT
         private readonly ?string $encodedPayload = null,
         private readonly bool $isPayloadDetached = false
     ) {
+        InheritanceChecker::warnIfValueObjectExtended(static::class, self::class);
     }
 
     #[Override]

--- a/src/Library/Signature/Signature.php
+++ b/src/Library/Signature/Signature.php
@@ -6,6 +6,7 @@ namespace Jose\Component\Signature;
 
 use Jose\Component\Core\Exception\InvalidArgumentException;
 use Jose\Component\Core\Exception\InvalidHeaderParameterException;
+use Jose\Component\Core\Util\InheritanceChecker;
 use function array_key_exists;
 use function sprintf;
 use function trigger_deprecation;
@@ -18,6 +19,8 @@ use function trigger_deprecation;
  * header therefore has no protected header at all, and the decoded one given to the constructor is discarded rather
  * than exposed, so that getProtectedHeader() never advertises parameters no signature protects. The class will be
  * final and readonly in 5.0.0, where the two arguments must agree.
+ *
+ * @final The class will be final and readonly in 5.0.0: build it with its constructor instead of extending it.
  */
 class Signature
 {
@@ -42,6 +45,7 @@ class Signature
         ?string $encodedProtectedHeader,
         private readonly array $header
     ) {
+        InheritanceChecker::warnIfValueObjectExtended(static::class, self::class);
         if ($encodedProtectedHeader === null && $protectedHeader !== []) {
             trigger_deprecation(
                 'web-token/jwt-framework',

--- a/tests/Component/Core/SealedValueObjectsTest.php
+++ b/tests/Component/Core/SealedValueObjectsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Tests\Component\Core;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\Signature;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use const E_USER_DEPRECATED;
+
+/**
+ * The value objects of the library will be final and readonly in 5.0.0. Unlike the services, they have no interface
+ * to decorate in place of the inheritance: the deprecation notice is the only warning their subclasses get before the
+ * change.
+ *
+ * @internal
+ */
+final class SealedValueObjectsTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('valueObjects')]
+    public function extendingAValueObjectIsDeprecatedButBuildingItIsNot(
+        callable $extended,
+        callable $plain,
+        string $sealedClass
+    ): void {
+        $deprecations = $this->collectDeprecations($extended);
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString($sealedClass, $deprecations[0]);
+        static::assertStringContainsString('final and readonly in 5.0.0', $deprecations[0]);
+        static::assertSame([], $this->collectDeprecations($plain));
+    }
+
+    /**
+     * @return iterable<string, array{callable(): object, callable(): object, class-string}>
+     */
+    public static function valueObjects(): iterable
+    {
+        yield 'JWK' => [
+            static fn (): JWK => new class([
+                'kty' => 'oct',
+            ]) extends JWK {},
+            static fn (): JWK => new JWK([
+                'kty' => 'oct',
+            ]),
+            JWK::class,
+        ];
+
+        yield 'JWKSet' => [
+            static fn (): JWKSet => new class([]) extends JWKSet {},
+            static fn (): JWKSet => new JWKSet([]),
+            JWKSet::class,
+        ];
+
+        yield 'JWS' => [
+            static fn (): JWS => new class('payload') extends JWS {},
+            static fn (): JWS => new JWS('payload'),
+            JWS::class,
+        ];
+
+        yield 'JWE' => [
+            static fn (): JWE => new class('ciphertext', 'iv', 'tag') extends JWE {},
+            static fn (): JWE => new JWE('ciphertext', 'iv', 'tag'),
+            JWE::class,
+        ];
+
+        yield 'Signature' => [
+            static fn (): Signature => new class('signature', [], null, []) extends Signature {},
+            static fn (): Signature => new Signature('signature', [], null, []),
+            Signature::class,
+        ];
+    }
+
+    /**
+     * @param callable(): object $callable
+     *
+     * @return string[]
+     */
+    private function collectDeprecations(callable $callable): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
+    }
+}


### PR DESCRIPTION
## Context

The inventory of what 4.3 announces for 5.0 turned up two breaks that 5.0 makes and that nothing warns about today. Both can only be announced while 4.3 is open: once 4.3.0 is tagged, they become unannounced breaks in a major.

Docblocks and deprecation notices only. No signature and no behaviour change.

## 1. The fourth key management interface was left out of the `WrappedKey` announcement

`KeyEncryption::encryptKey()`, `KeyWrapping::wrapKey()` and `KeyAgreement::getAgreementKey()` each carry a `BC NOTE` saying that 5.0 replaces their `array &$additionalHeader` output parameter with the `WrappedKey` object introduced for that purpose.

`KeyAgreementWithKeyWrapping::wrapAgreementKey()` has the very same output parameter and carried no note at all. It gets one, and `WrappedKey` now names the four methods it is the announced return type of instead of three.

## 2. The value objects are sealed without a word

`JWK`, `JWKSet`, `JWS`, `JWE` and `Signature` are all documented as "will be final and readonly in 5.0.0", but that sentence lives in the class docblock and nowhere else.

The eleven services that become final behave differently: they carry `@final`, so the static analysers report the inheritance, and they emit a deprecation through `InheritanceChecker` when they are extended. The five value objects did neither. A subclass of `JWK` gets no notice, no static analysis error, and stops working in 5.0.

They now behave like the services:

* `@final` in the class docblock,
* a deprecation notice at construction time, raised by the new `InheritanceChecker::warnIfValueObjectExtended()`.

The notice differs from the one raised for the services: a value object has no interface to decorate in place of the inheritance, so the advice is to build it with its constructor and to keep the state the subclass added in the object that uses it. The exemption for `Jose\Bundle\JoseFramework\Services\` moves into the guard the two notices share.

`@final` on `JWE` makes PHPStan see two return types that were only tolerated because the class could be extended: `getIV()` and `getTag()` are declared `?string` but read non-nullable properties. Narrowing them is a signature change, so it waits for 5.0 and the two findings are recorded in the baseline.

## Tests

`SealedValueObjectsTest` builds each of the five classes twice, directly and through an anonymous subclass, and asserts that only the second is deprecated.

## Left out on purpose

`TokenTypeSupport::retrieveTokenHeaders()`, implemented by `JWSTokenSupport` and `JWETokenSupport`, is the last public interface built entirely on output parameters and it is announced neither way. Replacing them with a result object is the same kind of change as `WrappedKey`, but it is a design decision rather than a correction, so it is not taken here. If 5.0 is to make it, the note has to land in 4.3 as well.
