### PR TITLE
feat(checker): announce the object replacing the token type support headers

### DIFF
--- a/src/Library/Checker/TokenHeaders.php
+++ b/src/Library/Checker/TokenHeaders.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jose\Component\Checker;
+
+/**
+ * The two headers a token type support reads for one signature or for one recipient of a token.
+ *
+ * It is the return type announced for TokenTypeSupport::retrieveTokenHeaders() in 5.0.0, where it replaces the
+ * "array &$protectedHeader" and "array &$unprotectedHeader" output parameters. It is not used by the interface yet:
+ * adding it now would break every third-party implementation of it.
+ *
+ * A support given a token it does not handle returns an object carrying two empty headers, which is what it does
+ * today by leaving the two output parameters untouched.
+ */
+final readonly class TokenHeaders
+{
+    /**
+     * @param array<string, mixed> $protectedHeader
+     * @param array<string, mixed> $unprotectedHeader
+     */
+    public function __construct(
+        private array $protectedHeader = [],
+        private array $unprotectedHeader = []
+    ) {
+    }
+
+    /**
+     * The header the token protects, empty when it protects none.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProtectedHeader(): array
+    {
+        return $this->protectedHeader;
+    }
+
+    /**
+     * The header the token does not protect, empty when it carries none. A JWE merges the shared unprotected header
+     * and the header of the selected recipient into it.
+     *
+     * @return array<string, mixed>
+     */
+    public function getUnprotectedHeader(): array
+    {
+        return $this->unprotectedHeader;
+    }
+}

--- a/src/Library/Checker/TokenTypeSupport.php
+++ b/src/Library/Checker/TokenTypeSupport.php
@@ -23,6 +23,11 @@ interface TokenTypeSupport
      *
      * @param array<string, mixed> $protectedHeader
      * @param array<string, mixed> $unprotectedHeader
+     *
+     * BC NOTE: in 5.0, this method will return a "TokenHeaders" object - the protected and the unprotected header of
+     * the token - and the two "array &$header" output parameters will be removed. The change cannot be made now
+     * without breaking every implementation of this interface. Implementations are encouraged to prepare for it: the
+     * object is already available as Jose\Component\Checker\TokenHeaders.
      */
     public function retrieveTokenHeaders(
         JWT $jwt,


### PR DESCRIPTION
Follow-up to #715, which left this one out as a design decision rather than a correction.

## Context

`TokenTypeSupport::retrieveTokenHeaders()` is the last public interface of the library built entirely on output parameters: it writes the protected and the unprotected header of a token into two variables of the caller and returns `void`.

The three other families already announce that 5.0.0 replaces their output parameters with an object:

* `ContentEncryptionAlgorithm::encryptContent()` → `EncryptedContent`,
* `KeyEncryption::encryptKey()`, `KeyWrapping::wrapKey()`, `KeyAgreement::getAgreementKey()` and, since #715, `KeyAgreementWithKeyWrapping::wrapAgreementKey()` → `WrappedKey`.

This one was announced neither way, so 5.0.0 would either break its implementations without notice or keep the last pair of output parameters in the library.

## What changes

`Jose\Component\Checker\TokenHeaders` carries the two headers and is documented as the return type announced for 5.0.0. The interface gets the matching `BC NOTE`.

Like `WrappedKey` and `EncryptedContent`, the object is not used by the interface yet: adding it now would break every implementation, the two supports of the library included. A support given a token it does not handle will return an object carrying two empty headers, which is what it does today by leaving the two output parameters untouched.

Docblocks and one new class. No signature and no behaviour change.