### PR TITLE
fix(composer): allow brick/math 0.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require": {
         "php": ">=8.2",
         "ext-openssl": "*",
-        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19",
+        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20",
         "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1",

--- a/src/Library/composer.json
+++ b/src/Library/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "php": ">=8.2",
-        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19",
+        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20",
         "psr/clock": "^1.0",
         "spomky-labs/pki-framework": "^1.2.1",
         "symfony/deprecation-contracts": "^2.5|^3.0"


### PR DESCRIPTION
## Problem

`brick/math` published six minor releases in seven months (0.15, 0.16, 0.17, 0.18, 0.19 and 0.20). Each one means adding a new `^0.x` alternative to the constraint, cutting a release, and repeating the operation in every package of the stack (spomky-labs/cbor-php, spomky-labs/pki-framework, web-auth/cose-lib, web-token/jwt-library). Whichever package lags behind caps `brick/math` for the whole dependency tree of the applications that install them.

## Change

`^0.20` is added to the chain in both `composer.json` and `src/Library/composer.json`, which must stay in sync.

```diff
-        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19"
+        "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20"
```

The explicit chain is kept on purpose instead of an open range such as `>=0.12 <1.0`. `brick/math` is still a 0.x package, where a minor release is allowed to break the API, so every version has to be opted into deliberately.

## Backward compatibility

Checked with `composer/semver`:

* `Intervals::isSubsetOf(old, new)` returns `true`, so no accepted version is lost
* the lower bound is unchanged at 0.12, nobody is forced to upgrade
* 0.21 and above remain excluded

## Which version is actually resolved

`brick/math` 0.20.0 was released on 2026-08-28, so this range is not speculative. The tree here still resolves 0.19.1 for now, because the released `spomky-labs/pki-framework` still caps `brick/math` at `^0.19`. It will pick 0.20.0 up once that one is released, which is precisely the lockstep effect this change is meant to shorten.
