### PR TITLE
ci: defer the jwt-unsecured and jwt-rsa15 splits

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -5,10 +5,6 @@ splits:
     target: "https://${GH_TOKEN}@github.com/web-token/jwt-library.git"
   - prefix: "src/Experimental"
     target: "https://${GH_TOKEN}@github.com/web-token/jwt-experimental.git"
-  - prefix: "src/Unsecured"
-    target: "https://${GH_TOKEN}@github.com/web-token/jwt-unsecured.git"
-  - prefix: "src/Rsa15"
-    target: "https://${GH_TOKEN}@github.com/web-token/jwt-rsa15.git"
 
 origins:
   - ^\d+\.\d+\.x$


### PR DESCRIPTION
## Problem

`web-token/jwt-library` is still published at 4.2.1 on Packagist, so it keeps capping `brick/math` at `^0.19` for everyone, even though 4.2.2 raised it to `^0.20`. The tag exists on jwt-framework, but the subtree was never split.

The `gitsplit` workflow has been failing since 2026-08-29 19:33, right after "feat(algorithms): ship none and RSA1_5 in their own packages" (#714) was merged. The last green run is from 18:59 the same day.

```
WARN Splitting  reference=4.3.x  splits="[src/Unsecured]"
FATA failed to split references: ... https://github.com/web-token/jwt-unsecured.git:
     remote: Repository not found.
```

`web-token/jwt-unsecured` and `web-token/jwt-rsa15` do not exist in the organisation yet.

The part that is easy to miss: the workflow runs `git clone` with no `-b`, so it checks out the **default branch**, currently 4.3.x, and `gitsplit` applies that single `.gitsplit.yml` to **every** reference it walks. The config on 4.2.x is correct and lists only the three historical splits, but it is never read. So 4.3.x's two missing remotes abort the whole run before it ever reaches the 4.2.x branch or the 4.2.2 tag.

## Change

The two entries are removed from `.gitsplit.yml` until the repositories exist. The split then completes again and catches up on every pending reference, including the 4.2.2 tag.

Nothing is lost in the meantime: 4.3.0 is not released, so the two new packages have no consumer, while `jwt-library` being frozen at 4.2.1 affects every downstream project today.

## When to revert

Re-add both entries as part of preparing the 4.3.0 release, once `web-token/jwt-unsecured` and `web-token/jwt-rsa15` have been created in the organisation and registered on Packagist. Adding a split whose target repository does not exist breaks the publication of every other package, so the repository must come first.
