### PR TITLE
ci: restore the jwt-unsecured and jwt-rsa15 splits

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -5,6 +5,10 @@ splits:
     target: "https://${GH_TOKEN}@github.com/web-token/jwt-library.git"
   - prefix: "src/Experimental"
     target: "https://${GH_TOKEN}@github.com/web-token/jwt-experimental.git"
+  - prefix: "src/Unsecured"
+    target: "https://${GH_TOKEN}@github.com/web-token/jwt-unsecured.git"
+  - prefix: "src/Rsa15"
+    target: "https://${GH_TOKEN}@github.com/web-token/jwt-rsa15.git"
 
 origins:
   - ^\d+\.\d+\.x$


### PR DESCRIPTION
## Context

#720 removed the `src/Unsecured` and `src/Rsa15` splits because their target repositories did not exist, which made every `gitsplit` run abort before reaching the 4.2.x branch and left `web-token/jwt-library` published at 4.2.1. That unblocked the split and 4.2.2 is now out.

## Change

`web-token/jwt-unsecured` and `web-token/jwt-rsa15` have since been created in the organisation, both public and empty, so the two entries are declared again and #720 is undone.

`gitsplit` only ever failed on the missing remotes. A prefix that is absent from a reference is walked without an error, exactly as `src/Experimental` already is on the 3.1.x tags, so declaring these two has no effect on 4.2.x and earlier references.

## Follow-up

Once merged, the split populates both repositories from 4.3.x. They then have to be registered on Packagist to become installable.
