### PR TITLE
ci: check out the repository properly in the gitsplit workflow

### DIFF
--- a/.github/workflows/gitsplit.yml
+++ b/.github/workflows/gitsplit.yml
@@ -1,4 +1,16 @@
 name: gitsplit
+
+# gitsplit walks every branch and tag matching the "origins" patterns of
+# .gitsplit.yml, so the checkout must be unshallow: fetch-depth: 0.
+#
+# It also reads a single .gitsplit.yml, the one in the working copy, and
+# applies it to all of those references. Checking out the ref that triggered
+# the run keeps that config in step with the branch being pushed, instead of
+# whatever the default branch happens to declare at that moment.
+#
+# The container is not given the repository credentials: it only needs to read
+# a public repository, and GITSPLIT_TOKEN for the targets it pushes to.
+
 on:
   push:
     tags:
@@ -13,9 +25,13 @@ jobs:
   gitsplit:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        run: git clone https://github.com/web-token/jwt-framework /home/runner/work/web-token/jwt-framework && cd /home/runner/work/web-token/jwt-framework
-      - name: Split repositories
-        run: docker run --rm -t -e GH_TOKEN -v /cache/gitsplit:/cache/gitsplit -v /home/runner/work/web-token/jwt-framework:/srv jderusse/gitsplit gitsplit
+      - name: "Checkout"
+        uses: "actions/checkout@v5"
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "Split repositories"
+        run: docker run --rm -t -e GH_TOKEN -v /cache/gitsplit:/cache/gitsplit -v ${{ github.workspace }}:/srv jderusse/gitsplit gitsplit
         env:
           GH_TOKEN: ${{ secrets.GITSPLIT_TOKEN }}


### PR DESCRIPTION
## Problem

The checkout step cloned the repository by hand:

```yaml
run: git clone https://github.com/web-token/jwt-framework /home/runner/work/web-token/jwt-framework && cd ...
```

Two consequences.

It clones into a path that has nothing to do with `github.workspace`, so the whole thing only holds together because the `docker run` mount repeats the same hardcoded path.

More importantly, `git clone` with no `-b` always lands on the **default branch**, whatever ref actually triggered the run. gitsplit reads a single `.gitsplit.yml`, the one in the working copy, and applies it to every branch and tag matching its `origins` patterns. So the default branch's config governed every reference, and the per-branch copies of the file were never read.

That is what turned #714 into a day-long outage: `src/Unsecured` and `src/Rsa15` were declared on 4.3.x before their repositories existed, and since 4.3.x is the default branch, the run aborted on the missing remote before ever reaching the 4.2.x branch or the 4.2.2 tag. `web-token/jwt-library` stayed published at 4.2.1, capping `brick/math` at `^0.19` for every downstream project, while the config on 4.2.x was perfectly correct and simply never read.

## Change

`actions/checkout@v5`, the version `ci.yml` already uses, with:

* `fetch-depth: 0`, because gitsplit walks every branch and tag and a shallow clone only holds the triggering ref
* `persist-credentials: false`, so the repository credentials are not handed to a third-party container image; it reads a public repository and only needs `GITSPLIT_TOKEN` for the targets it pushes to

The mount becomes `${{ github.workspace }}` instead of the hardcoded path, and a header comment records why the checkout has to look like this.

The behaviour change worth stating plainly: `.gitsplit.yml` now comes from the ref being pushed rather than from the default branch. A push to 4.2.x is governed by 4.2.x's config, a push to 4.3.x by 4.3.x's. A prefix that is absent from a reference is walked without an error, as `src/Experimental` already is on the 3.1.x tags, so a split declared on a newer branch still costs nothing on the older ones.

## Note

Targeting 4.2.x, the last released minor. `push` events run the workflow from the ref being pushed, so 4.3.x only picks this up through the usual merge-up.
